### PR TITLE
fix: Use http for the project URL when force http is set to yes

### DIFF
--- a/apps/cms-server/app.js
+++ b/apps/cms-server/app.js
@@ -27,7 +27,8 @@ async function loadProjects () {
       // We are no longer saving the protocol in the database, but we need a
       // protocol to be able to use `Url.parse` to get the host.
       if (!project.url.startsWith('http://') && !project.url.startsWith('https://')) {
-        project.url = 'https://' + project.url;
+        const protocol = process.env.FORCE_HTTP === 'yes' ? 'http://' : 'https://';
+        project.url = protocol + project.url;
       }
       let url = Url.parse(project.url);
       console.log('Project fetched: ' + url.host);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,6 +236,7 @@ services:
       - API_URL=${API_URL}
       - API_URL_INTERNAL=http://openstad-api-server:${API_PORT}
       - API_KEY=${API_FIXED_AUTH_KEY}
+      - FORCE_HTTP=${FORCE_HTTP}
     ports:
       - '${CMS_PORT}:${CMS_PORT}'
     volumes:


### PR DESCRIPTION
Hiermee kun je lokaal weer de pagina bewerken in het CMS