### PR TITLE
Feature/visibility enquete form

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/display.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/display.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/ui/button';
 import {
-  Form,
+  Form, FormControl,
   FormField,
   FormItem,
   FormLabel,
@@ -14,10 +14,13 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { EnqueteWidgetProps } from '@openstad-headless/enquete/src/enquete';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from "@/components/ui/select";
+import React from "react";
 
 const formSchema = z.object({
   displayTitle: z.boolean(),
-  displayDescription: z.boolean(),
+  displayDescription: z.boolean().optional(),
+  formVisibility: z.string().optional(),
 });
 
 export default function WidgetEnqueteDisplay(
@@ -33,6 +36,7 @@ export default function WidgetEnqueteDisplay(
     resolver: zodResolver<any>(formSchema),
     defaultValues: {
       displayTitle: props?.displayTitle || false,
+      formVisibility: props?.formVisibility || 'always',
     },
   });
 
@@ -66,6 +70,28 @@ export default function WidgetEnqueteDisplay(
               </FormItem>
             )}
           />
+          <FormField
+              control={form.control}
+              name="formVisibility"
+              render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Voor wie is de enquête zichtbaar?</FormLabel>
+                    <Select
+                        value={field.value}
+                        onValueChange={field.onChange}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Kies een optie" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="always">Iedereen</SelectItem>
+                        <SelectItem value="users">Ingelogde gebruikers en admins</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+              )}></FormField>
 
           <Button className="w-fit col-span-full" type="submit">
             Opslaan

--- a/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/items.tsx
@@ -24,7 +24,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { EnqueteWidgetProps } from '@openstad-headless/enquete/src/enquete';
 import { Item, Option } from '@openstad-headless/enquete/src/types/enquete-props';
 import { ArrowDown, ArrowUp, X } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
@@ -34,6 +34,10 @@ const formSchema = z.object({
   key: z.string(),
   description: z.string().optional(),
   questionType: z.string().optional(),
+  fieldKey: z.string(),
+  minCharacters: z.string().optional(),
+  maxCharacters: z.string().optional(),
+  variant: z.string().optional(),
   images: z
     .array(z.object({ image: z.any().optional(), src: z.string() }))
     .optional(),
@@ -83,6 +87,10 @@ export default function WidgetEnqueteItems(
           key: values.key,
           description: values.description,
           questionType: values.questionType,
+          fieldKey: values.fieldKey,
+          minCharacters: values.minCharacters,
+          maxCharacters: values.maxCharacters,
+          variant: values.variant || 'text input',
           options: values.options || [],
         },
       ]);
@@ -132,6 +140,10 @@ export default function WidgetEnqueteItems(
     question: '',
     questionSubtitle: '',
     questionType: '',
+    fieldKey: '',
+    minCharacters: '',
+    maxCharacters: '',
+    variant: 'text input',
     options: [],
   });
 
@@ -156,8 +168,12 @@ export default function WidgetEnqueteItems(
       form.reset({
         trigger: selectedItem.trigger,
         title: selectedItem.title || '',
+        fieldKey: selectedItem.fieldKey || '',
         description: selectedItem.description || '',
         questionType: selectedItem.questionType || '',
+        minCharacters: selectedItem.minCharacters || '',
+        maxCharacters: selectedItem.maxCharacters || '',
+        variant: selectedItem.variant || '',
         options: selectedItem.options || [],
       });
       setOptions(selectedItem.options || []);
@@ -585,6 +601,19 @@ export default function WidgetEnqueteItems(
                     />
                     <FormField
                       control={form.control}
+                      name="fieldKey"
+                      render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Key voor het opslaan, deze moet uniek zijn
+                              bijvoorbeeld: ‘samenvatting’
+                            </FormLabel>
+                            <Input {...field} />
+                            <FormMessage/>
+                          </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
                       name="description"
                       render={({ field }) => (
                         <FormItem>
@@ -629,6 +658,55 @@ export default function WidgetEnqueteItems(
                         </FormItem>
                       )}
                     />
+                    {form.watch('questionType') === 'open' && (
+                        <>
+                          <FormField
+                              control={form.control}
+                              name="variant"
+                              render={({ field }) => (
+                                  <FormItem>
+                                    <FormLabel>Is het veld qua grootte 1 regel of een tekstvak?</FormLabel>
+                                    <Select
+                                        value={field.value || 'text input'}
+                                        onValueChange={field.onChange}>
+                                      <FormControl>
+                                        <SelectTrigger>
+                                          <SelectValue placeholder="Kies een optie" />
+                                        </SelectTrigger>
+                                      </FormControl>
+                                      <SelectContent>
+                                        <SelectItem value="text input">1 regel</SelectItem>
+                                        <SelectItem value="textarea">Tekstvak</SelectItem>
+                                      </SelectContent>
+                                    </Select>
+                                    <FormMessage />
+                                  </FormItem>
+                              )}
+                          />
+                            <FormField
+                                control={form.control}
+                                name="minCharacters"
+                                render={({field}) => (
+                                    <FormItem>
+                                      <FormLabel>Minimaal aantal tekens</FormLabel>
+                                      <Input {...field} />
+                                      <FormMessage/>
+                                    </FormItem>
+                                )}
+                            />
+                            <FormField
+                                control={form.control}
+                                name="maxCharacters"
+                                render={({field}) => (
+                                    <FormItem>
+                                      <FormLabel>Maximaal aantal tekens</FormLabel>
+                                      <Input {...field} />
+                                      <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+                        </>
+                    )}
                     {hasOptions() && (
                       <FormItem>
                         <Button

--- a/packages/enquete/src/enquete.tsx
+++ b/packages/enquete/src/enquete.tsx
@@ -26,7 +26,7 @@ function Enquete(props: EnqueteWidgetProps) {
 
     const datastore = new DataStore(props);
 
-    const { data, create: createSubmission } = datastore.useSubmissions({
+    const { create: createSubmission } = datastore.useSubmissions({
         projectId: props.projectId,
     });
 
@@ -48,6 +48,11 @@ function Enquete(props: EnqueteWidgetProps) {
         }
     }
 
+    const formOnlyVisibleForUsers = (
+        (!!props.formVisibility && props.formVisibility === 'users')
+        || !props.formVisibility
+    );
+
     const formFields : FieldProps[] = [];
     if ( typeof(props) !== 'undefined'
         && typeof(props.items) === 'object'
@@ -57,14 +62,16 @@ function Enquete(props: EnqueteWidgetProps) {
             const fieldData : any = {
                 title: item.title,
                 description: item.description,
-                fieldKey: item.key,
-                disabled: hasRole(currentUser, 'member') ? false : true,
+                fieldKey: item.fieldKey,
+                disabled: !hasRole(currentUser, 'member') && formOnlyVisibleForUsers,
             };
 
             switch (item.questionType) {
                 case 'open':
                     fieldData['type'] = 'text';
-                    fieldData['variant'] = 'textarea';
+                    fieldData['variant'] = item.variant;
+                    fieldData['minCharacters'] = item.minCharacters || '';
+                    fieldData['maxCharacters'] = item.maxCharacters || '';
                     fieldData['rows'] = 5;
                     break;
                 case 'multiplechoice':
@@ -114,7 +121,8 @@ function Enquete(props: EnqueteWidgetProps) {
 
     return (
         <div className="osc">
-            {!hasRole(currentUser, 'member') && (
+            {
+                (formOnlyVisibleForUsers && !hasRole(currentUser, 'member')) && (
                 <>
                     <Banner className="big">
                         <h6>Inloggen om deel te nemen.</h6>
@@ -143,7 +151,7 @@ function Enquete(props: EnqueteWidgetProps) {
                     submitHandler={onSubmit}
                     title=""
                     submitText="Versturen"
-                    submitDisabled={hasRole(currentUser, 'member') ? false : true}
+                    submitDisabled={!hasRole(currentUser, 'member') && formOnlyVisibleForUsers}
                 />
             </div>
 

--- a/packages/enquete/src/types/enquete-props.ts
+++ b/packages/enquete/src/types/enquete-props.ts
@@ -6,6 +6,7 @@ export type EnqueteProps = {
   displayDescription?: boolean;
   description?: string;
   items?: Array<Item>;
+  formVisibility?: string;
 };
 
 export type Item = {
@@ -14,6 +15,10 @@ export type Item = {
   key: string;
   description?: string;
   questionType?: string;
+  fieldKey?: string;
+  minCharacters?: string;
+  maxCharacters?: string;
+  variant?: string;
   images?: Array<{
     image?: any;
     src: string;


### PR DESCRIPTION
Deze PR zorgt ervoor dat je bij de enquete widget kan kiezen of je ingelogd moet zijn of niet om de enquete in te vullen. Verder heb ik gelijk wat velden toegevoegd aan de opties, waaronder het belangrijkste veld: key voor in de database