### PR TITLE
fix/widget bugfixes

### DIFF
--- a/apps/admin-server/src/components/simple-calender-popup.tsx
+++ b/apps/admin-server/src/components/simple-calender-popup.tsx
@@ -1,4 +1,9 @@
+import { Calendar } from '@/components/ui/calendar';
+import { cn } from '@/lib/utils';
+import { format } from 'date-fns';
+import { CalendarIcon, RotateCcw } from 'lucide-react';
 import { FieldValues, Path, UseFormReturn } from 'react-hook-form';
+import { Button } from './ui/button';
 import {
   FormControl,
   FormField,
@@ -7,12 +12,6 @@ import {
   FormMessage,
 } from './ui/form';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
-import { Button } from './ui/button';
-import { cn } from '@/lib/utils';
-import { format } from 'date-fns';
-import { CalendarIcon, RotateCcw, XCircleIcon } from 'lucide-react';
-import { Calendar } from '@/components/ui/calendar';
-import { Delete } from 'lucide-react';
 
 // Would like to use a generic solution <T> to enable hinting in the using file
 // Now to remove the errors UseFormReturn<any> has to be used
@@ -22,7 +21,8 @@ export const SimpleCalendar: React.FC<{
   label: string;
   placeholder?: string;
   withReset?: boolean;
-}> = ({ form, fieldName, label, placeholder, withReset }) => {
+  allowPast?: boolean;
+}> = ({ form, fieldName, label, placeholder, withReset, allowPast }) => {
   return (
     <FormField
       control={form.control}
@@ -58,7 +58,12 @@ export const SimpleCalendar: React.FC<{
                       ? field.onChange(new Date(value.toDateString()))
                       : field.onChange(value);
                   }}
-                  disabled={(date) => date < new Date()}
+                  disabled={
+                    allowPast
+                      ? false
+                      : (date) =>
+                          date < new Date(new Date().setHours(0, 0, 0, 0))
+                  }
                   initialFocus
                 />
                 {withReset && (

--- a/apps/admin-server/src/pages/projects/[project]/widgets/agenda/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/agenda/[id]/items.tsx
@@ -313,9 +313,9 @@ export default function WidgetAgendaItems(
             {settingLinks ? (
               <div className="p-6 bg-white rounded-md col-span-2 grid grid-cols-1 lg:grid-cols-2 gap-x-6">
                 <div className="flex flex-col justify-between">
-                  <div>
+                  <div className="flex flex-col gap-y-2">
                     <Heading size="xl">Links</Heading>
-                    <Separator className="my-4" />
+                    <Separator className="mt-2" />
                     <FormField
                       control={form.control}
                       name={`links.${links.length - 1}.title`}
@@ -435,17 +435,17 @@ export default function WidgetAgendaItems(
                 <div>
                   <Heading size="xl">Agenda items</Heading>
                   <Separator className="my-4" />
-                  <div className="w-2/3">
-                    <FormField
-                      control={form.control}
-                      name="trigger"
-                      render={({ field }) => (
-                        <FormItem>
-                          <Input type="hidden" {...field} />
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
+                  <FormField
+                    control={form.control}
+                    name="trigger"
+                    render={({ field }) => (
+                      <FormItem>
+                        <Input type="hidden" {...field} />
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <div className="w-full lg:w-2/3 flex flex-col gap-y-2">
                     <FormField
                       control={form.control}
                       name="title"

--- a/packages/agenda/src/agenda.tsx
+++ b/packages/agenda/src/agenda.tsx
@@ -38,6 +38,7 @@ function Agenda(props: AgendaWidgetProps) {
         {props?.items &&
           props?.items?.length > 0 &&
           props.items
+            .filter((item) => item.active)
             ?.sort((a, b) => parseInt(a.trigger) - parseInt(b.trigger))
             .map((item) => (
               <div key={item.trigger} className="osc-agenda-item">

--- a/packages/resource-detail/src/resource-detail.tsx
+++ b/packages/resource-detail/src/resource-detail.tsx
@@ -1,12 +1,10 @@
 import './resource-detail.css';
-import React from 'react';
 //@ts-ignore D.type def missing, will disappear when datastore is ts
 import DataStore from '@openstad-headless/data-store/src';
-import { Spacer } from '@openstad-headless/ui/src';
-import { Image } from '@openstad-headless/ui/src';
+import { loadWidget } from '@openstad-headless/lib/load-widget';
+import { Image, Spacer } from '@openstad-headless/ui/src';
 import { BaseProps } from '../../types/base-props';
 import { ProjectSettingProps } from '../../types/project-setting-props';
-import { loadWidget } from '@openstad-headless/lib/load-widget';
 export type ResourceDetailWidgetProps = BaseProps &
   ProjectSettingProps & {
     projectId?: string;
@@ -75,13 +73,13 @@ function ResourceDetail(props: ResourceDetailWidgetProps) {
                   </span>
                 </div>
               )}
-              {props.displayDate && resource.publishDateHumanized && (
+              {props.displayDate && resource.startDateHumanized && (
                 <div>
                   <h6 className="osc-resource-detail-content-item-title">
                     Datum
                   </h6>
                   <span className="osc-resource-detail-content-item-text">
-                    {resource.publishDateHumanized}
+                    {resource.startDateHumanized}
                   </span>
                 </div>
               )}


### PR DESCRIPTION
Added:
- Added allowPast as an option when using the Simple Calendar Popup

Fix:
- publishDate is replaced by startDate on the resourceDetail widget
- Agenda items are only shown if active on the Agenda widget
- Creating a resource will now allow setting the current day as startDay/publishDay. 
- Small styling fixes
