### PR TITLE
Fix/tags filtering

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/tags/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/tags/index.tsx
@@ -21,7 +21,13 @@ export default function ProjectTags() {
   const [filterData, setFilterData] = useState(data);
 
   useEffect(() => {
-    const filterStartData = data?.sort((a, b) => {
+    let loadedTags = (data || []) as {
+      id: number;
+      name: string;
+      type?: string;
+    }[];
+
+    const filterStartData = loadedTags?.sort((a, b) => {
       const aType = a.type ?? '';
       const bType = b.type ?? '';
 
@@ -36,12 +42,6 @@ export default function ProjectTags() {
 
     setFilterData(filterStartData);
   }, [data])
-
-  let loadedTags = (data || []) as {
-    id: number;
-    name: string;
-    type?: string;
-  }[];
 
   return (
     <div>

--- a/apps/admin-server/src/pages/projects/[project]/tags/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/tags/index.tsx
@@ -21,7 +21,20 @@ export default function ProjectTags() {
   const [filterData, setFilterData] = useState(data);
 
   useEffect(() => {
-    setFilterData(data);
+    const filterStartData = data?.sort((a, b) => {
+      const aType = a.type ?? '';
+      const bType = b.type ?? '';
+
+      if (aType < bType) return -1;
+      if (aType > bType) return 1;
+
+      if (a.name < b.name) return -1;
+      if (a.name > b.name) return 1;
+
+      return 0;
+    });
+
+    setFilterData(filterStartData);
   }, [data])
 
   let loadedTags = (data || []) as {
@@ -73,20 +86,7 @@ export default function ProjectTags() {
               </ListHeading>
             </div>
             <ul>
-              {loadedTags
-                  .sort((a, b) => {
-                    const aType = a.type ?? '';
-                    const bType = b.type ?? '';
-
-                    if (aType < bType) return -1;
-                    if (aType > bType) return 1;
-
-                    if (a.name < b.name) return -1;
-                    if (a.name > b.name) return 1;
-
-                    return 0;
-                  })
-                  .map((tag: any) => (
+              {filterData?.map((tag: any) => (
                 <Link
                   href={`/projects/${project}/tags/${tag.id}`}
                   key={tag.id}>


### PR DESCRIPTION
Het filteren voor de tags werkte niet meer doordat ik de tags standaard heb gefilterd. Dit heb ik in een conflict niet op de juiste manier opgelost. Hiermee werkt het filteren en standaard filter weer.