### PR TITLE
refactor(deps): Gebruik Mailpit i.p.v. Mailhog

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - openstad-mongo-data:/var/lib/mongo
 
   openstad-mailpit:
-    image: axllent/mailpit:v1.15.0
+    image: axllent/mailpit:v1.15
     ports:
       - 1025:1025 # smtp server
       - 8025:8025 # web ui

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,8 +31,8 @@ services:
     volumes:
       - openstad-mongo-data:/var/lib/mongo
 
-  openstad-mailhog:
-    image: mailhog/mailhog
+  openstad-mailpit:
+    image: axllent/mailpit:v1.15.0
     ports:
       - 1025:1025 # smtp server
       - 8025:8025 # web ui


### PR DESCRIPTION
Motivatie:

Mailhog wordt al een tijdje (2 jaar+) niet meer onderhouden.
Mailpit is een drop-in replacement, license is hetzelfde (MIT).