### PR TITLE
fix(admin): url regex was too strict

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/settings/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/settings/index.tsx
@@ -35,10 +35,8 @@ const formSchema = z.object({
   }),
   cssUrl: z.string().optional(),
   areaId: z.string().optional(),
-  // This URL regex is not perfect, but we don't want to restrict too much.
-  // The main thing is that we want some text and a dot in the URL, and that we
-  // don't want the protocol.
-  url: z.string().regex(/^(?:([a-z0-9]+\.[a-z0-9.]+))?$/g, {
+  // We don't want to restrict this URL too much
+  url: z.string().regex(/^(?:([a-z0-9.:]+))?$/g, {
     message: 'De URL mag alleen kleine letters, cijfers en punten bevatten. Tip: gebruik geen https:// voor de URL'
   }).optional(),
 });


### PR DESCRIPTION
De URL regex was nog veel te strict, `localhost:31490` zou gewoon een geldige waarde moeten zijn.