### PR TITLE
fix(resource-detail): set default resource id as int

### DIFF
--- a/packages/resource-detail/src/resource-detail.tsx
+++ b/packages/resource-detail/src/resource-detail.tsx
@@ -82,7 +82,7 @@ function ResourceDetail({
   ...props
 }: ResourceDetailWidgetProps) {
   const urlParams = new URLSearchParams(window.location.search);
-  let resourceId = props.resourceId || '0';
+  let resourceId = props.resourceId || 0;
 
   if (!resourceId && props.resourceIdRelativePath) {
     const currentUrl = location.pathname;


### PR DESCRIPTION
Because the default was a string `'0'`, the if's on this variable (`if (!resourceId)`) would not work as intended. `!'0'` returns `false`, whereas `!0` returns true (as expected & intended)