### PR TITLE
fix: Get resource ID dynamic when no resource is set

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/rawresource/[id]/general.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/rawresource/[id]/general.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@/components/ui/button';
 import {
   Form,
-  FormControl,
+  FormControl, FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -76,6 +76,7 @@ export default function WidgetRawGeneral(
             render={({ field }) => (
               <FormItem>
                 <FormLabel>Resource</FormLabel>
+                <FormDescription>Indien er geen resource is gekoppeld, wordt er gecontroleerd of er een resource aanwezig is in de URL. In dat geval zal deze resource automatisch worden gekoppeld.</FormDescription>
                 <Select
                   onValueChange={(e) => {
                     field.onChange(e);
@@ -88,7 +89,7 @@ export default function WidgetRawGeneral(
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
-                    <SelectItem value="">Selecteer een resource</SelectItem>
+                    <SelectItem value="">Geen resource koppelen</SelectItem>
                     {data?.map((resource: any) => (
                       <SelectItem key={resource.id} value={`${resource.id}`}>
                         {resource.title}

--- a/packages/raw-resource/src/raw-resource.tsx
+++ b/packages/raw-resource/src/raw-resource.tsx
@@ -26,6 +26,8 @@ function RawResource(props: RawResourceWidgetProps) {
     targetUrl: props.resourceIdRelativePath,
   })); // todo: make it a number throughout the code
 
+  props.resourceId = resourceId
+
   const datastore = new DataStore({
     projectId: props.projectId,
     resourceId: resourceId,


### PR DESCRIPTION
Deze PR zorgt ervoor dat de resource, indien aanwezig, uit de URL wordt gehaald wanneer je geen resource kiest bij een raw widget. Dit wordt nu bij de beschrijving ook duidelijk gemaakt