### PR TITLE
feat: redirect after resource submission

### DIFF
--- a/packages/resource-form/src/main.tsx
+++ b/packages/resource-form/src/main.tsx
@@ -22,7 +22,6 @@ const config: ResourceFormWidgetProps = {
     description:
         'Op de laatste digitale denktank waren 11 bewoners. We hebben hun mening gevraagd over ontwerpkeuzes voor de renovatie. Maar we vinden het belangrijk meer bewoners te horen over hun voorkeuren. Omdat we soms nog twijfels hoorden. Daarom deze extra vragenlijst voor jou. Laat je ons weten wat jouw voorkeuren zijn? Dan kunnen wij betere keuzes maken. Natuurlijk laten we je weten wat de uitkomst is van de vragenlijst en welke definitieve keuzes we gaan maken.',
     items: defaultFormValues,
-    afterSubmitUrl: "http://localhost:5173/enquetes/[id]",
 
     resourceType: 'resource',
     formName: 'testformname',

--- a/packages/resource-form/src/props.ts
+++ b/packages/resource-form/src/props.ts
@@ -6,7 +6,6 @@ export type ResourceFormWidgetProps = BaseProps &
 
 export type ResourceFormWidget = {
     widgetId?: number;
-    afterSubmitUrl?: string;
     displayTitle?: boolean;
     title?: string;
     displayDescription?: boolean;
@@ -15,6 +14,7 @@ export type ResourceFormWidget = {
     items?: Array<Item>;
     info?: Info;
     confirmation?: Confirmation;
+    redirectUrl?: string,
 };
 
 export type General = {

--- a/packages/resource-form/src/resource-form.tsx
+++ b/packages/resource-form/src/resource-form.tsx
@@ -93,7 +93,15 @@ function ResourceFormWidget(props: ResourceFormWidgetProps) {
         try {
             const result = await createResource(finalFormData, props.widgetId);
             if (result) {
-                notifySuccess();
+                if(props.redirectUrl) {
+                    let redirectUrl = props.redirectUrl.replace("[id]", result.id);
+                    if (!redirectUrl.startsWith('http://') && !redirectUrl.startsWith('https://')) {
+                        redirectUrl = document.location.origin + '/' + (redirectUrl.startsWith('/') ? redirectUrl.substring(1) : redirectUrl);
+                    }
+                    document.location.href = redirectUrl.replace("[id]", result.id)
+                } else {
+                    notifySuccess();
+                }
             }
         } catch (e) {
             notifyFailed();


### PR DESCRIPTION
Use the `redirectUri` prop for this, because this is the one given from the admin-server. The `afterSubmitUrl` prop has been removed.