### PR TITLE
Allow for more flexible login links

### DIFF
--- a/apps/api-server/src/adapter/openstad/router.js
+++ b/apps/api-server/src/adapter/openstad/router.js
@@ -222,7 +222,8 @@ router
 
     let returnTo = req.query.returnTo;
     returnTo = returnTo || '/?jwt=[[jwt]]';
-    let redirectUrl = returnTo ? returnTo + (returnTo.includes('?') ? '&' : '?') + 'jwt=[[jwt]]' : false;
+    if (!returnTo.match(/\[\[jwt\]\]/) ) returnTo = returnTo + (returnTo.includes('?') ? '&' : '?') + 'jwt=[[jwt]]';
+    let redirectUrl = returnTo;
     redirectUrl = redirectUrl || (req.query.returnTo ? req.query.returnTo + (req.query.returnTo.includes('?') ? '&' : '?') + 'jwt=[[jwt]]' : false);
     redirectUrl = redirectUrl || '/';
 


### PR DESCRIPTION
This change allows for using a different name for the eturned jwt token.