### PR TITLE
Added ts variant of loadwidget in packages

### DIFF
--- a/packages/lib/load-widget.tsx
+++ b/packages/lib/load-widget.tsx
@@ -1,0 +1,12 @@
+import { createRoot } from 'react-dom/client';
+
+export default function loadWidget(this: any, elementId: string, props: any) {
+  const Component = this;
+
+  const container = document.getElementById(elementId);
+
+  if (container) {
+    const root = createRoot(container);
+    root.render(<Component {...props} />);
+  }
+}

--- a/packages/likes/src/likes.tsx
+++ b/packages/likes/src/likes.tsx
@@ -3,6 +3,7 @@ import { ProgressBar } from '@openstad-headless/ui/src';
 import useSWR, { Fetcher } from 'swr';
 import { useEffect, useState } from 'react';
 import './likes.css';
+import loadWidget from '../../lib/load-widget.js';
 
 type Props = {
   projectId?: string;
@@ -18,7 +19,7 @@ type Props = {
   };
 };
 
-export function Likes(props: Props) {
+function Likes(props: Props) {
   const projectId = props.projectId || props.config?.projectId;
   const ideaId = props.ideaId || props.config?.ideaId;
   const apIurl = props.apiUrl || props.config.api?.url;
@@ -93,3 +94,7 @@ export function Likes(props: Props) {
     </>
   );
 }
+
+Likes.loadWidget = loadWidget;
+
+export { Likes as default, Likes };


### PR DESCRIPTION
Added a loadwidget lib file based on the original for the widgets in packages (not to be confused with packages/components/*) This will require https://github.com/openstad/openstad-headless/pull/46 to be changed to work with the vite projects