### PR TITLE
CSP fixes

### DIFF
--- a/apps/api-server/src/routes/widget/widget.js
+++ b/apps/api-server/src/routes/widget/widget.js
@@ -306,7 +306,7 @@ function getWidgetJavascriptOutput(
         const renderedWidgets = {};
         
         const currentScript = document.currentScript;
-          currentScript.insertAdjacentHTML('afterend', \`<div id="\${randomComponentId}" style="width: 100%; height: 100%;"></div>\`);
+          currentScript.insertAdjacentHTML('afterend', \`<div id="\${randomComponentId}"></div>\`);
 
           const redirectUri = encodeURI(window.location.href);
           
@@ -314,6 +314,7 @@ function getWidgetJavascriptOutput(
           
           document.querySelector('head').innerHTML += \`
             <style>${css}</style>
+            <style>#\${randomComponentId} { width: 100%; height: 100%; }</style>
             <link href="${remixIconCss}" rel="stylesheet">
             ${extraCss}
           \`;


### PR DESCRIPTION
Add two fixes for CSP issues;

1. widget height/width was given through inline styling, now we add it to a `style` tag in the head.
2. We remove `eval` for `swr`, instead we traverse the api.