### PR TITLE
Fix/keep values when switching tabs

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/comments/[id]/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/comments/[id]/index.tsx
@@ -47,7 +47,7 @@ export default function WidgetArguments() {
           },
           {
             name: 'Argumenten',
-            url: `/projects/${projectId}/widgets/arguments/${id}`,
+            url: `/projects/${projectId}/widgets/comments/${id}`,
           },
         ]}>
         <div className="container py-6">
@@ -58,9 +58,9 @@ export default function WidgetArguments() {
               <TabsTrigger value="form">Formulier</TabsTrigger>
             </TabsList>
             <TabsContent value="general" className="p-0">
-              {widget?.config ? (
+              {previewConfig ? (
                 <ArgumentsGeneral
-                  {...widget?.config}
+                  {...previewConfig}
                   updateConfig={(config) =>
                     updateConfig({ ...widget.config, ...config })
                   }
@@ -76,9 +76,9 @@ export default function WidgetArguments() {
               ) : null}
             </TabsContent>
             <TabsContent value="list" className="p-0">
-              {widget?.config ? (
+              {previewConfig ? (
                 <ArgumentsList
-                  {...widget?.config}
+                  {...previewConfig}
                   updateConfig={(config) =>
                     updateConfig({ ...widget.config, ...config })
                   }
@@ -94,9 +94,9 @@ export default function WidgetArguments() {
               ) : null}
             </TabsContent>
             <TabsContent value="form" className="p-0">
-              {widget?.config ? (
+              {previewConfig ? (
                 <ArgumentsForm
-                  {...widget?.config}
+                  {...previewConfig}
                   updateConfig={(config) =>
                     updateConfig({ ...widget.config, ...config })
                   }

--- a/apps/admin-server/src/pages/projects/[project]/widgets/likes/[id]/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/likes/[id]/index.tsx
@@ -17,12 +17,7 @@ export default function WidgetLikes() {
   const { data: widget, updateConfig } = useWidgetConfig();
   const { previewConfig, updatePreview } = useWidgetPreview<LikeWidgetProps>({
     projectId,
-    resourceId: '2',
-    api: {
-      url: '/api/openstad',
-    },
-    title: 'Vind je dit een goed idee?',
-    variant: 'medium',
+    resourceId: '2'
   });
 
   return (
@@ -50,9 +45,9 @@ export default function WidgetLikes() {
               <TabsTrigger value="publish">Publiceren</TabsTrigger>
             </TabsList>
             <TabsContent value="display" className="p-0">
-              {widget?.config ? (
+              {previewConfig ? (
                 <LikesDisplay
-                  {...widget?.config}
+                  {...previewConfig}
                   updateConfig={(config) =>
                     updateConfig({ ...widget.config, ...config })
                   }

--- a/apps/admin-server/src/pages/projects/[project]/widgets/likes/[id]/weergave.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/likes/[id]/weergave.tsx
@@ -21,7 +21,7 @@ import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 import { Heading } from '@/components/ui/typography';
 import { Separator } from '@/components/ui/separator';
-import { LikeProps } from '@openstad/likes/src/likes';
+import { LikeProps, LikeWidgetProps } from '@openstad/likes/src/likes';
 import { EditFieldProps } from '@/lib/form-widget-helpers/EditFieldProps';
 import { useFieldDebounce } from '@/hooks/useFieldDebounce';
 
@@ -34,19 +34,13 @@ const formSchema = z.object({
 });
 type FormData = z.infer<typeof formSchema>;
 
-type Props = {
-  title: string;
-  variant: 'small' | 'medium' | 'large';
-  yesLabel: string;
-  noLabel: string;
-  hideCounters: boolean;
-};
 
-export default function LikesDisplay(props: Props & EditFieldProps<LikeProps>) {
+
+export default function LikesDisplay(props: LikeWidgetProps & EditFieldProps<LikeWidgetProps>) {
   const { onFieldChange } = useFieldDebounce(props.onFieldChanged);
 
   function onSubmit(values: FormData) {
-    props.updateConfig(values);
+    props.updateConfig({...props, ...values});
   }
 
   const form = useForm<FormData>({


### PR DESCRIPTION
De waarden van de widget preview worden nu behouden wanneer je wisselt tussen tabs in zowel likes als comments.