### PR TITLE
Bugfix/add auth to new project

### DIFF
--- a/apps/admin-server/src/hooks/use-project.tsx
+++ b/apps/admin-server/src/hooks/use-project.tsx
@@ -30,7 +30,7 @@ export function useProject(scopes?: Array<string>) {
                 adapter: 'openstad',
                 authTypes: 'Url',
               },
-              anoymous: {
+              anonymous: {
                 name: `${name} anonymous`,
                 adapter: 'openstad',
                 authTypes: 'Anonymous',

--- a/apps/admin-server/src/hooks/use-project.tsx
+++ b/apps/admin-server/src/hooks/use-project.tsx
@@ -22,6 +22,23 @@ export function useProject(scopes?: Array<string>) {
       },
       body: JSON.stringify({
         name,
+        config: {
+          auth: {
+            provider: {
+              openstad: {
+                name: `${name} normal`,
+                adapter: 'openstad',
+                authTypes: 'Url',
+              },
+              anoymous: {
+                name: `${name} anonymous`,
+                adapter: 'openstad',
+                authTypes: 'Anonymous',
+                requiredUserFields: 'postcode',
+              }
+            }
+          }
+        }
       }),
     });
     return await res.json();

--- a/apps/admin-server/src/pages/projects/create.tsx
+++ b/apps/admin-server/src/pages/projects/create.tsx
@@ -60,7 +60,7 @@ export default function CreateProject() {
     const project = await createProject(values.projectName);
     if (project) {
       toast.success('Project aangemaakt!');
-      router.push(`/projects/${project.id}/widgets`);
+      router.push(`/projects/${project.id}/settings`);
     } else {
       toast.error('Er is helaas iets mis gegaan.')
     }
@@ -77,7 +77,7 @@ export default function CreateProject() {
       );
       if (project) {
         toast.success('Project aangemaakt!');
-        router.push(`/projects/${project.id}/widgets`);
+        router.push(`/projects/${project.id}/settings`);
       } else {
         toast.error('De file die geüpload is bevat onjuiste data.');
       }

--- a/apps/api-server/src/adapter/openstad/service.js
+++ b/apps/api-server/src/adapter/openstad/service.js
@@ -181,7 +181,7 @@ service.fetchClient = async function({ authConfig, project }) {
 
   let clientId = authConfig.clientId;
   if (!clientId) {
-    throw new Error('OpenStad.service.updateClient: clientId not found')
+    throw new Error('OpenStad.service.fetchClient: clientId not found')
   }
 
   try {
@@ -193,7 +193,7 @@ service.fetchClient = async function({ authConfig, project }) {
       },
     })
     if (!response.ok) {
-      throw new Error('OpenStad.service.updateClient: fetch client failed')
+      throw new Error('OpenStad.service.fetchClient: fetch client failed')
     }
     let client = await response.json();
     return client;

--- a/apps/api-server/src/adapter/openstad/service.js
+++ b/apps/api-server/src/adapter/openstad/service.js
@@ -243,10 +243,10 @@ service.createClient = async function({ authConfig, project }) {
         authTypes,
         requiredUserFields,
         twoFactorRoles,
-        siteUrl: `${project.url}`,
-        redirectUrl: `${config.url}`,
+        siteUrl: project.url || '',
+        redirectUrl: config.url || '',
         allowedDomains: [ config.domain ],
-        name: `${project.name}`,
+        name: authConfig.name || project.name || '',
         description: `Client for API project ${project.name} (${project.id})`,
         config: newConfig
       }),


### PR DESCRIPTION
Een nieuw project heeft geen auth clients, Op de API is dat toegevoegd in https://github.com/openstad/openstad-headless/pull/76 maar dat is blijkbaar nooit verwerkt in de admin server.

En in het proces heb ik nog wat andere client/login verbeteringen doorgevoerd...