### PR TITLE
fix: add missing env vars for api initial seeds

### DIFF
--- a/charts/openstad-headless/Chart.yaml
+++ b/charts/openstad-headless/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: 0.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openstad-headless/templates/api/deployment.yaml
+++ b/charts/openstad-headless/templates/api/deployment.yaml
@@ -134,6 +134,18 @@ spec:
 
           - name: BASE_DOMAIN
             value: {{ .Values.host.base }}
+
+          - name: AUTH_ADMIN_CLIENT_ID
+            valueFrom:
+              secretKeyRef:
+                key: admin_client_id
+                name: {{ template "openstad.auth.secret.fullname" . }}
+
+          - name: AUTH_ADMIN_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                key: admin_client_secret
+                name: {{ template "openstad.auth.secret.fullname" . }}
         
           {{- if .Values.api.extraEnvVars }}
           {{- include "common.tplvalues.render" (dict "value" .Values.api.extraEnvVars "context" $) | nindent 10 }}

--- a/operations/deployments/openstad-headless/deploy-acc.sh
+++ b/operations/deployments/openstad-headless/deploy-acc.sh
@@ -19,7 +19,7 @@ chart_dir="$ROOT_DIR/charts"
 
 STACK="openstad-headless"
 CHART="openstad-headless/openstad-headless"
-CHART_VERSION="0.0.4"
+CHART_VERSION="0.0.5"
 NAMESPACE="headless-acc-2024"
 CONTEXT="do-ams3-openstad-ams-acc"
 PREVIOUS_CONTEXT=$(kubectl config current-context)


### PR DESCRIPTION
Deze waardes zijn vooral belangrijk bij het initialiseren van de database. Anders valt hij terug op `uniquecode` etc.