### PR TITLE
rename logintokens and add global openstad user

### DIFF
--- a/apps/api-server/src/adapter/openstad/router.js
+++ b/apps/api-server/src/adapter/openstad/router.js
@@ -109,10 +109,10 @@ router
   .get(async function (req, res, next) {
     // check redirect first
     let returnTo = req.query.returnTo;
-    returnTo = returnTo || '/?jwt=[[jwt]]';
-    if (!returnTo.match(/\[\[jwt\]\]/) ) returnTo = returnTo + (returnTo.includes('?') ? '&' : '?') + 'jwt=[[jwt]]';
+    returnTo = returnTo || '/?openstadlogintoken=[[jwt]]';
+    if (!returnTo.match(/\[\[jwt\]\]/) ) returnTo = returnTo + (returnTo.includes('?') ? '&' : '?') + 'openstadlogintoken=[[jwt]]';
     let redirectUrl = returnTo;
-    redirectUrl = redirectUrl || (req.query.returnTo ? req.query.returnTo + (req.query.returnTo.includes('?') ? '&' : '?') + 'jwt=[[jwt]]' : false);
+    redirectUrl = redirectUrl || (req.query.returnTo ? req.query.returnTo + (req.query.returnTo.includes('?') ? '&' : '?') + 'openstadlogintoken=[[jwt]]' : false);
     redirectUrl = redirectUrl || '/';
 
     const isAllowedRedirectDomain = (url, project) => {

--- a/apps/cms-server/app.js
+++ b/apps/cms-server/app.js
@@ -200,7 +200,7 @@ app.get('/auth/login', (req, res, next) => {
     returnUrl = returnUrl + pathToReturnTo;
   }
 
-  returnUrl = encodeURIComponent(returnUrl + '?logintoken=[[jwt]]');
+  returnUrl = encodeURIComponent(returnUrl + '?openstadlogintoken=[[jwt]]');
 
   const apiUrl = process.env.API_URL;
   let url = `${apiUrl}/auth/project/${project.id}/login?redirectUri=${returnUrl}`;

--- a/apps/cms-server/modules/openstad-auth/index.js
+++ b/apps/cms-server/modules/openstad-auth/index.js
@@ -48,7 +48,7 @@ module.exports = {
           return self.apos.permissions.can(req, permission);
         };
 
-        if (req.query.logintoken) {
+        if (req.query.openstadlogintoken) {
           const thisHost = req.headers['x-forwarded-host'] || req.get('host');
           const protocol = req.headers['x-forwarded-proto'] || req.protocol;
           const fullUrl = protocol + '://' + thisHost + req.originalUrl;
@@ -56,12 +56,12 @@ module.exports = {
           const fullUrlPath = parsedUrl.path;
 
           // remove the JWT Parameter otherwise keeps redirecting
-          let returnTo = req.session && req.session.returnTo ? req.session.returnTo : removeURLParameter(fullUrlPath, 'logintoken');
+          let returnTo = req.session && req.session.returnTo ? req.session.returnTo : removeURLParameter(fullUrlPath, 'openstadlogintoken');
 
           // make sure references to external urls fail, only take the path
           returnTo = Url.parse(returnTo, true);
           returnTo = returnTo.path;
-          req.session.jwt = req.query.logintoken;
+          req.session.jwt = req.query.openstadlogintoken;
           req.session.returnTo = null;
 
           req.session.save(() => {
@@ -90,6 +90,7 @@ module.exports = {
               req.data.isEditor = user.role === 'editor'; // user;
               req.data.isModerator = user.role === 'moderator'; // user;
               req.data.jwt = jwt;
+              req.data.globalOpenStadUser = { id: user.id, role: user.role, jwt };
 
               if (req.data.isAdmin || req.data.isEditor || req.data.isModerator) {
                 req.data.hasModeratorRights = true;

--- a/apps/cms-server/views/layout.html
+++ b/apps/cms-server/views/layout.html
@@ -20,6 +20,7 @@ page or piece.') }}
 {% endblock %}
 
 {% block beforeMain %}
+{% include 'partials/openstaduser.html' %}
 <div class="bp-wrapper">
   {% include 'partials/css.html' %}
   {% include 'partials/cookie-warning.html' %}

--- a/apps/cms-server/views/partials/openstaduser.html
+++ b/apps/cms-server/views/partials/openstaduser.html
@@ -1,0 +1,5 @@
+{% if data.globalOpenStadUser %}
+<script>
+const globalOpenStadUser = {{data.globalOpenStadUser | dump | safe }}
+</script>
+{% endif %}

--- a/packages/data-store/src/hooks/use-current-user.js
+++ b/packages/data-store/src/hooks/use-current-user.js
@@ -19,7 +19,10 @@ export default function useCurrentUser(props) {
     }
 
     // get user from props
-    let initialUser = props.openStadUser || {};
+    let initialUser = {};
+    try {
+      initialUser = globalOpenStadUser || props.openStadUser || {};
+    } catch(err) {}
 
     if (initialUser.id && initialUser.projectId == self.projectId) {
       return initialUser;
@@ -30,15 +33,19 @@ export default function useCurrentUser(props) {
     // jwt in url: use and remove from url
     const params = new URLSearchParams(window.location.search);
     let jwt;
-    if (params.has('jwt')) {
-      jwt = params.get('jwt');
+    if (params.has('openstadlogintoken')) {
+      jwt = params.get('openstadlogintoken');
       session.set('openStadUser', { jwt });
       let url = window.location.href;
-      url = url.replace(new RegExp(`[?&]jwt=${jwt}`), '');
+      url = url.replace(new RegExp(`[?&]openstadlogintoken=${jwt}`), '');
       history.replaceState(null, '', url);
     }
 
-    const cmsUser = props.cmsUser || {};
+    let cmsUser = {};
+    try {
+      cmsUser = globalCmsUser || props.cmsUser || {};
+    } catch(err) {}
+
     // get cmsUser from session data - this is a fix for badly written cms logouts
     let sessionCmsUser = session.get('cmsUser') || {};
     if (sessionCmsUser && cmsUser) {
@@ -67,6 +74,7 @@ export default function useCurrentUser(props) {
 
     // fetch me for this jwt
     if (jwt) {
+
       self.api.currentUserJWT = jwt; // use current user in subsequent requests
 
       // refresh already fetched data, now with the current user
@@ -76,6 +84,7 @@ export default function useCurrentUser(props) {
       let openStadUser = await self.api.user.fetchMe({
         projectId: self.projectId,
       });
+
       session.set('openStadUser', { ...openStadUser, jwt });
       return openStadUser;
     } else {


### PR DESCRIPTION
Zoals besproken: widgets en apos gebruiken nu beide `openstadlogintoken` als naam van de jwt param.

Toegevoegd: de opnemen in de html, zodat de widgets die kunnen oppakken.

Daarnaast bleek het doorgeven van users naar de widgets niet te werken; dat is blijkbaar ergens gesneuveld bij het omzetten van mijn voorbeeld componenten naar de huidige opzet. Dat heb ik gefixed.
