### PR TITLE
fix: move k8s client to correct api

### DIFF
--- a/apps/api-server/src/services/checkHostStatus.js
+++ b/apps/api-server/src/services/checkHostStatus.js
@@ -6,7 +6,7 @@ const ip = require('ip');
 const getK8sApi = () => {
   const kc = new k8s.KubeConfig();
   kc.loadFromCluster();
-  return kc.makeApiClient(k8s.NetworkingV1beta1Api);
+  return kc.makeApiClient(k8s.NetworkingV1Api);
 };
 
 const lookupPromise = async (domain) => {


### PR DESCRIPTION
The NetworkingV1beta API has been deprecated. By using the NetworkingV1Api we should be able to read / create / update Ingresses again.