### PR TITLE
fix the fixed superuser

### DIFF
--- a/apps/api-server/src/middleware/user.js
+++ b/apps/api-server/src/middleware/user.js
@@ -119,7 +119,7 @@ async function getUserInstance({ authConfig, authProvider, userId, isFixed, proj
     dbUser = await db.User.findOne({ where });
 
     if (isFixed) {
-      if (!dbUser.projectId) dbUser.role = 'superuser';
+      if (!dbUser.projectId || dbUser.projectId == config.admin.projectId) dbUser.role = 'superuser'; // !dbUser.projectId is backwards compatibility
       return dbUser;
     }
 


### PR DESCRIPTION
Na denieuwe opzet van admin login, met superusers, is de oude constructie (zeg maar hack) met een user zonder projectId niet langer nodig. Ik had dat aangepast in de seeds gisteren.

Maar vandaag merk ik dat dat niet helemaal goed gaat: bij fixed users deed hij nog niet de juiste check.

Vandaar deze fix.