### PR TITLE
allow MongoDB database name to be prefixed

### DIFF
--- a/apps/cms-server/app.js
+++ b/apps/cms-server/app.js
@@ -136,7 +136,12 @@ async function run(id, projectData, options, callback) {
   };
 
   if (process.env.MONGODB_URI) {
-    project.mongo.uri = process.env.MONGODB_URI.replace("{database}", project.shortName);
+    // Apply the MongoDB prefix (if given) to the database name,
+    // and ensure we don't exceed the MongoDB database name length limit
+    const dbPrefix = process.env.MONGODB_PREFIX ? process.env.MONGODB_PREFIX + (!process.env.MONGODB_PREFIX.endsWith('_') ? '_' : '') : '';
+    const dbName = (dbPrefix + (project.shortName)).substring(0, 63);
+    
+    project.mongo.uri = process.env.MONGODB_URI.replace("{database}", dbName);
   }
 
   const config = project;

--- a/charts/openstad-headless/templates/cms/deployment.yaml
+++ b/charts/openstad-headless/templates/cms/deployment.yaml
@@ -43,6 +43,11 @@ spec:
               secretKeyRef:
                 key: mongodbUri
                 name: {{ template "openstad.cms.secret.fullname" . }}
+          - name: MONGODB_PREFIX
+            valueFrom:
+              secretKeyRef:
+                key: mongodbPrefix
+                name: {{ template "openstad.cms.secret.fullname" . }}
           - name: CMS_DEFAULTS
             value: "{}"
           # Inject extra environment variables
@@ -58,4 +63,3 @@ spec:
         - name: data-vol
           persistentVolumeClaim:
             claimName: cms-data-claim
-

--- a/charts/openstad-headless/templates/secrets/cms-secret.yaml
+++ b/charts/openstad-headless/templates/secrets/cms-secret.yaml
@@ -9,3 +9,4 @@ metadata:
 data:
   apiKey: {{ .Values.secrets.cms.apiKey | default (randAlphaNum 32) | b64enc }}
   mongodbUri: {{ .Values.secrets.cms.mongodbUri | default (printf "%s-mongodb.%s.svc.cluster.local" .Release.Name .Release.Namespace) | b64enc }}
+  mongodbPrefix: {{ .Values.secrets.cms.mongodbPrefix | default (printf "%s_" .Release.Namespace) | b64enc }}


### PR DESCRIPTION
By setting the `MONGODB_PREFIX` env variable for the cms-server, we can define the prefix for the MongoDB database.