### PR TITLE
Fix map is required in resource form

### DIFF
--- a/packages/form/src/validation.tsx
+++ b/packages/form/src/validation.tsx
@@ -21,7 +21,7 @@ export const getSchemaForField = (field: CombinedFieldPropsWithType) => {
             let maxWarning = field.maxCharactersWarning || 'Tekst moet maximaal {maxCharacters} karakters bevatten';
             maxWarning = maxWarning.replace('{maxCharacters}', max.toString());
 
-            return z.string().min(min, minWarning).max(max, maxWarning);
+            return z.string().min(min, minWarning).max(max, maxWarning).optional();
 
         case 'checkbox':
             if (typeof (field.fieldRequired) !== 'undefined' && field.fieldRequired) {

--- a/packages/form/src/validation.tsx
+++ b/packages/form/src/validation.tsx
@@ -37,10 +37,19 @@ export const getSchemaForField = (field: CombinedFieldPropsWithType) => {
                 return undefined;
             }
         case 'map':
-            return z.object({
-                lat: z.number().optional(),
-                lng: z.number().optional()
-            }).refine((value) => Object.keys(value).length > 0, {message: (field.requiredWarning || 'Dit veld is verplicht')});
+            if (typeof (field.fieldRequired) !== 'undefined' && field.fieldRequired) {
+                return z.object({
+                    lat: z.number().optional(),
+                    lng: z.number().optional()
+                }).refine((value) => Object.keys(value).length > 0, {message: (field.requiredWarning || 'Dit veld is verplicht')});
+            } else {
+                return z.object({
+                    lat: z.number().optional(),
+                    lng: z.number().optional()
+                }).optional();
+            }
+
+
         case 'range':
         case 'radiobox':
         case 'select':

--- a/packages/form/src/validation.tsx
+++ b/packages/form/src/validation.tsx
@@ -37,18 +37,16 @@ export const getSchemaForField = (field: CombinedFieldPropsWithType) => {
                 return undefined;
             }
         case 'map':
+            const mapSchema = z.object({
+                lat: z.number().optional(),
+                lng: z.number().optional(),
+            });
+
             if (typeof (field.fieldRequired) !== 'undefined' && field.fieldRequired) {
-                return z.object({
-                    lat: z.number().optional(),
-                    lng: z.number().optional()
-                }).refine((value) => Object.keys(value).length > 0, {message: (field.requiredWarning || 'Dit veld is verplicht')});
-            } else {
-                return z.object({
-                    lat: z.number().optional(),
-                    lng: z.number().optional()
-                }).optional();
+                return mapSchema.refine((value) => Object.keys(value).length > 0, { message: (field.requiredWarning || 'Dit veld is verplicht') });
             }
 
+            return mapSchema.optional();
 
         case 'range':
         case 'radiobox':


### PR DESCRIPTION
Allow map to be optional. Also adds `optional` to text fields, because the min/max already handles this.