### PR TITLE
Fix components widget in apostrophe

### DIFF
--- a/apps/api-server/src/routes/widget/widget.js
+++ b/apps/api-server/src/routes/widget/widget.js
@@ -287,9 +287,12 @@ function getWidgetJavascriptOutput(
     (function () {
       try {
         let process = { env: { NODE_ENV: 'production' } };
-
+        
+        const randomComponentId = '${componentId}-' + Math.floor(Math.random() * 1000000);
+        const renderedWidgets = {};
+        
         const currentScript = document.currentScript;
-          currentScript.insertAdjacentHTML('afterend', \`<div id="${componentId}" style="width: 100%; height: 100%;"></div>\`);
+          currentScript.insertAdjacentHTML('afterend', \`<div id="\${randomComponentId}" style="width: 100%; height: 100%;"></div>\`);
 
           const redirectUri = encodeURI(window.location.href);
           const config = JSON.parse(\`${widgetConfig}\`.replaceAll("[[REDIRECT_URI]]", redirectUri));
@@ -301,8 +304,16 @@ function getWidgetJavascriptOutput(
           \`;
           
           function renderWidget () {
+            
+            // Check if widget has already been rendered
+            if (renderedWidgets[randomComponentId]) {
+              return;
+            }
+            
+            renderedWidgets[randomComponentId] = true;
+            
             ${widgetOutput}
-            ${widgetSettings.functionName}.${widgetSettings.componentName}.loadWidget('${componentId}', config);
+            ${widgetSettings.functionName}.${widgetSettings.componentName}.loadWidget(randomComponentId, config);
           }
           
           ${reactCheck}

--- a/apps/cms-server/modules/openstad-component-widget/views/widget.html
+++ b/apps/cms-server/modules/openstad-component-widget/views/widget.html
@@ -1,1 +1,1 @@
-<div class="openstad-component-widget" data-openstad-component-url="{{data.widget.componentUrl}}" />
+<div class="openstad-component-widget" data-openstad-component-url="{{data.widget.componentUrl}}"></div>


### PR DESCRIPTION
Dit lost een bug op waarbij een Openstad Component die direct boven / onder een Apostrophe widget geplaatst werd de structuur visueel kapot maakt. Apostrophe is erg streng op het correct sluiten van divs (en terecht), en een div mag niet op deze `<div ... />` manier gesloten worden.

Ook is het nu mogelijk om dezelfde widget vaker in te laden op een pagina, doordat elk component nu client-side een uniek ID krijgt.