### PR TITLE
Add OpenStad Auth configuration to Create project

### DIFF
--- a/apps/api-server/config/default.js
+++ b/apps/api-server/config/default.js
@@ -151,6 +151,10 @@ Als de webmaster de website gesloten heeft is deze in principe nog wel te bezoek
     },
 	},
 
+  admin: {
+    projectId: process.env.ADMIN_PROJECTID || 1,
+  },
+
   dev: {
     'Header-Access-Control-Allow-Origin': '*'
   }


### PR DESCRIPTION
When creating a new project on the API clients should be created on the OpenStad auth server, and the settings of those clients saved on the new project.

Settings of the client van be sent as part of the config:
```
POST :HOSTNAME/api/project
Content-type: application/json
Authorization: XXX

{
  "name": "My new project",
  "config": {
    "auth": {
      "provider": {
        "openstad": {
          "authTypes": "UniqueCode",
          "requiredUserFields": "city"
        }
      }
    }
  }
}

```