### PR TITLE
site Title

### DIFF
--- a/apps/cms-server/modules/@apostrophecms/global/index.js
+++ b/apps/cms-server/modules/@apostrophecms/global/index.js
@@ -58,6 +58,12 @@ module.exports = {
         label: 'Site titel',
       },
 
+      hideSiteTitle: {
+        type: 'boolean',
+        label: 'Verberg site titel',
+        def: true,
+      },
+
       siteLogo: {
         type: 'attachment',
         label: 'Site logo',
@@ -287,7 +293,7 @@ module.exports = {
     group: {
       basics: {
         label: 'Algemene instellingen',
-        fields: ['siteTitle', 'siteLogo', 'ctaButtons'],
+        fields: ['siteTitle', 'hideSiteTitle',  'siteLogo', 'ctaButtons'],
       },
       css: {
         label: 'Vormgeving',

--- a/apps/cms-server/views/layout.html
+++ b/apps/cms-server/views/layout.html
@@ -1,6 +1,6 @@
 {% extends data.outerLayout %}
 
-{% set title = [ data.global.projectTitle, ' - ', data.piece.title or data.page.title ] | join %}
+{% set title = [ data.global.siteTitle, ' - ', data.piece.title or data.page.title ] | join %}
 {% block title %}
 {{ title }}
 {% if not title %}


### PR DESCRIPTION
Site Title uit de global wordt nu gebruikt in het tabblad.
Voorheen als de title ingevuld was, werd deze ook standaard in de page header getoond. Dat staat nu default uit, met een optie om het aan te zetten in de global settings.  