### PR TITLE
Juiste toast bij fout aanmaken tags

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/tags/create.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/tags/create.tsx
@@ -38,7 +38,7 @@ export default function ProjectTagCreate() {
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     const tags = await createTag(values.name, values.type, values.seqnr);
-    if (tags) {
+    if (tags && tags.status !== 500) {
       toast.success('Tag aangemaakt!');
       router.push(`/projects/${project}/tags`);
     } else {

--- a/apps/admin-server/src/pages/projects/[project]/tags/create.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/tags/create.tsx
@@ -38,7 +38,7 @@ export default function ProjectTagCreate() {
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     const tags = await createTag(values.name, values.type, values.seqnr);
-    if (tags && tags.status !== 500) {
+    if (tags && tags.status === 200) {
       toast.success('Tag aangemaakt!');
       router.push(`/projects/${project}/tags`);
     } else {


### PR DESCRIPTION
Wanneer je niet in staat bent om een tag aan te maken, omdat je niet bij dit specifieke project hoort, krijg je nog steeds een succesvolle toast te zien. Dit is nu opgelost.