### PR TITLE
fix: bind deployment scripts (except local) to published chart

### DIFF
--- a/operations/deployments/openstad-headless/deploy-acc.sh
+++ b/operations/deployments/openstad-headless/deploy-acc.sh
@@ -5,7 +5,7 @@ set -e
 ################################################################################
 # repo
 ################################################################################
-# helm repo add openstad-headless https://raw.githubusercontent.com/openstad/openstad-headless/master
+helm repo add openstad-headless https://raw.githubusercontent.com/openstad/openstad-headless/gh-pages
 helm repo update > /dev/null
 
 ################################################################################
@@ -18,8 +18,7 @@ images="$ROOT_DIR/operations/deployments/openstad-headless/environments/acc/imag
 chart_dir="$ROOT_DIR/charts"
 
 STACK="openstad-headless"
-# CHART="openstad-headless/openstad-headless"
-CHART="openstad-headless"
+CHART="openstad-headless/openstad-headless"
 CHART_VERSION="0.0.1"
 NAMESPACE="headless-acc-2024"
 CONTEXT="do-ams3-openstad-ams-acc"
@@ -32,20 +31,13 @@ echo "Decrypting files..."
 sh $ROOT_DIR/operations/scripts/decrypt.sh
 
 echo "Starting deployment..."
-# Temp for local chart testing
-current_folder=$(pwd)
-cd $chart_dir
-# end temp
 helm upgrade "$STACK" "$CHART" \
   --create-namespace \
   --install \
+  --version "$CHART_VERSION" \
   --namespace "$NAMESPACE" \
   -f "$values" \
   -f "$secrets" \
   -f "$images"
-# Temp for local chart testing
-#   --version "$CHART_VERSION"
-cd $current_folder
-# end temp
 
 kubectl config set current-context $PREVIOUS_CONTEXT

--- a/operations/deployments/openstad-headless/deploy-local.sh
+++ b/operations/deployments/openstad-headless/deploy-local.sh
@@ -32,16 +32,20 @@ echo "Decrypting files..."
 sh $ROOT_DIR/operations/scripts/decrypt.sh
 
 echo "Starting deployment..."
+# Temp for local chart testing
 current_folder=$(pwd)
 cd $chart_dir
-helm template "$STACK" "$CHART" \
-  --atomic \
+# end temp
+helm upgrade "$STACK" "$CHART" \
   --create-namespace \
+  --install \
   --namespace "$NAMESPACE" \
   -f "$values" \
   -f "$secrets" \
   -f "$images"
+# Temp for local chart testing
 #   --version "$CHART_VERSION"
-
 cd $current_folder
+# end temp
+
 kubectl config set current-context $PREVIOUS_CONTEXT


### PR DESCRIPTION
Omdat er nu een helm chart is gepubliceerd kan het deployment script deze gebruiken ipv lokale charts gebruiken


