### PR TITLE
Fix/admin login should not break on cms login

### DIFF
--- a/apps/admin-server/src/auth.ts
+++ b/apps/admin-server/src/auth.ts
@@ -81,10 +81,7 @@ async function authMiddleware(req: NextRequest, res: NextResponse) {
     return NextResponse.redirect( newUrl, { headers: res.headers });
   }
 
-  if (!(
-      req.nextUrl.pathname.startsWith('/_') ||         // not on internal urls
-      req.nextUrl.pathname.startsWith('/api/openstad') // api routes require user but will nog login
-     )) {
+  if (!(req.nextUrl.pathname.startsWith('/_'))) { // not on internal urls
 
     let forceNewLogin = false;
 
@@ -119,14 +116,15 @@ async function authMiddleware(req: NextRequest, res: NextResponse) {
     }
 
     // login if token not found
-    if (!jwt) {
+    if (!jwt && !req.nextUrl.pathname.startsWith('/api/openstad')) {
+       // api routes require user but will nog login
       return signIn(req, res, targetProjectId, forceNewLogin)
     }
 
   }
 
   // api requests: add jwt
-  if (req.nextUrl.pathname.startsWith('/api/openstad')) {
+  if (jwt && req.nextUrl.pathname.startsWith('/api/openstad')) {
     let path = req.nextUrl.pathname.replace('/api/openstad', '');
     let query = searchParams ? '?' + searchParams.toString() : '';
     query = query.replace(/openstadlogintoken=(?:.(?!&|$))+./, '');

--- a/apps/api-server/src/adapter/openstad/router.js
+++ b/apps/api-server/src/adapter/openstad/router.js
@@ -94,12 +94,12 @@ router
 
   })
   .get(function (req, res, next) {
-
     // redirect to idp server
     let redirectUri = encodeURIComponent(config.url + '/auth/project/' + req.project.id + '/digest-login?useAuth=' + req.authConfig.provider + '\&returnTo=' + req.query.redirectUri);
-    let url = `${req.authConfig.serverUrl}/login`;
-    if (req.query.loginPriviliged) url += '/admin';
-    url += `?redirect_uri=${redirectUri}&response_type=code&client_id=${req.authConfig.clientId}&scope=offline&forceLogin=1`;
+    let url = `${req.authConfig.serverUrl}/dialog/authorize`;
+    if (req.query.loginPriviliged) url = `${req.authConfig.serverUrl}/auth/admin/login`,
+    url += `?redirect_uri=${redirectUri}&response_type=code&client_id=${req.authConfig.clientId}&scope=offline`;
+    console.log(url);
     res.redirect(url);
 
   })


### PR DESCRIPTION
**TL;DR**

Je kunt weer inloggen op cms en admin tegelijk, zolang je op beide inlogt als admin user.

**Uitleg**

Twee dingen:
- ik heb vorige week de login url van de api naar de auth server gewijzigd omdat dat eleganter leek, maar dat was iets te bijdehand, want daarmee heb ik SSO op de auth server kapot gemaakt
- de admin server deed api calls met verlopen jwt's omdat een afvanging op de verkeerde plaats stond

Beide zijn gefixed, waardoor inloggen op het cms je niet uit de admin gooit.

Maar.

De auth server is SSO, dus als je bent ingelogd op de admin, dan anoniem inlogt op het cms, en dan weer wat rondklikt in de admin (met name wisselen van project) dan kan dat nog steeds mis gaan. Je wordt dan door de admin naar de auth server gestuurd, die je als anonieme user terug stuurt naar de admin, die dan (terecht) vind dat je niet langer bent ingelogd.

Dat is functioneel correct, maar wellicht goed om te weten :)

