### PR TITLE
Update setup to reflect changes from PR145

### DIFF
--- a/scripts/setup-admin.js
+++ b/scripts/setup-admin.js
@@ -19,6 +19,7 @@ CLIENT_SECRET=${process.env.AUTH_ADMIN_CLIENT_SECRET}
 OAUTH_URL=${process.env.AUTH_APP_URL}
 API_URL=${process.env.API_URL}
 API_URL_INTERNAL=${process.env.API_URL}
+API_FIXED_AUTH_KEY=${process.env.API_FIXED_AUTH_KEY}
 PORT=${process.env.ADMIN_PORT}
 `
     if (actions['create config']) {

--- a/scripts/setup-admin.js
+++ b/scripts/setup-admin.js
@@ -18,7 +18,7 @@ CLIENT_ID=${process.env.AUTH_ADMIN_CLIENT_ID}
 CLIENT_SECRET=${process.env.AUTH_ADMIN_CLIENT_SECRET}
 OAUTH_URL=${process.env.AUTH_APP_URL}
 API_URL=${process.env.API_URL}
-NEXT_PUBLIC_API_URL=${process.env.API_URL}
+API_URL_INTERNAL=${process.env.API_URL}
 PORT=${process.env.ADMIN_PORT}
 `
     if (actions['create config']) {


### PR DESCRIPTION
In PR145 is NEXT_PUBLIC_API_URL gewijzigd naar API_URL_INTERNAL (waarvoor hulde).

Hier een kleine aanvulling zodat dat ook werkt na een `npm run setup`