### PR TITLE
feat: create/update ingress on project save

### DIFF
--- a/apps/api-server/src/models/Project.js
+++ b/apps/api-server/src/models/Project.js
@@ -191,6 +191,10 @@ module.exports = function (db, sequelize, DataTypes) {
   });
 
   async function beforeUpdateOrCreate(instance, options) {
+    // If a URL is provided, and no uniqueId is set, generate one
+    if (instance && instance.url && (!instance.config || !instance.config.uniqueId)) {
+      instance.config.uniqueId = Math.round(new Date().getTime() / 1000) + instance.url.replace(/\W/g, '').slice(0,40);
+    }
   }
 
   Project.scopes = function scopes() {

--- a/apps/api-server/src/routes/api/project.js
+++ b/apps/api-server/src/routes/api/project.js
@@ -141,9 +141,13 @@ router.route('/')
 	.post(function(req, res, next) {
 		db.Project
 			.create(req.body)
-			.then((result) => {
-				req.results = result;
-				return next();
+			.then(result => {
+        req.results = result;
+				return checkHostStatus({id: result.id});
+			})
+			.then(() => {
+				next();
+        return null;
 			})
 			.catch(next)
 	})
@@ -322,12 +326,12 @@ router.route('/:projectId(\\d+)/:willOrDo(will|do)-anonymize-all-users')
 		result.message = 'Ok';
 
 		req.project.doAnonymizeAllUsers(
-			[...result.users], 
+			[...result.users],
 			[...result.externalUserIds],
 			req.query.useAuth
 
 		);
-      } 
+      }
       next();
     } catch (err) {
       return next(err);


### PR DESCRIPTION
By adding a `config.uniqueId` for each created site, we can create unique ingresses for each project. Upon creating/saving a project the ingress is created if it doesn't yet exist. If it already exists, the ingress is checked against the url of the project. If the URL is not yet in there, we add / replace the url (depends on if there are multiple hosts or not)