### PR TITLE
Fix resource form document upload

### DIFF
--- a/apps/image-server/.dockerignore
+++ b/apps/image-server/.dockerignore
@@ -10,6 +10,7 @@ public/uploads
 node_modules/
 .env
 .DS_Store
-*.md 
+*.md
 LICENSE
 images/
+documents/

--- a/apps/image-server/server.js
+++ b/apps/image-server/server.js
@@ -184,7 +184,7 @@ const documentMulterConfig = {
       'application/vnd.openxmlformats-officedocument.presentationml.presentation'
     ];
 
-    if (allowedTypes.indexOf(file.mimetype) === -1) {
+    if (file.mimetype && allowedTypes.indexOf(file.mimetype) === -1 && !file.mimetype.startsWith('image/')) {
       req.fileValidationError = 'goes wrong on the mimetype';
       return cb(null, false, new Error('goes wrong on the mimetype'));
     }


### PR DESCRIPTION
Dit zorgt ervoor dat er ook images geüpload mogen worden. De documents/ folder moest ook nog in de dockerignore.