### PR TITLE
Fix/resource form missing fields

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/items.tsx
@@ -601,21 +601,23 @@ export default function WidgetEnqueteItems(
                         </FormItem>
                       )}
                     />
-                    <FormField
-                      control={form.control}
-                      name="fieldKey"
-                      render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>
-                              Key voor het opslaan
-                              <InfoDialog content={'Voor de volgende types zijn deze velden altijd veplicht: Titel, Samenvatting en Beschrijving'} />
-                              </FormLabel>
-                            <em className='text-xs'>Deze moet uniek zijn bijvoorbeeld: ‘samenvatting’</em>
-                            <Input {...field} />
-                            <FormMessage/>
-                          </FormItem>
-                      )}
-                    />
+                    {form.watch('questionType') !== 'none' && (
+                      <FormField
+                        control={form.control}
+                        name="fieldKey"
+                        render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>
+                                Key voor het opslaan
+                                <InfoDialog content={'Voor de volgende types zijn deze velden altijd veplicht: Titel, Samenvatting en Beschrijving'} />
+                                </FormLabel>
+                              <em className='text-xs'>Deze moet uniek zijn bijvoorbeeld: ‘samenvatting’</em>
+                              <Input {...field} />
+                              <FormMessage/>
+                            </FormItem>
+                        )}
+                      />
+                    )}
                     <FormField
                       control={form.control}
                       name="description"
@@ -643,7 +645,7 @@ export default function WidgetEnqueteItems(
                             </FormControl>
                             <SelectContent>
                               <SelectItem value="none">
-                                Geen antwoordopties
+                                Informatie blok
                               </SelectItem>
                               <SelectItem value="images">
                                 Twee antwoordopties met afbeeldingen

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourceform/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourceform/[id]/items.tsx
@@ -722,7 +722,7 @@ export default function WidgetResourceFormItems(
                                                 }}
                                             />
                                         )}
-                                        {form.watch('fieldType') === 'text' && (
+                                        {form.watch('fieldType') === 'text' || form.watch('type') === 'text' && (
                                             <>
                                                 <FormField
                                                     control={form.control}

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourceform/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourceform/[id]/items.tsx
@@ -547,7 +547,7 @@ export default function WidgetResourceFormItems(
                                                             </SelectTrigger>
                                                         </FormControl>
                                                         <SelectContent>
-                                                            <SelectItem value="none">Geen antwoordopties</SelectItem>
+                                                            <SelectItem value="none">Informatie blok</SelectItem>
                                                             <SelectItem value="radiobox">Radio buttons</SelectItem>
                                                             <SelectItem value="text">Tekstveld</SelectItem>
                                                             <SelectItem value="checkbox">Checkboxes</SelectItem>
@@ -614,26 +614,27 @@ export default function WidgetResourceFormItems(
                                                 </FormItem>
                                             )}
                                         />
-                                        <FormField
-                                            control={form.control}
-                                            name="fieldKey"
-                                            render={({ field }) => {
-                                                const nonStaticType = ['none', 'radiobox', 'text', 'checkbox', 'map', 'upload'];
-                                                const type = form.watch('type');
-                                                const fieldKey = !nonStaticType.includes(type || '') ? type : '';
+                                        {form.watch('type') !== 'none' && (
+                                            <FormField
+                                                control={form.control}
+                                                name="fieldKey"
+                                                render={({ field }) => {
+                                                    const nonStaticType = ['none', 'radiobox', 'text', 'checkbox', 'map', 'upload'];
+                                                    const type = form.watch('type');
+                                                    const fieldKey = !nonStaticType.includes(type || '') ? type : '';
 
-                                                return (
-                                                    <FormItem>
-                                                        <FormLabel>Key voor het opslaan</FormLabel>
-                                                        <em className='text-xs'>Deze moet uniek zijn bijvoorbeeld: ‘samenvatting’</em>
+                                                    return (
+                                                        <FormItem>
+                                                            <FormLabel>Key voor het opslaan</FormLabel>
+                                                            <em className='text-xs'>Deze moet uniek zijn bijvoorbeeld: ‘samenvatting’</em>
 
-                                                        <Input {...field} disabled={!!fieldKey} />
-                                                        <FormMessage />
-                                                    </FormItem>
-                                                )
-                                            }
-                                            }
-                                        />
+                                                            <Input {...field} disabled={!!fieldKey} />
+                                                            <FormMessage />
+                                                        </FormItem>
+                                                    )
+                                                }}
+                                            />
+                                        )}
                                         {form.watch('type') === 'tags' && (
                                             <FormField
                                                 control={form.control}
@@ -681,44 +682,46 @@ export default function WidgetResourceFormItems(
                                                 }}
                                             />
                                         )}
-                                        <FormField
-                                            control={form.control}
-                                            name="fieldRequired"
-                                            render={({ field }) => {
-                                                const staticType = ['title', 'summary', 'description'];
-                                                const type = form.watch('type');
-                                                const required = staticType.includes(type || '');
+                                        {form.watch('type') !== 'none' && (
+                                            <FormField
+                                                control={form.control}
+                                                name="fieldRequired"
+                                                render={({ field }) => {
+                                                    const staticType = ['title', 'summary', 'description'];
+                                                    const type = form.watch('type');
+                                                    const required = staticType.includes(type || '');
 
-                                                return (
-                                                    <FormItem>
-                                                        <FormLabel>
-                                                            Is dit veld verplicht?
-                                                            <InfoDialog content={'Voor de volgende types zijn deze velden altijd veplicht: Titel, Samenvatting en Beschrijving'} />
-                                                        </FormLabel>
-                                                        <Select
-                                                            onValueChange={(e: string) => field.onChange(e === 'true')}
-                                                            value={
-                                                                required
-                                                                    ? 'true'
-                                                                    : (field.value ? 'true' : 'false')
-                                                            }
-                                                            disabled={required}
-                                                        >
-                                                            <FormControl>
-                                                                <SelectTrigger>
-                                                                    <SelectValue placeholder="Kies een optie" />
-                                                                </SelectTrigger>
-                                                            </FormControl>
-                                                            <SelectContent>
-                                                                <SelectItem value="true">Ja</SelectItem>
-                                                                <SelectItem value="false">Nee</SelectItem>
-                                                            </SelectContent>
-                                                        </Select>
-                                                        <FormMessage />
-                                                    </FormItem>
-                                                )
-                                            }}
-                                        />
+                                                    return (
+                                                        <FormItem>
+                                                            <FormLabel>
+                                                                Is dit veld verplicht?
+                                                                <InfoDialog content={'Voor de volgende types zijn deze velden altijd veplicht: Titel, Samenvatting en Beschrijving'} />
+                                                            </FormLabel>
+                                                            <Select
+                                                                onValueChange={(e: string) => field.onChange(e === 'true')}
+                                                                value={
+                                                                    required
+                                                                        ? 'true'
+                                                                        : (field.value ? 'true' : 'false')
+                                                                }
+                                                                disabled={required}
+                                                            >
+                                                                <FormControl>
+                                                                    <SelectTrigger>
+                                                                        <SelectValue placeholder="Kies een optie" />
+                                                                    </SelectTrigger>
+                                                                </FormControl>
+                                                                <SelectContent>
+                                                                    <SelectItem value="true">Ja</SelectItem>
+                                                                    <SelectItem value="false">Nee</SelectItem>
+                                                                </SelectContent>
+                                                            </Select>
+                                                            <FormMessage />
+                                                        </FormItem>
+                                                    )
+                                                }}
+                                            />
+                                        )}
                                         {form.watch('fieldType') === 'text' && (
                                             <>
                                                 <FormField

--- a/packages/enquete/src/enquete.tsx
+++ b/packages/enquete/src/enquete.tsx
@@ -116,6 +116,9 @@ function Enquete(props: EnqueteWidgetProps) {
                         { value: 'Laugh', label: <Icon icon="ri-emotion-laugh-line" /> },
                     ];
                     break;
+                case 'none':
+                    fieldData['type'] = 'none';
+                    break;
             }
 
             formFields.push(fieldData);

--- a/packages/form/src/form.tsx
+++ b/packages/form/src/form.tsx
@@ -9,8 +9,9 @@ import TickmarkSlider from "@openstad-headless/ui/src/form-elements/tickmark-sli
 import FileUploadField from "@openstad-headless/ui/src/form-elements/file-upload";
 import MapField from "@openstad-headless/ui/src/form-elements/map";
 import { handleSubmit } from "./submit";
-import HiddenInput from "@openstad-headless/ui/src/form-elements/hidden/index.js";
-import ImageChoiceField from "@openstad-headless/ui/src/form-elements/image-choice/index.js";
+import HiddenInput from "@openstad-headless/ui/src/form-elements/hidden";
+import ImageChoiceField from "@openstad-headless/ui/src/form-elements/image-choice";
+import InfoField from "@openstad-headless/ui/src/form-elements/info";
 import { FormFieldErrorMessage, Button } from "@utrecht/component-library-react";
 import './form.css'
 
@@ -63,6 +64,7 @@ function Form({
         map: MapField as React.ComponentType<ComponentFieldProps>,
         hidden: HiddenInput as React.ComponentType<ComponentFieldProps>,
         imageChoice: ImageChoiceField as React.ComponentType<ComponentFieldProps>,
+        none: InfoField as React.ComponentType<ComponentFieldProps>,
     };
 
     const renderField = (field: ComponentFieldProps, index: number) => {

--- a/packages/form/src/form.tsx
+++ b/packages/form/src/form.tsx
@@ -95,7 +95,7 @@ function Form({
                         <div className={`question question-type-${field.type}`} key={index}>
                             {renderField(field, index)}
                             <FormFieldErrorMessage className="error-message">
-                                {formErrors[field.fieldKey] && <span>{formErrors[field.fieldKey]}</span>}
+                                {field.fieldKey && formErrors[field.fieldKey] && <span>{formErrors[field.fieldKey]}</span>}
                             </FormFieldErrorMessage>
                         </div>
                     ))}

--- a/packages/form/src/props.ts
+++ b/packages/form/src/props.ts
@@ -7,7 +7,8 @@ import type { RadioboxFieldProps } from "@openstad-headless/ui/src/form-elements
 import type { FileUploadProps} from "@openstad-headless/ui/src/form-elements/file-upload";
 import type { HiddenInputProps } from "@openstad-headless/ui/src/form-elements/hidden";
 import type {ImageChoiceFieldProps} from "@openstad-headless/ui/src/form-elements/image-choice";
-import {MapProps} from "@openstad-headless/ui/src/form-elements/map/index.js";
+import type {MapProps} from "@openstad-headless/ui/src/form-elements/map";
+import type {InfoFieldProps} from "@openstad-headless/ui/src/form-elements/info";
 
 export type FormProps = {
     title?: string;
@@ -29,7 +30,8 @@ type CombinedFieldPropsWithType =
     | ({ type?: 'upload' } & FileUploadProps)
     | ({ type?: 'hidden' } & HiddenInputProps)
     | ({ type?: 'imageChoice' } & ImageChoiceFieldProps)
-    | ({ type?: 'map' } & MapProps);
+    | ({ type?: 'map' } & MapProps)
+    | ({ type?: 'none' } & InfoFieldProps);
 
 type ComponentFieldProps = (
     {
@@ -47,7 +49,8 @@ type CombinedFieldProps = (
     RadioboxFieldProps |
     FileUploadProps |
     HiddenInputProps |
-    ImageChoiceFieldProps
+    ImageChoiceFieldProps |
+    InfoFieldProps
 );
 
 export type { CombinedFieldProps as FieldProps, CombinedFieldPropsWithType, ComponentFieldProps};

--- a/packages/resource-form/src/parts/init-fields.tsx
+++ b/packages/resource-form/src/parts/init-fields.tsx
@@ -36,7 +36,7 @@ export const InitializeFormFields = (items, data) => {
             }
 
             const fieldData: any = {
-                type: item.fieldType,
+                type: item.fieldType || item.type,
                 title: item.title,
                 description: item.description,
                 fieldKey: item.fieldKey,

--- a/packages/resource-form/src/parts/init-fields.tsx
+++ b/packages/resource-form/src/parts/init-fields.tsx
@@ -45,13 +45,11 @@ export const InitializeFormFields = (items, data) => {
                 maxCharacters: getMinMaxByField(`${item.fieldKey}MaxLength`, data) || item.maxCharacters || '',
                 variant: item.variant,
                 multiple: item.multiple,
-                options: item.options
+                options: item.options,
+                rows: 5
             };
 
             switch (item.fieldType) {
-                case 'text':
-                    fieldData['rows'] = 4;
-                    break;
                 case 'checkbox':
                 case 'select':
                 case 'radiobox':

--- a/packages/ui/src/form-elements/info/index.tsx
+++ b/packages/ui/src/form-elements/info/index.tsx
@@ -4,6 +4,8 @@ import {Paragraph, Strong} from "@utrecht/component-library-react";
 export type InfoFieldProps = {
     title?: string;
     description?: string;
+    fieldKey?: string;
+    type?: string;
 }
 
 const InfoField: FC<InfoFieldProps> = ({

--- a/packages/ui/src/form-elements/info/index.tsx
+++ b/packages/ui/src/form-elements/info/index.tsx
@@ -1,0 +1,21 @@
+import React, { FC } from "react";
+import {Paragraph, Strong} from "@utrecht/component-library-react";
+
+export type InfoFieldProps = {
+    title?: string;
+    description?: string;
+}
+
+const InfoField: FC<InfoFieldProps> = ({
+   title = '',
+   description = ''
+}) => {
+    return (
+        <div className="info-field-container">
+          {title && <Paragraph><Strong>{title}</Strong></Paragraph>}
+          {description && <Paragraph>{description}</Paragraph>}
+        </div>
+    );
+};
+
+export default InfoField;


### PR DESCRIPTION
Dit lost de volgende punten op:

- Aan de voorkant worden alleen velden getoond die met Resource: beginnen. Dus eigen textvelden worden niet getoond.
- Bij het Resource form kun je niet kiezen of een tekstveld een input of area moet worden