### PR TITLE
Fix a bug in findAndCountAll

### DIFF
--- a/apps/api-server/src/db.js
+++ b/apps/api-server/src/db.js
@@ -59,6 +59,16 @@ var sequelize = new Sequelize(dbConfig.database, dbConfig.user, dbConfig.passwor
 	},
 });
 
+// fix a bug in findAndCountAll: https://github.com/sequelize/sequelize/issues/10557
+sequelize.addHook('beforeCount', function (options) {
+  if (this._scope.include && this._scope.include.length > 0) {
+    options.distinct = true
+    options.col = this._scope.col || options.col || `${this.options.name.singular}.id`
+  }
+  if (options.include && options.include.length > 0) {
+    options.include = null
+  }
+})
 
 // Define models.
 let db = {};


### PR DESCRIPTION
Paginering op de API telt verkeerd door een bug in Sequelize. Het gaat om het tellen van items terwijl je includes gebruikt; dat levert een query op waarvan de telling dus niet klopt.

Deze fix komt van https://github.com/sequelize/sequelize/issues/10557
