### PR TITLE
Let cms logout go through openstad logout

### DIFF
--- a/apps/cms-server/modules/openstad-auth/index.js
+++ b/apps/cms-server/modules/openstad-auth/index.js
@@ -63,6 +63,11 @@ async function logout(req, res, next) {
 module.exports = {
   middleware(self) {
     return {
+      async enrich(req, res, next) {
+        const projectId = req.project.id;
+        req.data.global.logoutUrl = `${process.env.API_URL}/auth/project/${projectId}/logout?useAuth=default&redirectUri=${req.protocol}://${req.host}${req.url}`;
+        return next();
+      },
       async authenticate (req, res, next) {
 
         if (!req.session) {
@@ -132,13 +137,13 @@ module.exports = {
               });
             };
 
-            const ONE_MINUTE = 1 * 1000;
+            const FIVE_SECONDS = 5 * 1000;
             const date = new Date().getTime();
-            const dateToCheck = req.session.openStadlastJWTCheck ? new Date(req.session.openStadlastJWTCheck) : new Date().getTime() - ONE_MINUTE - 1;
+            const dateToCheck = req.session.openStadlastJWTCheck ? new Date(req.session.openStadlastJWTCheck) : new Date().getTime() - FIVE_SECONDS - 1;
 
             // apostropheCMS does a lot calls on page load
             // if user is a CMS user and last apicheck was within one minute ago don't repeat
-            if (req.user && req.session.openstadUser && ((date - dateToCheck) < ONE_MINUTE)) {
+            if (req.user && req.session.openstadUser && ((date - dateToCheck) < FIVE_SECONDS)) {
               setUserData(req, next);
             } else {
 

--- a/apps/cms-server/modules/openstad-auth/index.js
+++ b/apps/cms-server/modules/openstad-auth/index.js
@@ -38,22 +38,15 @@ async function logout(req, res, next) {
   if (req.session) {
     const destroySession = () => {
       return require('util').promisify(function(callback) {
-        // Be thorough, nothing in the session potentially related to the login should survive logout
         return req.session.destroy(callback);
       })();
     };
     const cookie = req.session.cookie;
     await destroySession();
-    // Session cookie expiration isn't automatic with `req.session.destroy`.
-    // Fix that to reduce challenges for those attempting to implement custom
-    // caching strategies at the edge
-    // https://github.com/expressjs/session/issues/241
     const expireCookie = new expressSession.Cookie(cookie);
     expireCookie.expires = new Date(0);
     const name = self.apos.modules['@apostrophecms/express'].sessionOptions.name;
     req.res.header('set-cookie', expireCookie.serialize(name, 'deleted'));
-
-    // TODO: get cookie name from config
     req.res.cookie(`${self.apos.shortName}.${loggedInCookieName}`, 'false');
   }
   next()

--- a/apps/cms-server/modules/openstad-auth/ui/apos/apps/logout.js
+++ b/apps/cms-server/modules/openstad-auth/ui/apos/apps/logout.js
@@ -1,0 +1,13 @@
+export default function() {
+  apos.bus.$on('admin-menu-click', async (item) => {
+    if (item !== '@apostrophecms/login-logout') {
+      return;
+    }
+    console.log('++1', apos.data);
+    try {
+      console.log('++2');
+      document.location.href = 'https://api.os20.nlsvgtr.nl/auth/project/2/logout?useAuth=default&redirectUri=https://plannen.cms.os20.nlsvgtr.nl/'
+      console.log('++3');
+    } catch(err) { console.log(err) }
+  });
+};

--- a/apps/cms-server/modules/openstad-auth/ui/apos/apps/logout.js
+++ b/apps/cms-server/modules/openstad-auth/ui/apos/apps/logout.js
@@ -3,11 +3,8 @@ export default function() {
     if (item !== '@apostrophecms/login-logout') {
       return;
     }
-    console.log('++1', apos.data);
     try {
-      console.log('++2');
-      document.location.href = 'https://api.os20.nlsvgtr.nl/auth/project/2/logout?useAuth=default&redirectUri=https://plannen.cms.os20.nlsvgtr.nl/'
-      console.log('++3');
+      document.location.href = logoutUrl;
     } catch(err) { console.log(err) }
   });
 };

--- a/apps/cms-server/views/layout.html
+++ b/apps/cms-server/views/layout.html
@@ -13,6 +13,7 @@ page or piece.') }}
 <script src="https://unpkg.com/react@18.2.0/umd/react.production.min.js"></script>
 <script src="https://unpkg.com/react-dom@18.2.0/umd/react-dom.production.min.js"></script>
 <script type="text/javascript">
+  let logoutUrl = '{{ data.global.logoutUrl | safe }}'
   if (typeof process == 'undefined') {
     process = { env: {NODE_ENV: 'production'} };
   }


### PR DESCRIPTION
In the existing situation a cms logout is just that. The user is stll lgged in on the auth server, and also on widgets that exist on the page.

This PR makes the CMS logout a logout on openstad. The CMS then sees that the current toknen is no longer valid, and logs out on the cms as well.

A logout will now be everywhere, including  on widgets on the site.
