### PR TITLE
fix: resource-form misses `general` config

### DIFF
--- a/apps/api-server/src/routes/widget/widget.js
+++ b/apps/api-server/src/routes/widget/widget.js
@@ -234,6 +234,12 @@ function setConfigsToOutput(
   widgetConfig,
   widgetId
 ) {
+  
+  // Move general settings to the root to ensure we have the correct config
+  if (widgetConfig.hasOwnProperty('general')) {
+    widgetConfig = {...widgetConfig, ...widgetConfig.general};
+  }
+  
   let config = merge.recursive(
     {},
     widgetSettings.Config,


### PR DESCRIPTION
This should be moved to the root to ensure we have the data available.