### PR TITLE
Fix duplicate sections bug

### DIFF
--- a/apps/cms-server/modules/openstad-section-widget/index.js
+++ b/apps/cms-server/modules/openstad-section-widget/index.js
@@ -170,5 +170,15 @@ module.exports = {
       },
     }
 
+  },
+  methods: function (self) {
+    return {
+      async load(req, widgets) {
+        // Loop through widgets and apply a containerId to each widget
+        widgets.forEach((widget) => {
+          widget.containerId = this.apos.util.generateId();
+        });
+      }
+    }
   }
 };

--- a/apps/cms-server/modules/openstad-section-widget/views/widget.html
+++ b/apps/cms-server/modules/openstad-section-widget/views/widget.html
@@ -169,7 +169,7 @@
         {% area data.widget, 'column2' %}
       </div>
     </div>
-    </div>
-  {% endif %}
-</div>
+    {% endif %}
+  </div>
 {% endif %}
+</div>

--- a/apps/cms-server/modules/openstad-section-widget/views/widget.html
+++ b/apps/cms-server/modules/openstad-section-widget/views/widget.html
@@ -173,4 +173,3 @@
   {% endif %}
 </div>
 {% endif %}
-</div>

--- a/apps/cms-server/modules/openstad-section-widget/views/widget.html
+++ b/apps/cms-server/modules/openstad-section-widget/views/widget.html
@@ -1,8 +1,7 @@
 <style>
   {{data.widget.formattedContainerStyles}}
 </style>
-
-<div id="{% if data.widget.htmlId%}{{data.widget.htmlId}}{% else %}{{data.widget.containerId}}{% endif %}" class="section
+<div id="{{data.widget.containerId}}" class="section
   {% if data.widget.sectionToggle %}
   {% if data.widget.sectionOpen %}open{% else %}closed{% endif %}
   {% endif %}


### PR DESCRIPTION
If there were 2 or more sections placed, a third one would be added automatically. But only visually - It wasn't editable.

After a lot of digging and debugging I found a unneeded closing div tag to be the culprit.

This also fixes a bug where the footer would show duplicated.