### PR TITLE
Fix/ban occupied tags

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/tags/create.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/tags/create.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { useForm } from 'react-hook-form';
@@ -18,6 +18,7 @@ import { PageLayout } from '@/components/ui/page-layout';
 import { Heading } from '@/components/ui/typography';
 import { Separator } from '@/components/ui/separator';
 import { useRouter } from 'next/router';
+import { getApiFetchMethodNames } from '@openstad-headless/data-store/src/api/index';
 import useTag from '@/hooks/use-tags';
 import toast from 'react-hot-toast';
 
@@ -32,6 +33,7 @@ export default function ProjectTagCreate() {
   const router = useRouter();
   const project = router.query.project;
   const { createTag } = useTag(project as string);
+  const [disabled, setDisabled]  = useState(false);
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver<any>(formSchema),
@@ -47,6 +49,21 @@ export default function ProjectTagCreate() {
       toast.error('Er is helaas iets mis gegaan.')
     }
   }
+
+  const apiFetchMethodNames = getApiFetchMethodNames();
+
+  useEffect(() => {
+    const type = form.watch('type');
+
+    if ( !!apiFetchMethodNames && Array.isArray(apiFetchMethodNames) && apiFetchMethodNames.includes(type) ) {
+      form.setError('type', {type: 'manual', message: `${type} valt onder de benamingen die niet gebruikt mag worden wegens mogelijke conflicten.`});
+      setDisabled(true);
+    } else {
+      form.clearErrors(['type'])
+      setDisabled(false);
+    }
+
+  }, [ form.watch('type') ] );
 
   return (
     <div>
@@ -125,7 +142,11 @@ export default function ProjectTagCreate() {
                   </FormItem>
                 )}
               />
-              <Button className="w-fit col-span-full" type="submit">
+              <Button
+                className="w-fit col-span-full"
+                disabled={disabled}
+                type="submit"
+              >
                 Opslaan
               </Button>
             </form>

--- a/packages/data-store/src/api/index.js
+++ b/packages/data-store/src/api/index.js
@@ -17,6 +17,20 @@ export default function singelton(props = { config: {} }) {
   return (windowGlobal.OpenStadAPI = windowGlobal.OpenStadAPI || new API(props));
 }
 
+export function getApiFetchMethodNames() {
+  const apiInstance = new API({ logMethods: true });
+  const apiFetchMethodNames = [];
+
+  for (const key of Object.keys(apiInstance)) {
+    const value = apiInstance[key];
+    if (value && typeof value === 'object' && 'fetch' in value) {
+      apiFetchMethodNames.push(key);
+    }
+  }
+
+  return apiFetchMethodNames;
+}
+
 function API(props = {}) {
   let self = this;
 
@@ -82,4 +96,8 @@ function API(props = {}) {
     fetch: userVote.fetch.bind(self),
     submitVote: userVote.submitVote.bind(self),
   };
+
+  if (props.logMethods) {
+    return self;
+  }
 }

--- a/packages/data-store/src/index.d.ts
+++ b/packages/data-store/src/index.d.ts
@@ -1,1 +1,4 @@
 declare module '@openstad-headless/data-store/src';
+declare module '@openstad-headless/data-store/src/api/index' {
+  export function getApiFetchMethodNames(): string[];
+}

--- a/packages/data-store/tsconfig.json
+++ b/packages/data-store/tsconfig.json
@@ -18,5 +18,9 @@
     "allowSyntheticDefaultImports": true,
     "emitDeclarationOnly": true,
 
-  }
+  },
+  "include": [
+    "src/**/*",
+    "types/**/*"
+  ]
 }


### PR DESCRIPTION
Deze PR zorgt ervoor dat je geen namen mag gebruiken voor de tag type die al gebruikt worden in de dataStore