### PR TITLE
feat: add selection for role to like comments

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/settings/comments.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/settings/comments.tsx
@@ -12,6 +12,13 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/ui/form';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
 import { PageLayout } from '@/components/ui/page-layout';
 import { Heading } from '@/components/ui/typography';
@@ -31,6 +38,8 @@ const formSchema = z.object({
   descriptionMinLength: z.coerce.number().gt(0).optional(),
   descriptionMaxLength: z.coerce.number().gt(0).optional(),
   adminLabel: z.string().optional(),
+  requiredUserRole: z.enum(['anonymous', 'member']),
+  requiredUserLikeRole: z.enum(['anonymous', 'member']),
 });
 
 export default function ProjectSettingsComments() {
@@ -40,6 +49,7 @@ export default function ProjectSettingsComments() {
   const { data, updateProject } = useProject();
 
   const [ showCommentSettings, setShowCommentSettings ] = useState(false);
+  const [ showLikeSettings, setShowLikeSettings ] = useState(false);
 
   const defaults = useCallback(
     () => ({
@@ -50,6 +60,8 @@ export default function ProjectSettingsComments() {
         descriptionMinLength: data?.config?.comments?.descriptionMinLength,
         descriptionMaxLength: data?.config?.comments?.descriptionMaxLength,
         adminLabel: data?.config?.comments?.adminLabel,
+        requiredUserRole: data?.config?.comments?.requiredUserRole,
+        requiredUserLikeRole: data?.config?.comments?.requiredUserLikeRole,
     }),
     [data]
   );
@@ -62,6 +74,7 @@ export default function ProjectSettingsComments() {
   useEffect(() => {
     form.reset(defaults());
     setShowCommentSettings(data?.config?.comments?.canComment)
+    setShowLikeSettings(data?.config?.comments?.canLike)
   }, [form, defaults]);
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
@@ -74,6 +87,8 @@ export default function ProjectSettingsComments() {
           canLike: values.canLike,
           descriptionMinLength: values.descriptionMinLength,
           descriptionMaxLength: values.descriptionMaxLength,
+          requiredUserRole: values.requiredUserRole,
+          requiredUserLikeRole: values.requiredUserLikeRole,
           adminLabel: values.adminLabel,
         },
       },
@@ -136,6 +151,34 @@ export default function ProjectSettingsComments() {
                 )}
               />
 
+               <FormField
+                control={form.control}
+                name="requiredUserRole"
+                render={({ field }) => (
+                  <FormItem className="col-span-1">
+                    <FormLabel>
+                      Wat voor gebruikers hebben het recht om te reageren?
+                    </FormLabel>
+                    <Select onValueChange={field.onChange} value={field.value}>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Geregistreerde gebruikers" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="anonymous">
+                          Anonieme gebruikers
+                        </SelectItem>
+                        <SelectItem value="member">
+                          Geregistreerde gebruikers
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
               {showCommentSettings ? (
                 <>
 
@@ -172,6 +215,7 @@ export default function ProjectSettingsComments() {
                           className="block w-[50px] h-[25px] bg-stone-300 rounded-full relative focus:shadow-[0_0_0_2px] focus:shadow-black data-[state=checked]:bg-primary outline-none cursor-default"
                           onCheckedChange={(e: boolean) => {
                             field.onChange(e);
+                            setShowLikeSettings(e);
                           }}
                           checked={field.value}>
                           <Switch.Thumb className="block w-[21px] h-[21px] bg-white rounded-full transition-transform duration-100 translate-x-0.5 will-change-transform data-[state=checked]:translate-x-[27px]" />
@@ -180,6 +224,38 @@ export default function ProjectSettingsComments() {
                       </FormItem>
                     )}
                   />
+
+                  {showLikeSettings && (
+                    <>
+                      <FormField
+                        control={form.control}
+                        name="requiredUserLikeRole"
+                        render={({ field }) => (
+                          <FormItem className="col-span-1">
+                            <FormLabel>
+                              Wat voor gebruikers hebben het recht om te liken?
+                            </FormLabel>
+                            <Select onValueChange={field.onChange} value={field.value}>
+                              <FormControl>
+                                <SelectTrigger>
+                                  <SelectValue placeholder="Geregistreerde gebruikers" />
+                                </SelectTrigger>
+                              </FormControl>
+                              <SelectContent>
+                                <SelectItem value="anonymous">
+                                  Anonieme gebruikers
+                                </SelectItem>
+                                <SelectItem value="member">
+                                  Geregistreerde gebruikers
+                                </SelectItem>
+                              </SelectContent>
+                            </Select>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    </>)
+                  }
 
                   <FormField
                     control={form.control}

--- a/packages/comments/src/comments.tsx
+++ b/packages/comments/src/comments.tsx
@@ -32,6 +32,7 @@ export type CommentsWidgetProps = BaseProps &
     showForm?: boolean,
     closedText?: string;
     requiredUserRole?: string,
+    requiredUserLikeRole?: string,
     descriptionMinLength?: number,
     descriptionMaxLength?: number,
     selectedComment?: Number | undefined;
@@ -69,6 +70,7 @@ function Comments({
     showForm: typeof props.showForm != 'undefined' ? props.showForm : true,
     closedText: props.comments?.closedText || 'Het insturen van reacties is gesloten, u kunt niet meer reageren',
     requiredUserRole: props.comments?.requiredUserRole || 'member',
+    requiredUserLikeRole: props.comments?.requiredUserLikeRole || 'member',
     descriptionMinLength: props.comments?.descriptionMinLength || 30,
     descriptionMaxLength: props.comments?.descriptionMaxLength || 500,
     adminLabel: props.comments?.adminLabel || 'admin',

--- a/packages/comments/src/parts/comment.tsx
+++ b/packages/comments/src/parts/comment.tsx
@@ -59,9 +59,9 @@ function Comment({
   }
 
   function canLike() {
-    if (!widgetContext || !widgetContext.canComment) return false;
+    if (!widgetContext || !widgetContext.canLike) return false;
     if (hasRole(currentUser, 'moderator')) return true;
-    return hasRole(currentUser, widgetContext.requiredUserRole);
+    return hasRole(currentUser, widgetContext.requiredUserLikeRole);
   }
 
   function canEdit() {
@@ -85,10 +85,10 @@ function Comment({
     const markerIcons = Array.from(document.getElementsByClassName('leaflet-marker-icon'));
     const comments = Array.from(document.getElementsByClassName('comment-item'));
     const isAlreadySelected = markerIcons[index]?.classList.contains('--highlightedIcon');
-  
+
     markerIcons.forEach((markerIcon) => markerIcon.classList.remove('--highlightedIcon'));
     comments.forEach((comment) => comment.classList.remove('selected'));
-  
+
     if (!isAlreadySelected) {
       markerIcons[index]?.classList.toggle('--highlightedIcon');
       document.getElementById(`comment-${index}`)?.classList.toggle('selected');

--- a/packages/types/project-setting-props.ts
+++ b/packages/types/project-setting-props.ts
@@ -35,6 +35,7 @@ export type ProjectSettingProps = {
     canReply: boolean,
     closedText: string;
     requiredUserRole: string,
+    requiredUserLikeRole: string,
     descriptionMinLength: number,
     descriptionMaxLength: number,
     adminLabel: string,


### PR DESCRIPTION
This allows us to differentiate between roles that can comment and that can like, for instance allowing only members to comment, and anonymous users to like.