### PR TITLE
Feature/cms admin login

### DIFF
--- a/apps/admin-server/src/pages/users/[user]/general.tsx
+++ b/apps/admin-server/src/pages/users/[user]/general.tsx
@@ -28,6 +28,7 @@ const formSchema = z.object({
   address: z.string().optional(),
   city: z.string().optional(),
   postcode: z.string().optional(),
+  password: z.string().optional(),
 });
 
 export default function CreateUserGeneral() {
@@ -50,6 +51,7 @@ export default function CreateUserGeneral() {
       address: user?.address || '',
       city: user?.city || '',
       postcode: user?.postcode || '',
+      password: user?.password || '',
     }),
     [user]
   );
@@ -162,6 +164,20 @@ export default function CreateUserGeneral() {
                 <FormLabel>Postcode</FormLabel>
                 <FormControl>
                   <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Password</FormLabel>
+                <FormControl>
+                  <Input type="password" {...field} />
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/apps/admin-server/src/pages/users/create.tsx
+++ b/apps/admin-server/src/pages/users/create.tsx
@@ -40,7 +40,7 @@ export default function CreateUser() {
     try {
       let user = await createUser({
         email: values.email,
-        parojectId: values.projectId,
+        projectId: values.projectId,
       });
       toast.success('User is toegevoegd')
       user.key = `${user.idpUser.provider}-*-${user.idpUser.identifier}`

--- a/apps/api-server/src/adapter/openstad/router.js
+++ b/apps/api-server/src/adapter/openstad/router.js
@@ -97,7 +97,9 @@ router
 
     // redirect to idp server
     let redirectUri = encodeURIComponent(config.url + '/auth/project/' + req.project.id + '/digest-login?useAuth=' + req.authConfig.provider + '\&returnTo=' + req.query.redirectUri);
-    let url = `${req.authConfig.serverUrl}/dialog/authorize?redirect_uri=${redirectUri}&response_type=code&client_id=${req.authConfig.clientId}&scope=offline&forceLogin=1`;
+    let url = `${req.authConfig.serverUrl}/login`;
+    if (req.query.loginPriviliged) url += '/admin';
+    url += `?redirect_uri=${redirectUri}&response_type=code&client_id=${req.authConfig.clientId}&scope=offline&forceLogin=1`;
     res.redirect(url);
 
   })

--- a/apps/api-server/src/routes/api/user.js
+++ b/apps/api-server/src/routes/api/user.js
@@ -14,7 +14,7 @@ const hasRole = require('../../lib/sequelize-authorization/lib/hasRole');
 
 const filterBody = (req, res, next) => {
   const data = {};
-  const keys = ['name', 'nickName', 'email', 'phoneNumber', 'address', 'city', 'postcode', 'extraData', 'listableByRole', 'detailsViewableByRole'];
+  const keys = ['password', 'name', 'nickName', 'email', 'phoneNumber', 'address', 'city', 'postcode', 'extraData', 'listableByRole', 'detailsViewableByRole'];
 
   keys.forEach((key) => {
     if (typeof req.body[key] != 'undefined') {

--- a/apps/auth-server/model/user.js
+++ b/apps/auth-server/model/user.js
@@ -112,7 +112,7 @@ module.exports = (db, sequelize, Sequelize) => {
         where: { userId: self.id }
       })
       .then(userRoles => {
-        let userRole = userRoles.find( userRole => userRole.client.clientId == clientId );
+        let userRole = userRoles.find( userRole => userRole.client.clientId == clientId || userRole.client.id == clientId );
         let role = userRole?.role;
         return role?.name
       })

--- a/apps/cms-server/app.js
+++ b/apps/cms-server/app.js
@@ -177,13 +177,15 @@ app.use('/config-reset', async function (req, res, next) {
   next();
 });
 
-app.use('/login', function (req, res, next) {
+app.use(':priviliged(/admin)?/login', function (req, res, next) {
   const domainAndPath = req.openstadDomain;
   const i = req.url.indexOf('?');
-  const query = req.url.substr(i + 1);
+  let query = req.url.substr(i + 1);
   const protocol = req.headers['x-forwarded-proto'] || req.protocol;
   const url = protocol + '://' + domainAndPath + '/auth/login';
-
+  if (req.params.priviliged) {
+    query += `${query ? '&' : ''}loginPriviliged=1`;
+  }
   return res.redirect(url && query ? url + '?' + query : url);
 });
 


### PR DESCRIPTION
Op het oude openstad kon je inloggen op /admin/login, en daarmee kon je met email of password inloggen op een site die uniekecode login had.

Dat werkt nu ook weer in headless. 

Password kon nog niet gezet, en dat wil je denk ik wel, dus dat is toegevoegd.

En create user had nog een bug; dat is nu gefixed.