### PR TITLE
Ticket: Admin geeft geen feedback op errors

### DIFF
--- a/apps/admin-server/src/components/resource-form.tsx
+++ b/apps/admin-server/src/components/resource-form.tsx
@@ -68,7 +68,6 @@ const formSchema = z.object({
   modBreakDate: z.date().optional(),
 
   location: z.string().optional(),
-  images: z.string().array().default([]),
 
   extraData: z
     .object({
@@ -120,7 +119,6 @@ export default function ResourceForm({ onFormSubmit }: Props) {
         : undefined,
 
       location: existingData?.location || '',
-      images: existingData?.images || [],
       extraData: {
         originalId: existingData?.extraData?.originalId || undefined,
       },


### PR DESCRIPTION
Niels - 
Als ik in de admin een plan resource bewerk in site 2 (default developments seeds) dan gebeurt er niets als ik op opslaan druk.

Vermoedelijk is een error in het formulier waardoor er geen submit plaats vindt, maar als gebruiker zie je die error niet.

Hetzelfde verschijnsel doet zich voor als je een error krijgt in een andere tab; Bart en BNiels keken daar samen naar bij het editen van tags: het formulier geeft een error maar de gebruiker krijgt geen (zichtbare) feedback.

Bart -
Oorzaak gevonden: 'images' in het formschema verwacht een array, maar de default waarde die aangemaakt wordt door de scripts is echter geen array. Voor nu wordt deze waarde überhaupt nog niet gebruikt: Dus de waarde is voor nu weggehaald.