### PR TITLE
Exporteren van projecten

### DIFF
--- a/apps/web/src/components/ui/sidenav-project.tsx
+++ b/apps/web/src/components/ui/sidenav-project.tsx
@@ -242,6 +242,15 @@ export function SidenavProject({ className }: { className?: string }) {
             <span className="truncate">Dupliceren</span>
           </Button>
         </Link>
+        <Link href={`/projects/${project}/export`}>
+          <Button
+            variant={location.includes("/export") ? "secondary" : "ghost"}
+            className="w-full flex justify-start"
+            onClick={(e) => {}}
+          >
+            <span className="truncate">Exporteren</span>
+          </Button>
+        </Link>
       </div>
       <div className="flex-grow"></div>
     </nav>

--- a/apps/web/src/hooks/use-comments.tsx
+++ b/apps/web/src/hooks/use-comments.tsx
@@ -1,0 +1,9 @@
+import useSWR from 'swr';
+
+export default function useComments(projectId?: string) {
+  const url = `/api/openstad/api/project/${projectId}/comment`;
+
+  const commentListSwr = useSWR(projectId ? url : null);
+
+  return {...commentListSwr}
+}

--- a/apps/web/src/hooks/use-poll.tsx
+++ b/apps/web/src/hooks/use-poll.tsx
@@ -1,0 +1,9 @@
+import useSWR from 'swr';
+
+export default function usePolls(projectId?: string) {
+  const url = `/api/openstad/api/project/${projectId}/poll`;
+
+  const pollListSwr = useSWR(projectId ? url : null);
+
+  return {...pollListSwr}
+}

--- a/apps/web/src/hooks/use-tags.tsx
+++ b/apps/web/src/hooks/use-tags.tsx
@@ -1,0 +1,9 @@
+import useSWR from 'swr';
+
+export default function useTags(projectId?: string) {
+  const url = `/api/openstad/api/project/${projectId}/tag`;
+
+  const tagListSwr = useSWR(projectId ? url : null);
+
+  return {...tagListSwr}
+}

--- a/apps/web/src/pages/projects/[project]/codes/create.tsx
+++ b/apps/web/src/pages/projects/[project]/codes/create.tsx
@@ -55,16 +55,9 @@ export default function ProjectCodeCreate() {
           },
           {
             name: 'Stemcodes toevoegen',
-            url: `projects/${project}/codes/create`,
+            url: `/projects/${project}/codes/create`,
           },
-        ]}
-        action={
-          <div className="flex">
-            <Link href="/projects/1/codes/export">
-              <Button variant="default">Exporteer stemcodes</Button>
-            </Link>
-          </div>
-        }>
+        ]}>
         <div className="container py-6">
           <Form {...form} className="p-6 bg-white rounded-md">
             <Heading size="xl">Toevoegen</Heading>

--- a/apps/web/src/pages/projects/[project]/duplicate.tsx
+++ b/apps/web/src/pages/projects/[project]/duplicate.tsx
@@ -68,7 +68,7 @@ export default function ProjectDuplicate() {
                 },
                 {
                     name: "Dupliceren",
-                    url: "/projects/duplicate"
+                    url: `/projects/${project}/duplicate`
                 }
             ]}
             >

--- a/apps/web/src/pages/projects/[project]/export.tsx
+++ b/apps/web/src/pages/projects/[project]/export.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { PageLayout } from '../../../components/ui/page-layout';
+
+import { Button } from '../../../components/ui/button';
+import { Heading } from '@/components/ui/typography';
+import { Separator } from '@/components/ui/separator';
+import { useRouter } from 'next/router';
+import { useProject } from '@/hooks/use-project';
+import useVotes from '@/hooks/use-votes';
+import useIdeas from '@/hooks/use-ideas';
+import useTags from '@/hooks/use-tags';
+import useComments from '@/hooks/use-comments';
+import usePolls from '@/hooks/use-poll';
+
+export default function ProjectExport() {
+  const router = useRouter();
+  const { project } = router.query;    
+
+  // Function to export data as a file
+  const exportData = (data: any, fileName: any, type: any) => {
+    // Create a link and download the file
+    const blob = new Blob([data], { type });
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = fileName;
+    a.click();
+    window.URL.revokeObjectURL(url);
+  };
+
+  const { data, isLoading } = useProject();
+  const { data: projectVotes, isLoading: isLoadingVotes } = useVotes(project as string);
+  const { data: projectIdeas, isLoading: isLoadingIdeas } = useIdeas(project as string);
+  const { data: projectTags, isLoading: isLoadingTags } = useTags(project as string);
+  const { data: projectComments, isLoading: isLoadingComments } = useComments(project as string);
+  const { data: projectPolls, isLoading: isLoadingPolls } = usePolls(project as string);
+
+
+  function transform() {
+    const totalData = {data, projectVotes, projectIdeas, projectTags, projectComments, projectPolls};
+    const jsonData = JSON.stringify(totalData);
+    exportData(jsonData, "test.json", "application/json");
+  }
+
+  return (
+    <div>
+      <PageLayout
+        pageHeader="Projecten"
+        breadcrumbs={[
+          {
+            name: 'Projecten',
+            url: '/projects',
+          },
+          {
+            name: 'Exporteren',
+            url: `/projects/${project}/export`,
+          },
+        ]}>
+        <div className="container py-6">
+          <div className="p-6 bg-white rounded-md">
+            <Heading size="xl">Exporteren</Heading>
+            <Separator className="my-4" />
+            <div className="grid grid-cols-2 gap-4 w-fit">
+              <div className="col-span-full">
+                <div>
+                  De volgende gegevens worden geëxporteerd.
+                  <ul className="list-disc">
+                    <li className="ml-4">Projectgegevens</li>
+                    <li className="ml-4">Plannen</li>
+                    <li className="ml-4">Comments per plan</li>
+                    <li className="ml-4">Polls per plan</li>
+                    <li className="ml-4">Stemmen per plan</li>
+                    <li className="ml-4">Tags</li>
+                  </ul>
+                </div>
+              </div>
+              <Button className="w-fit col-span-full mt-4" type="submit" onClick={transform}>
+                Opslaan
+              </Button>
+            </div>
+          </div>
+        </div>
+      </PageLayout>
+    </div>
+  );
+}

--- a/apps/web/src/pages/projects/[project]/export.tsx
+++ b/apps/web/src/pages/projects/[project]/export.tsx
@@ -17,7 +17,7 @@ export default function ProjectExport() {
   const { project } = router.query;    
 
   // Function to export data as a file
-  const exportData = (data: any, fileName: any, type: any) => {
+  const exportData = (data: BlobPart, fileName: string, type: string) => {
     // Create a link and download the file
     const blob = new Blob([data], { type });
     const url = window.URL.createObjectURL(blob);
@@ -28,7 +28,7 @@ export default function ProjectExport() {
     window.URL.revokeObjectURL(url);
   };
 
-  const { data, isLoading } = useProject();
+  const { data: projectData, isLoading } = useProject();
   const { data: projectVotes, isLoading: isLoadingVotes } = useVotes(project as string);
   const { data: projectIdeas, isLoading: isLoadingIdeas } = useIdeas(project as string);
   const { data: projectTags, isLoading: isLoadingTags } = useTags(project as string);
@@ -37,9 +37,9 @@ export default function ProjectExport() {
 
 
   function transform() {
-    const totalData = {data, projectVotes, projectIdeas, projectTags, projectComments, projectPolls};
+    const totalData = {projectData, projectVotes, projectIdeas, projectTags, projectComments, projectPolls};
     const jsonData = JSON.stringify(totalData);
-    exportData(jsonData, "test.json", "application/json");
+    exportData(jsonData, `${projectData.name}.json`, "application/json");
   }
 
   return (


### PR DESCRIPTION
Het exporteren van projecten naar een JSON bestand werkt. De data van een project, en de volgende gerelateerde onderdelen, worden er nu in weergegeven:
- Plannen per project
- Stemmen per project
- Polls per project
- Comments per project
- Tags per project

Er zijn twee dingen die ik wil bespreken in dit pull request voordat ik het merge: Een mogelijke manier om de calls naar de database met elkaar te combineren, aangezien je nu zes verschillende API calls doet om alle data die je wilt op te halen voordat het in de JSON gezet wordt, en mogelijk de structuur van de JSON (alles wordt nu op een enkele regel opgeslagen en is van elkaar te scheiden via de titel, maar misschien willen we alle onderdelen op aparte regels hebben).