### PR TITLE
add superuser to resource-possible-roles

### DIFF
--- a/apps/api-server/src/models/Resource.js
+++ b/apps/api-server/src/models/Resource.js
@@ -124,6 +124,7 @@ module.exports = function (db, sequelize, DataTypes) {
 
       viewableByRole: {
         type: DataTypes.ENUM(
+          'superuser',
           'admin',
           'editor',
           'moderator',


### PR DESCRIPTION
Fix: missende rol geeft een SQL error wanneer je een resource edit als superuser.