### PR TITLE
Fix enquete datastore

### DIFF
--- a/packages/data-store/src/api/index.js
+++ b/packages/data-store/src/api/index.js
@@ -55,7 +55,6 @@ function API(props = {}) {
   };
 
   self.submissions = {
-    fetch: submissions.fetch.bind(self),
     create: submissions.create.bind(self)
   }
 

--- a/packages/data-store/src/api/index.js
+++ b/packages/data-store/src/api/index.js
@@ -55,6 +55,7 @@ function API(props = {}) {
   };
 
   self.submissions = {
+    fetch: submissions.fetch.bind(self),
     create: submissions.create.bind(self)
   }
 

--- a/packages/data-store/src/api/submissions.js
+++ b/packages/data-store/src/api/submissions.js
@@ -1,7 +1,6 @@
 export default {
   fetch: async function ({ projectId }) {
-    let url = `/api/project/${projectId}/submission`;
-    return this.fetch(url);
+    return [];
   },
 
   create: async function ({ projectId }, data) {

--- a/packages/enquete/src/enquete.tsx
+++ b/packages/enquete/src/enquete.tsx
@@ -21,7 +21,7 @@ export type EnqueteWidgetProps = BaseProps &
 
 function Enquete(props: EnqueteWidgetProps) {
     const notifyCreate = () =>
-        toast.success('Enquete ingedient', { position: 'bottom-center' });
+        toast.success('Enquete ingediend', { position: 'bottom-center' });
 
     const datastore = new DataStore(props);
 


### PR DESCRIPTION
Dit haalt de `fetch` method van de submissions datastore af. We gebruiken die alleen om enquetes in te schieten, en ophalen hoeft aan de voorkant nooit.

Het probleem met de `fetch` method is dat we nu een hoop GET requests uitvoeren die eigenlijk altijd tot een 500 leiden.