### PR TITLE
fix save widget login url

### DIFF
--- a/apps/admin-server/src/hooks/use-widget-config.tsx
+++ b/apps/admin-server/src/hooks/use-widget-config.tsx
@@ -14,6 +14,11 @@ export function useWidgetConfig() {
   );
 
   async function updateConfig(config: any) {
+
+    // these are added by the preview but should not be saved
+    if (config.login?.url) delete config.login?.url;
+    if (config.logout?.url) delete config.logout?.url;
+
     try {
       const res = await fetch(
         `/api/openstad/api/project/${projectId}/widgets/${id}?includeType=1`,


### PR DESCRIPTION
widget.config.login.url is added by the preview, and therefore saved when updating a widget. This saved login url does not work from the cms.

This fix deletes widget.config.login.url from the saved configuration. A cleaner fix would be to keep the preview and config-to-be-saved apart, but for now this should suffice.