### PR TITLE
Update env variables for k8s

### DIFF
--- a/charts/openstad-headless/templates/admin/deployment.yaml
+++ b/charts/openstad-headless/templates/admin/deployment.yaml
@@ -28,12 +28,16 @@ spec:
         env:
           - name: PORT
             value: "{{ .Values.admin.service.httpPort }}"
-          - name: NEXTAUTH_URL
+          - name: NEXT_PUBLIC_URL
             value: https://{{ template "openstad.admin.url" . }}
-          - name: NEXTAUTH_SECRET
+          - name: NEXT_PUBLIC_API_URL
+            value: https://{{ template "openstad.api.url" . }}
+          - name: URL
+            value: https://{{ template "openstad.admin.url" . }}
+          - name: COOKIE_SECRET
             valueFrom:
               secretKeyRef:
-                key: nextAuthSecret
+                key: cookieSecret
                 name: {{ template "openstad.admin.secret.fullname" . }}
           - name: CLIENT_ID
             valueFrom:

--- a/charts/openstad-headless/templates/api/deployment.yaml
+++ b/charts/openstad-headless/templates/api/deployment.yaml
@@ -136,6 +136,9 @@ spec:
           - name: BASE_DOMAIN
             value: {{ .Values.host.base }}
 
+          - name: ADMIN_DOMAIN
+            value: {{ template "openstad.admin.url" . }}
+
           - name: AUTH_ADMIN_CLIENT_ID
             valueFrom:
               secretKeyRef:

--- a/charts/openstad-headless/templates/secrets/admin-secret.yaml
+++ b/charts/openstad-headless/templates/secrets/admin-secret.yaml
@@ -10,5 +10,5 @@ metadata:
     "helm.sh/hook-delete-policy": "before-hook-creation"
 type: Opaque
 data:
-  nextAuthSecret: {{ .Values.admin.secrets.nextAuthSecret | default (randAlphaNum 32) | b64enc }}
-  apiKey: {{ .Values.admin.secrets.apiKey | b64enc }}
+  cookieSecret: {{ .Values.admin.secrets.cookieSecret | default (randAlphaNum 32) | b64enc }}
+  apiKey: {{ .Values.admin.secrets.apiKey | default (randAlphaNum 32) | b64enc }}

--- a/charts/openstad-headless/templates/secrets/cms-secret.yaml
+++ b/charts/openstad-headless/templates/secrets/cms-secret.yaml
@@ -8,4 +8,4 @@ metadata:
     "helm.sh/resource-policy": keep
 data:
   apiKey: {{ .Values.secrets.cms.apiKey | default (randAlphaNum 32) | b64enc }}
-  mongodbUri: {{ .Values.secrets.cms.mongodbUri | b64enc }}
+  mongodbUri: {{ .Values.secrets.cms.mongodbUri | default (printf "%s-mongodb.%s.svc.cluster.local" .Release.Name .Release.Namespace) | b64enc }}

--- a/charts/openstad-headless/values.yaml
+++ b/charts/openstad-headless/values.yaml
@@ -129,7 +129,7 @@ admin:
 
   # Secret values
   secrets:
-    nextAuthSecret:
+    cookieSecret:
     apiKey:
 
   # Service settings:
@@ -317,6 +317,9 @@ image:
   name: 'image'
   label: openstad-image-service
 
+  secrets:
+    verificationToken:
+
   # Service settings:
   # Primarily port configuration
   service:
@@ -465,7 +468,7 @@ secrets:
   admin:
     clientId:
     clientSecret:
-    nextauthSecret:
+    cookieSecret:
     imageApiToken:
 
   api:

--- a/operations/deployments/openstad-headless/environments/acc/secrets/secrets.enc.yml
+++ b/operations/deployments/openstad-headless/environments/acc/secrets/secrets.enc.yml
@@ -33,7 +33,7 @@ secrets:
         mongodbUri: ENC[AES256_GCM,data:0mN3sAsdIm4SqDJ7WSp3aTnr8CtfCaFIphkbQ5HfpIpzquQusBJXqgAp/fv1FwUH3An3mko=,iv:F0x+GWzpp2kKVgCRDavueu6tuuPQ0X7B6ceUtwtppP4=,tag:uxuAm+F0uiSke98qk1G6Jg==,type:str]
 admin:
     secrets:
-        nextAuthSecret: ENC[AES256_GCM,data:cKZF8co3XYwadLpLdFKwPezTFct6yxgZj2fuTZrc2Wg=,iv:ZXG9mBkGIHiOdY7rU5uP4nCvnNVAkGlkEWr//4hv29A=,tag:oShWnDqWUAIoIpIlTB+k3g==,type:str]
+        cookieSecret: ENC[AES256_GCM,data:cKZF8co3XYwadLpLdFKwPezTFct6yxgZj2fuTZrc2Wg=,iv:ZXG9mBkGIHiOdY7rU5uP4nCvnNVAkGlkEWr//4hv29A=,tag:oShWnDqWUAIoIpIlTB+k3g==,type:str]
         apiKey: ENC[AES256_GCM,data:BSJYIzlE/Q2MCpIKMXP3R6wK0iF5o5lnm8urRJisNQg=,iv:AssdVxfbg38AwX3+nFi0GNqrOL3qIN77DZhzEfedy4g=,tag:NieGlbCTAX2r+r8mQsaVxw==,type:str]
 image:
     secrets:


### PR DESCRIPTION
Dit voegt de vereiste ENV variabelen toe aan de admin / api.

Voor de admin zijn dit:

```
NEXT_PUBLIC_URL
NEXT_PUBLIC_API_URL
URL
COOKIE_SECRET
```

Voor de API is dit `ADMIN_DOMAIN`

---


Om `COOKIE_SECRET` te vullen heb ik de — nu vervallen — `nextAuthSecret` hernoemd naar `cookieSecret`, ook in de values.yaml en in het bestaande ACC secret.



Ik heb ook `helm lint` gedraaid en kreeg foutmeldingen op 2 values die leeg bleken in de standaard values.yaml; `apiKey` en `mongodbUri`. Die heb ik nu beide een standaardwaarde gegeven.

