### PR TITLE
fix: generate QR codes locally

### DIFF
--- a/apps/auth-server/controllers/auth/twoFactor.js
+++ b/apps/auth-server/controllers/auth/twoFactor.js
@@ -1,4 +1,5 @@
 const twofactor = require("node-2fa");
+const QRCode = require('qrcode')
 
 const twoFactorBaseUrl = '/auth/two-factor';
 
@@ -86,10 +87,9 @@ exports.configure = async (req, res, next) => {
 
         let twoFactorSecret = req.user.twoFactorToken;
 
-        // @todo, would be good to take this from ENV or settings somewhere. Currently however no name per installation
-        const issuer = "Openstad";
+        const issuer = process.env.ENVIRONMENT_NAME ? process.env.ENVIRONMENT_NAME : "Openstad";
         // take email, since this is always present, make sure @ char doesn't cause issues in some cases
-        const accountName = req.user.email;
+        const accountName = req.user.email ? req.user.email : req.user.name;
 
         if (!twoFactorSecret) {
             /**
@@ -108,8 +108,10 @@ exports.configure = async (req, res, next) => {
 
         }
 
-        const qrCode = `https://chart.googleapis.com/chart?chs=166x166&chld=L|0&cht=qr&chl=otpauth://totp/=${encodeURIComponent(issuer)}:${encodeURIComponent(accountName)}%3Fsecret=${twoFactorSecret}%26issuer=${encodeURIComponent(issuer)}`;
+        const otpAuthUrl = `otpauth://totp/${encodeURIComponent(issuer)}:%20${encodeURIComponent(accountName)}?secret=${twoFactorSecret}&issuer=${encodeURIComponent(issuer)}`;
 
+        const qrCode = await QRCode.toDataURL(otpAuthUrl);
+        
         res.render('auth/two-factor/configure', {
             postUrl: twoFactorBaseUrl + '/configure',
             twoFactorQrSrc: qrCode,
@@ -139,4 +141,3 @@ exports.configurePost = async (req, res, next) => {
             .catch((err) => { next(err) });
     }
 }
-

--- a/apps/auth-server/package.json
+++ b/apps/auth-server/package.json
@@ -45,6 +45,7 @@
     "passport-local": "^1.0.x",
     "passport-oauth2-client-password": "^0.1.x",
     "passport-url": "^1.0.4",
+    "qrcode": "^1.5.3",
     "sanitize-html": "^2.7.0",
     "sequelize": "^6.28.0",
     "session-file-store": "^1.2.0",

--- a/charts/openstad-headless/templates/auth/deployment.yaml
+++ b/charts/openstad-headless/templates/auth/deployment.yaml
@@ -64,7 +64,7 @@ spec:
               secretKeyRef:
                 name: openstad-db-credentials
                 key: hostport
-          
+
           - name: DB_NAME
             valueFrom:
               secretKeyRef:
@@ -143,7 +143,7 @@ spec:
               secretKeyRef:
                 key: secret
                 name: openstad-session-secret
-          
+
           - name: COOKIE_SECURE_OFF
             value: "{{ .Values.auth.cookie.secureOff | default "no" }}"
 
@@ -155,6 +155,9 @@ spec:
 
           - name: ALLOWED_ADMIN_DOMAINS
             value: '["{{ template  "openstad.admin.url" . }}"]'
+
+          - name: ENVIRONMENT_NAME
+            value: {{ .Values.public.environmentName | default "Openstad" | quote }}
 
           - name: NODE_ENV
             value: production

--- a/charts/openstad-headless/values.yaml
+++ b/charts/openstad-headless/values.yaml
@@ -69,6 +69,7 @@ mysql:
 # Internal config
 public:
   name: openstad
+  environmentName:
 
 # Settings
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,6 +142,7 @@ services:
       - API_URL=${API_URL}
       - ADMIN_URL=${ADMIN_URL}
       - ALLOWED_ADMIN_DOMAINS=["${ADMIN_DOMAIN}"]
+      - ENVIRONMENT_NAME=${ENVIRONMENT_NAME}
       - NODE_ENV=development
     ports:
       - '${AUTH_PORT}:${AUTH_PORT}'

--- a/package-lock.json
+++ b/package-lock.json
@@ -275,6 +275,7 @@
         "passport-local": "^1.0.x",
         "passport-oauth2-client-password": "^0.1.x",
         "passport-url": "^1.0.4",
+        "qrcode": "^1.5.3",
         "sanitize-html": "^2.7.0",
         "sequelize": "^6.28.0",
         "session-file-store": "^1.2.0",
@@ -597,9 +598,9 @@
       }
     },
     "apps/image-server/node_modules/mysql2": {
-      "version": "3.9.6",
-      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.9.6.tgz",
-      "integrity": "sha512-9NYUMLQv6yXnu+5hUh8PZ5CdKoG6VWDzXbojIdTyob8upNZXU3rBNQK9viaEqfgw+LMifhd+53VEZPxZk3bTWA==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.9.7.tgz",
+      "integrity": "sha512-KnJT8vYRcNAZv73uf9zpXqNbvBG7DJrs+1nACsjZP1HMJ1TgXEy8wnNilXAn/5i57JizXKtrUtwDB7HxT9DDpw==",
       "dependencies": {
         "denque": "^2.1.0",
         "generate-function": "^2.3.1",
@@ -644,6 +645,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@apostrophecms/emulate-mongo-3-driver": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@apostrophecms/emulate-mongo-3-driver/-/emulate-mongo-3-driver-1.0.2.tgz",
+      "integrity": "sha512-BUPy4NcpECfCOz+LmZQDiq50JzUYphJGCxpuGQdX78Z8C3NUzocP/RNsFgEgreSMjS1ghhRvXUjTmaY7bF1HzQ==",
+      "dependencies": {
+        "mongodb": "^6.5.0",
+        "mongodb-legacy": "^6.0.1"
       }
     },
     "node_modules/@apostrophecms/vue-color": {
@@ -3853,6 +3863,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.5.tgz",
+      "integrity": "sha512-XLNOMH66KhJzUJNwT/qlMnS4WsNDWD5ASdyaSH3EtK+F4r/CFGa3jT4GNi4mfOitGvWXtdLgQJkQjxSVrio+jA==",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "node_modules/@next/env": {
       "version": "13.5.6",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.6.tgz",
@@ -5877,9 +5895,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.3.tgz",
-      "integrity": "sha512-X9alQ3XM6I9IlSlmC8ddAvMSyG1WuHk5oUnXGw+yUBs3BFoTizmG1La/Gr8fVJvDWAq+zlYTZ9DBgrlKRVY06g==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.16.4.tgz",
+      "integrity": "sha512-GkhjAaQ8oUTOKE4g4gsZ0u8K/IHU1+2WQSgS1TwTcYvL+sjbaQjNHFXbOJ6kgqGHIO1DfUhI/Sphi9GkRT9K+Q==",
       "cpu": [
         "arm"
       ],
@@ -5890,9 +5908,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.3.tgz",
-      "integrity": "sha512-eQK5JIi+POhFpzk+LnjKIy4Ks+pwJ+NXmPxOCSvOKSNRPONzKuUvWE+P9JxGZVxrtzm6BAYMaL50FFuPe0oWMQ==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.16.4.tgz",
+      "integrity": "sha512-Bvm6D+NPbGMQOcxvS1zUl8H7DWlywSXsphAeOnVeiZLQ+0J6Is8T7SrjGTH29KtYkiY9vld8ZnpV3G2EPbom+w==",
       "cpu": [
         "arm64"
       ],
@@ -5903,9 +5921,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.3.tgz",
-      "integrity": "sha512-Od4vE6f6CTT53yM1jgcLqNfItTsLt5zE46fdPaEmeFHvPs5SjZYlLpHrSiHEKR1+HdRfxuzXHjDOIxQyC3ptBA==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.16.4.tgz",
+      "integrity": "sha512-i5d64MlnYBO9EkCOGe5vPR/EeDwjnKOGGdd7zKFhU5y8haKhQZTN2DgVtpODDMxUr4t2K90wTUJg7ilgND6bXw==",
       "cpu": [
         "arm64"
       ],
@@ -5916,9 +5934,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.3.tgz",
-      "integrity": "sha512-0IMAO21axJeNIrvS9lSe/PGthc8ZUS+zC53O0VhF5gMxfmcKAP4ESkKOCwEi6u2asUrt4mQv2rjY8QseIEb1aw==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.16.4.tgz",
+      "integrity": "sha512-WZupV1+CdUYehaZqjaFTClJI72fjJEgTXdf4NbW69I9XyvdmztUExBtcI2yIIU6hJtYvtwS6pkTkHJz+k08mAQ==",
       "cpu": [
         "x64"
       ],
@@ -5929,9 +5947,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.3.tgz",
-      "integrity": "sha512-ge2DC7tHRHa3caVEoSbPRJpq7azhG+xYsd6u2MEnJ6XzPSzQsTKyXvh6iWjXRf7Rt9ykIUWHtl0Uz3T6yXPpKw==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.16.4.tgz",
+      "integrity": "sha512-ADm/xt86JUnmAfA9mBqFcRp//RVRt1ohGOYF6yL+IFCYqOBNwy5lbEK05xTsEoJq+/tJzg8ICUtS82WinJRuIw==",
       "cpu": [
         "arm"
       ],
@@ -5942,9 +5960,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.14.3.tgz",
-      "integrity": "sha512-ljcuiDI4V3ySuc7eSk4lQ9wU8J8r8KrOUvB2U+TtK0TiW6OFDmJ+DdIjjwZHIw9CNxzbmXY39wwpzYuFDwNXuw==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.16.4.tgz",
+      "integrity": "sha512-tJfJaXPiFAG+Jn3cutp7mCs1ePltuAgRqdDZrzb1aeE3TktWWJ+g7xK9SNlaSUFw6IU4QgOxAY4rA+wZUT5Wfg==",
       "cpu": [
         "arm"
       ],
@@ -5955,9 +5973,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.3.tgz",
-      "integrity": "sha512-Eci2us9VTHm1eSyn5/eEpaC7eP/mp5n46gTRB3Aar3BgSvDQGJZuicyq6TsH4HngNBgVqC5sDYxOzTExSU+NjA==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.16.4.tgz",
+      "integrity": "sha512-7dy1BzQkgYlUTapDTvK997cgi0Orh5Iu7JlZVBy1MBURk7/HSbHkzRnXZa19ozy+wwD8/SlpJnOOckuNZtJR9w==",
       "cpu": [
         "arm64"
       ],
@@ -5968,9 +5986,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.3.tgz",
-      "integrity": "sha512-UrBoMLCq4E92/LCqlh+blpqMz5h1tJttPIniwUgOFJyjWI1qrtrDhhpHPuFxULlUmjFHfloWdixtDhSxJt5iKw==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.16.4.tgz",
+      "integrity": "sha512-zsFwdUw5XLD1gQe0aoU2HVceI6NEW7q7m05wA46eUAyrkeNYExObfRFQcvA6zw8lfRc5BHtan3tBpo+kqEOxmg==",
       "cpu": [
         "arm64"
       ],
@@ -5981,9 +5999,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.3.tgz",
-      "integrity": "sha512-5aRjvsS8q1nWN8AoRfrq5+9IflC3P1leMoy4r2WjXyFqf3qcqsxRCfxtZIV58tCxd+Yv7WELPcO9mY9aeQyAmw==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.16.4.tgz",
+      "integrity": "sha512-p8C3NnxXooRdNrdv6dBmRTddEapfESEUflpICDNKXpHvTjRRq1J82CbU5G3XfebIZyI3B0s074JHMWD36qOW6w==",
       "cpu": [
         "ppc64"
       ],
@@ -5994,9 +6012,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.3.tgz",
-      "integrity": "sha512-sk/Qh1j2/RJSX7FhEpJn8n0ndxy/uf0kI/9Zc4b1ELhqULVdTfN6HL31CDaTChiBAOgLcsJ1sgVZjWv8XNEsAQ==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.16.4.tgz",
+      "integrity": "sha512-Lh/8ckoar4s4Id2foY7jNgitTOUQczwMWNYi+Mjt0eQ9LKhr6sK477REqQkmy8YHY3Ca3A2JJVdXnfb3Rrwkng==",
       "cpu": [
         "riscv64"
       ],
@@ -6007,9 +6025,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.3.tgz",
-      "integrity": "sha512-jOO/PEaDitOmY9TgkxF/TQIjXySQe5KVYB57H/8LRP/ux0ZoO8cSHCX17asMSv3ruwslXW/TLBcxyaUzGRHcqg==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.16.4.tgz",
+      "integrity": "sha512-1xwwn9ZCQYuqGmulGsTZoKrrn0z2fAur2ujE60QgyDpHmBbXbxLaQiEvzJWDrscRq43c8DnuHx3QorhMTZgisQ==",
       "cpu": [
         "s390x"
       ],
@@ -6020,9 +6038,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.3.tgz",
-      "integrity": "sha512-8ybV4Xjy59xLMyWo3GCfEGqtKV5M5gCSrZlxkPGvEPCGDLNla7v48S662HSGwRd6/2cSneMQWiv+QzcttLrrOA==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.16.4.tgz",
+      "integrity": "sha512-LuOGGKAJ7dfRtxVnO1i3qWc6N9sh0Em/8aZ3CezixSTM+E9Oq3OvTsvC4sm6wWjzpsIlOCnZjdluINKESflJLA==",
       "cpu": [
         "x64"
       ],
@@ -6033,9 +6051,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.3.tgz",
-      "integrity": "sha512-s+xf1I46trOY10OqAtZ5Rm6lzHre/UiLA1J2uOhCFXWkbZrJRkYBPO6FhvGfHmdtQ3Bx793MNa7LvoWFAm93bg==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.16.4.tgz",
+      "integrity": "sha512-ch86i7KkJKkLybDP2AtySFTRi5fM3KXp0PnHocHuJMdZwu7BuyIKi35BE9guMlmTpwwBTB3ljHj9IQXnTCD0vA==",
       "cpu": [
         "x64"
       ],
@@ -6046,9 +6064,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.3.tgz",
-      "integrity": "sha512-+4h2WrGOYsOumDQ5S2sYNyhVfrue+9tc9XcLWLh+Kw3UOxAvrfOrSMFon60KspcDdytkNDh7K2Vs6eMaYImAZg==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.16.4.tgz",
+      "integrity": "sha512-Ma4PwyLfOWZWayfEsNQzTDBVW8PZ6TUUN1uFTBQbF2Chv/+sjenE86lpiEwj2FiviSmSZ4Ap4MaAfl1ciF4aSA==",
       "cpu": [
         "arm64"
       ],
@@ -6059,9 +6077,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.3.tgz",
-      "integrity": "sha512-T1l7y/bCeL/kUwh9OD4PQT4aM7Bq43vX05htPJJ46RTI4r5KNt6qJRzAfNfM+OYMNEVBWQzR2Gyk+FXLZfogGw==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.16.4.tgz",
+      "integrity": "sha512-9m/ZDrQsdo/c06uOlP3W9G2ENRVzgzbSXmXHT4hwVaDQhYcRpi9bgBT0FTG9OhESxwK0WjQxYOSfv40cU+T69w==",
       "cpu": [
         "ia32"
       ],
@@ -6072,9 +6090,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.3.tgz",
-      "integrity": "sha512-/BypzV0H1y1HzgYpxqRaXGBRqfodgoBBCcsrujT6QRcakDQdfU+Lq9PENPh5jB4I44YWq+0C2eHsHya+nZY1sA==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.16.4.tgz",
+      "integrity": "sha512-YunpoOAyGLDseanENHmbFvQSfVL5BxW3k7hhy0eN4rb3gS/ct75dVD0EXOWIqFT/nE8XYW6LP6vz6ctKRi0k9A==",
       "cpu": [
         "x64"
       ],
@@ -7520,9 +7538,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.56.9",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.9.tgz",
-      "integrity": "sha512-W4W3KcqzjJ0sHg2vAq9vfml6OhsJ53TcUjUqfzzZf/EChUtwspszj/S0pzMxnfRcO55/iGq47dscXw71Fxc4Zg==",
+      "version": "8.56.10",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
+      "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -7604,9 +7622,9 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
     "node_modules/@types/leaflet": {
-      "version": "1.9.11",
-      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.11.tgz",
-      "integrity": "sha512-Cwqw9h+1LVnsuOutOSNHlIE1DBQ9U/0CCLfAkwtkgggrYRwf7SUlyZM0LQzngpwKyvFQbPLCf6hNMzly56pGZw==",
+      "version": "1.9.12",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.12.tgz",
+      "integrity": "sha512-BK7XS+NyRI291HIo0HCfE18Lp8oA30H1gpi1tf0mF3TgiCEzanQjOqNZ4x126SXzzi2oNSZhZ5axJp1k0iM6jg==",
       "dev": true,
       "dependencies": {
         "@types/geojson": "*"
@@ -7819,6 +7837,19 @@
       "version": "13.11.9",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.9.tgz",
       "integrity": "sha512-FCTsikRozryfayPuiI46QzH3fnrOoctTjvOYZkho9BTFLCOZ2rgZJHMOVgCOfttjPJcgOx52EpkY0CMfy87MIw=="
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.4.tgz",
+      "integrity": "sha512-lXCmTWSHJvf0TRSO58nm978b8HJ/EdsSsEKLd3ODHFjo+3VGAyyTp4v50nWvwtzBxSMQrVOK7tcuN0zGPLICMw==",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -8597,10 +8628,11 @@
       }
     },
     "node_modules/apostrophe": {
-      "version": "3.63.3",
-      "resolved": "https://registry.npmjs.org/apostrophe/-/apostrophe-3.63.3.tgz",
-      "integrity": "sha512-B9Ly3ygrSfJ9kCUy3HUe3lTngkY0k4im3lm18UUBUW0Gsouh/Vgx99lcZIxFIR2iNSccHR84rvIXuPmu9VZLgA==",
+      "version": "3.64.0",
+      "resolved": "https://registry.npmjs.org/apostrophe/-/apostrophe-3.64.0.tgz",
+      "integrity": "sha512-XDNTAD0HPRFF4DxfoqHZD5+8oNvD/OcVYPoo4vS09229gKhIGIVL1d1cILMCwOHFZRdUpqJY4rYLS0912/rWVg==",
       "dependencies": {
+        "@apostrophecms/emulate-mongo-3-driver": "^1.0.2",
         "@apostrophecms/vue-color": "^2.8.2",
         "@opentelemetry/api": "^1.0.4",
         "@opentelemetry/semantic-conventions": "^1.0.1",
@@ -8644,11 +8676,10 @@
         "cheerio": "^1.0.0-rc.10",
         "chokidar": "^3.5.2",
         "common-tags": "^1.8.0",
-        "connect-mongo": "^3.0.0",
+        "connect-mongo": "^5.1.0",
         "connect-multiparty": "^2.1.1",
         "cookie-parser": "^1.4.5",
         "cors": "^2.8.5",
-        "credentials": "^3.0.2",
         "css-loader": "^5.2.4",
         "cuid": "^2.1.8",
         "dayjs": "^1.9.8",
@@ -8674,7 +8705,6 @@
         "mini-css-extract-plugin": "^1.6.0",
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.5",
-        "mongodb": "^3.6.6",
         "node-fetch": "^2.6.1",
         "nodemailer": "^6.6.1",
         "nunjucks": "^3.2.1",
@@ -9281,9 +9311,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1601.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1601.0.tgz",
-      "integrity": "sha512-znwVdKs3g0j1cAFfi+PGPSmBxXjiekJXp1nnOUq4rxXYvN7av8gxptXaQz+vqB4uhNFsD+OXNQh+6bd9eQxZmw==",
+      "version": "2.1605.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1605.0.tgz",
+      "integrity": "sha512-/wtOuF7WgkbN6YL3xJ+FB54kvIAfnP/DQVDaE6rSYv6ft0xr01Si94NgQWhb5OcFkFfRAC4auZX8PiFNtOi9xQ==",
       "hasInstallScript": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -9615,12 +9645,49 @@
       }
     },
     "node_modules/bl": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "dependencies": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bluebird": {
@@ -9800,11 +9867,11 @@
       }
     },
     "node_modules/bson": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
-      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.6.0.tgz",
+      "integrity": "sha512-BVINv2SgcMjL4oYbBuCQTpE3/VKOSxrOA8Cj/wQP7izSzlBGVomdm+TcUd0Pzy0ytLSSDweCKQ6X3f5veM5LQA==",
       "engines": {
-        "node": ">=0.6.19"
+        "node": ">=16.20.1"
       }
     },
     "node_modules/buffer": {
@@ -9980,7 +10047,6 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -9994,9 +10060,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001611",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001611.tgz",
-      "integrity": "sha512-19NuN1/3PjA3QI8Eki55N8my4LzfkMCRLgCVfrl/slbSAchQfV0+GwjPrK3rq37As4UCLlM/DHajbKkAqbv92Q==",
+      "version": "1.0.30001612",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001612.tgz",
+      "integrity": "sha512-lFgnZ07UhaCcsSZgWW0K5j4e69dK1u/ltrL9lTUiFOwNHs12S3UMIEYgBV0Z6C6hRDev7iRnMzzYmKabYdXF9g==",
       "funding": [
         {
           "type": "opencollective",
@@ -10325,9 +10391,9 @@
       "integrity": "sha512-dhUqc57gSMCo6TX85FLfe51eC/s+Im2MLkAgJwfaRRexR2tA4dd3eLEW4L6efzHc2iNorrRRXITifnDLlRrhaA=="
     },
     "node_modules/clsx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
-      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "engines": {
         "node": ">=6"
       }
@@ -10567,11 +10633,19 @@
       }
     },
     "node_modules/connect-mongo": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/connect-mongo/-/connect-mongo-3.2.0.tgz",
-      "integrity": "sha512-0Mx88079Z20CG909wCFlR3UxhMYGg6Ibn1hkIje1hwsqOLWtL9HJV+XD0DAjUvQScK6WqY/FA8tSVQM9rR64Rw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/connect-mongo/-/connect-mongo-5.1.0.tgz",
+      "integrity": "sha512-xT0vxQLqyqoUTxPLzlP9a/u+vir0zNkhiy9uAdHjSCcUUf7TS5b55Icw8lVyYFxfemP3Mf9gdwUOgeF3cxCAhw==",
       "dependencies": {
-        "mongodb": "^3.1.0"
+        "debug": "^4.3.1",
+        "kruptein": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      },
+      "peerDependencies": {
+        "express-session": "^1.17.1",
+        "mongodb": ">= 5.1.0 < 7"
       }
     },
     "node_modules/connect-multiparty": {
@@ -10867,17 +10941,6 @@
       },
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/credentials": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/credentials/-/credentials-3.0.2.tgz",
-      "integrity": "sha512-sXRowWaF1BkaB/2XMxyH2Q9jrHPTR1pCPr13FR8AreVQiYpLOwikCqatD8rFDsbMV/n/z0ZPBUFF6/tdIACHYA==",
-      "dependencies": {
-        "commander": "^2.18.0"
-      },
-      "bin": {
-        "credentials": "bin/cmd.js"
       }
     },
     "node_modules/crelt": {
@@ -11232,6 +11295,14 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
@@ -11443,6 +11514,11 @@
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
@@ -11677,9 +11753,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.740",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.740.tgz",
-      "integrity": "sha512-Yvg5i+iyv7Xm18BRdVPVm8lc7kgxM3r6iwqCH2zB7QZy1kZRNmd0Zqm0zcD9XoFREE5/5rwIuIAOT+/mzGcnZg=="
+      "version": "1.4.747",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.747.tgz",
+      "integrity": "sha512-+FnSWZIAvFHbsNVmUxhEqWiaOiPMcfum1GQzlWCg/wLigVtshOsjXHyEFfmt6cFK6+HkS3QOJBv6/3OPumbBfw=="
     },
     "node_modules/emitter-listener": {
       "version": "1.1.2",
@@ -11713,6 +11789,11 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/encode-utf8": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
+      "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw=="
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -15692,7 +15773,6 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
       "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "jsbn": "1.1.0",
@@ -17630,7 +17710,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
       "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "dev": true,
       "optional": true
     },
     "node_modules/jsdom": {
@@ -17962,14 +18041,14 @@
       }
     },
     "node_modules/kruptein": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/kruptein/-/kruptein-2.2.3.tgz",
-      "integrity": "sha512-BTwprBPTzkFT9oTugxKd3WnWrX630MqUDsnmBuoa98eQs12oD4n4TeI0GbpdGcYn/73Xueg2rfnw+oK4dovnJg==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/kruptein/-/kruptein-3.0.6.tgz",
+      "integrity": "sha512-EQJjTwAJfQkC4NfdQdo3HXM2a9pmBm8oidzH270cYu1MbgXPNPMJuldN7OPX+qdhPO5rw4X3/iKz0BFBfkXGKA==",
       "dependencies": {
         "asn1.js": "^5.4.1"
       },
       "engines": {
-        "node": ">6"
+        "node": ">8"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -18593,8 +18672,7 @@
     "node_modules/memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "optional": true
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
     },
     "node_modules/memorystream": {
       "version": "0.3.1",
@@ -19549,27 +19627,34 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.4.tgz",
-      "integrity": "sha512-K5q8aBqEXMwWdVNh94UQTwZ6BejVbFhh1uB6c5FKtPE9eUMZPUO3sRZdgIEcHSrAWmxzpG/FeODDKL388sqRmw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.5.0.tgz",
+      "integrity": "sha512-Fozq68InT+JKABGLqctgtb8P56pRrJFkbhW0ux+x1mdHeyinor8oNzJqwLjV/t5X5nJGfTlluxfyMnOXNggIUA==",
       "dependencies": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "optional-require": "^1.1.8",
-        "safe-buffer": "^5.1.2"
+        "@mongodb-js/saslprep": "^1.1.5",
+        "bson": "^6.4.0",
+        "mongodb-connection-string-url": "^3.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=16.20.1"
       },
-      "optionalDependencies": {
-        "saslprep": "^1.0.0"
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
       },
       "peerDependenciesMeta": {
-        "aws4": {
+        "@aws-sdk/credential-providers": {
           "optional": true
         },
-        "bson-ext": {
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
           "optional": true
         },
         "kerberos": {
@@ -19578,20 +19663,44 @@
         "mongodb-client-encryption": {
           "optional": true
         },
-        "mongodb-extjson": {
+        "snappy": {
           "optional": true
         },
-        "snappy": {
+        "socks": {
           "optional": true
         }
       }
     },
-    "node_modules/mongodb/node_modules/denque": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
-      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.0.tgz",
+      "integrity": "sha512-t1Vf+m1I5hC2M5RJx/7AtxgABy1cZmIPQRMXw+gEIPn/cZNF3Oiy+l0UIypUwVB5trcWHq3crg2g3uAR9aAwsQ==",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^13.0.0"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
+      "dependencies": {
+        "tr46": "^4.1.1",
+        "webidl-conversions": "^7.0.0"
+      },
       "engines": {
-        "node": ">=0.10"
+        "node": ">=16"
+      }
+    },
+    "node_modules/mongodb-legacy": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-legacy/-/mongodb-legacy-6.0.1.tgz",
+      "integrity": "sha512-cbm3UOqAYo6yElNk9CHNp5tQwRl1PCpBpcSkVvlvyg7S+gG6vSt1zrFiEniNaWOwwWnIr/IsAeSo48Nm701B/A==",
+      "dependencies": {
+        "mongodb": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
       }
     },
     "node_modules/morgan": {
@@ -20130,9 +20239,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.59.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.59.0.tgz",
-      "integrity": "sha512-HyyfzvTLCE8b1SX2nWimlra8cibEsypcSu/Az4SXMhWhtuctkwAX7qsEYNjUOIoYtPV884oN3wtYTN+iZKBtvw==",
+      "version": "3.62.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.62.0.tgz",
+      "integrity": "sha512-CPMcGa+y33xuL1E0TcNIu4YyaZCxnnvkVaEXrsosR3FxN+fV8xvb7Mzpb7IgKler10qeMkE6+Dp8qJhpzdq35g==",
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -20626,9 +20735,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
-      "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ=="
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.9.tgz",
+      "integrity": "sha512-2f3F0SEEer8bBu0dsNCFF50N0cTThV1nWFYcEYFZttdW0lDAoybv9cQoK7X7/68Z89S7FoRrVjP1LPX4XRf9vg=="
     },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
@@ -20950,17 +21059,6 @@
       "resolved": "apps/cms-server",
       "link": true
     },
-    "node_modules/optional-require": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
-      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
-      "dependencies": {
-        "require-at": "^1.0.6"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -21039,7 +21137,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -21405,9 +21502,9 @@
       }
     },
     "node_modules/pino-abstract-transport": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz",
-      "integrity": "sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+      "integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
       "dependencies": {
         "readable-stream": "^4.0.0",
         "split2": "^4.0.0"
@@ -21748,6 +21845,14 @@
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/pony-cause": {
@@ -22420,9 +22525,9 @@
       }
     },
     "node_modules/prosemirror-view": {
-      "version": "1.33.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.33.4.tgz",
-      "integrity": "sha512-xQqAhH8/HGleVpKDhQsrd+oqdyeKMxFtdCWDxWMmP+n0k27fBpyUqa8pA+RB5cFY8rqDDc1hll69aRZQa7UaAw==",
+      "version": "1.33.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.33.5.tgz",
+      "integrity": "sha512-AbYYLgg2h5CLARLcTtbNrMARlMwV51jTrezcJkV0NS9J4vi28+rhJ45iIWVSjCcRY209BoySDuJ58b8wIFqdmQ==",
       "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
@@ -22490,6 +22595,132 @@
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
+      "integrity": "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "encode-utf8": "^1.0.3",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
       "engines": {
         "node": ">=6"
       }
@@ -23346,14 +23577,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/require-at": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
-      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -23369,6 +23592,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
@@ -23514,9 +23742,9 @@
       "integrity": "sha512-fJhQQI5tLrQvYIYFpOnFinzv9dwmR7hRnUz1XqP3OJ1jIweTNOd6aTO4jwQSgcBSFUB+/KHJxuGneime+FdzOw=="
     },
     "node_modules/rollup": {
-      "version": "4.14.3",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.3.tgz",
-      "integrity": "sha512-ag5tTQKYsj1bhrFC9+OEWqb5O6VYgtQDO9hPDBMmIbePwhfSr+ExlcU741t8Dhw5DkPCQf6noz0jb36D6W9/hw==",
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.16.4.tgz",
+      "integrity": "sha512-kuaTJSUbz+Wsb2ATGvEknkI12XV40vIiHmLuFlejoo7HtDok/O5eDDD0UpCVY5bBX5U5RYo8wWP83H7ZsqVEnA==",
       "dev": true,
       "dependencies": {
         "@types/estree": "1.0.5"
@@ -23529,22 +23757,22 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.14.3",
-        "@rollup/rollup-android-arm64": "4.14.3",
-        "@rollup/rollup-darwin-arm64": "4.14.3",
-        "@rollup/rollup-darwin-x64": "4.14.3",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.14.3",
-        "@rollup/rollup-linux-arm-musleabihf": "4.14.3",
-        "@rollup/rollup-linux-arm64-gnu": "4.14.3",
-        "@rollup/rollup-linux-arm64-musl": "4.14.3",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.14.3",
-        "@rollup/rollup-linux-riscv64-gnu": "4.14.3",
-        "@rollup/rollup-linux-s390x-gnu": "4.14.3",
-        "@rollup/rollup-linux-x64-gnu": "4.14.3",
-        "@rollup/rollup-linux-x64-musl": "4.14.3",
-        "@rollup/rollup-win32-arm64-msvc": "4.14.3",
-        "@rollup/rollup-win32-ia32-msvc": "4.14.3",
-        "@rollup/rollup-win32-x64-msvc": "4.14.3",
+        "@rollup/rollup-android-arm-eabi": "4.16.4",
+        "@rollup/rollup-android-arm64": "4.16.4",
+        "@rollup/rollup-darwin-arm64": "4.16.4",
+        "@rollup/rollup-darwin-x64": "4.16.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.16.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.16.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.16.4",
+        "@rollup/rollup-linux-arm64-musl": "4.16.4",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.16.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.16.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.16.4",
+        "@rollup/rollup-linux-x64-gnu": "4.16.4",
+        "@rollup/rollup-linux-x64-musl": "4.16.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.16.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.16.4",
+        "@rollup/rollup-win32-x64-msvc": "4.16.4",
         "fsevents": "~2.3.2"
       }
     },
@@ -23696,18 +23924,6 @@
         "is-plain-object": "^5.0.0",
         "parse-srcset": "^1.0.2",
         "postcss": "^8.3.11"
-      }
-    },
-    "node_modules/saslprep": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-      "optional": true,
-      "dependencies": {
-        "sparse-bitfield": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/sass": {
@@ -24052,6 +24268,17 @@
         "node": ">=6 <7 || >=8"
       }
     },
+    "node_modules/session-file-store/node_modules/kruptein": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/kruptein/-/kruptein-2.2.3.tgz",
+      "integrity": "sha512-BTwprBPTzkFT9oTugxKd3WnWrX630MqUDsnmBuoa98eQs12oD4n4TeI0GbpdGcYn/73Xueg2rfnw+oK4dovnJg==",
+      "dependencies": {
+        "asn1.js": "^5.4.1"
+      },
+      "engines": {
+        "node": ">6"
+      }
+    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -24336,7 +24563,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">= 6.0.0",
@@ -24452,7 +24678,6 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
       "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "ip-address": "^9.0.5",
@@ -24624,7 +24849,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
-      "optional": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
@@ -25311,7 +25535,7 @@
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
       "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
-      "deprecated": "Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.",
+      "deprecated": "Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net",
       "dependencies": {
         "component-emitter": "^1.2.0",
         "cookiejar": "^2.1.0",
@@ -25580,39 +25804,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/tar-stream/node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/tar-stream/node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
     "node_modules/tar-stream/node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -25691,9 +25882,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.30.3",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.30.3.tgz",
-      "integrity": "sha512-STdUgOUx8rLbMGO9IOwHLpCqolkDITFFQSMYYwKE1N2lY6MVSaeoi10z/EhWxRc6ybqoVmKSkhKYH/XUpl7vSA==",
+      "version": "5.30.4",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.30.4.tgz",
+      "integrity": "sha512-xRdd0v64a8mFK9bnsKVdoNP9GQIKUAaJPTaqEQDL4w/J8WaW4sWXXoMZ+6SimPkfT5bElreXf8m9HnmPc3E1BQ==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -25787,9 +25978,9 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.4.1.tgz",
-      "integrity": "sha512-d/Ex2iWd1whipbT681JmTINKw0ZwOUBZm7+Gjs64DHuX34mmw8vJL2bFAaNacaW72zYiTJxSHi5abUuOi5nsfg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-2.6.0.tgz",
+      "integrity": "sha512-t4eNiKdGwd1EV6tx76mRbrOqwvkxz+ssOiQXEXw88m4p/Xp6679vg16sf39BAstRjHOiWIqp5+J2ylHk3pU30g==",
       "dependencies": {
         "real-require": "^0.2.0"
       }
@@ -26438,9 +26629,9 @@
       }
     },
     "node_modules/umzug/node_modules/type-fest": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.15.0.tgz",
-      "integrity": "sha512-tB9lu0pQpX5KJq54g+oHOLumOx+pMep4RaM6liXh2PKmVRFF+/vAtUP0ZaJ0kOySfVNjF6doBWPHhBhISKdlIA==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.17.0.tgz",
+      "integrity": "sha512-9flrz1zkfLRH3jO3bLflmTxryzKMxVa7841VeMgBaNQGY6vH4RCcpN/sQLB7mQQYh1GZ5utT2deypMuCy4yicw==",
       "engines": {
         "node": ">=16"
       },
@@ -27665,6 +27856,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
@@ -27956,9 +28152,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "version": "3.23.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.4.tgz",
+      "integrity": "sha512-/AtWOKbBgjzEYYQRNfoGKHObgfAZag6qUJX1VbHo2PRBgS+wfWagEY2mizjfyAPcGesrJOcx/wcl0L9WnVrHFw==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
The Google Chart API is deprecated, so we are now generating our own QR codes. I have also added the option to change the Issuer from the default `Openstad` to something of your liking, either through docker-compose (`ENVIRONMENT_NAME` in your env) or through the helm chart (`values.public.environmentName`)

2FA setup screen with `ENVIRONMENT_NAME` set to `Beheerpaneel Openstad lokaal`:
![image](https://github.com/openstad/openstad-headless/assets/205926/2fcf5294-3ca8-4be5-b9a2-6d3083af5333)


QR code when scanned with 2fa app: 

https://github.com/openstad/openstad-headless/assets/205926/67479f1d-2107-49ab-b2c0-0903c19e170a

