### PR TITLE
polygon options to different maps + preview reload fix.

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourceoverview/[id]/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourceoverview/[id]/index.tsx
@@ -27,6 +27,7 @@ import WidgetResourcesMapContent from '../../resourcesmap/[id]/content';
 import WidgetResourcesMapMap from '../../resourcesmap/[id]/map';
 import { ResourceOverviewMapWidgetTabProps } from '../../resourcesmap/[id]';
 import WidgetResourcesMapButton from '../../resourcesmap/[id]/buttons';
+import WidgetResourcesMapPolygons from '../../resourcesmap/[id]/polygons';
 import { extractConfig } from '@/lib/sub-widget-helper';
 
 export const getServerSideProps = withApiUrl;
@@ -104,6 +105,7 @@ export default function WidgetResourceOverview({ apiUrl }: WithApiUrlProps) {
                   <Tabs defaultValue="general">
                     <TabsList className="w-full bg-white border-b-0 mb-4 rounded-md h-fit flex flex-wrap overflow-auto">
                       <TabsTrigger value="general">Kaart</TabsTrigger>
+                      <TabsTrigger value="polygons">Polygonen</TabsTrigger>
                       <TabsTrigger value="buttons">knoppen</TabsTrigger>
                     </TabsList>
                     <TabsContent value="general" className="p-0">
@@ -112,7 +114,7 @@ export default function WidgetResourceOverview({ apiUrl }: WithApiUrlProps) {
                           ResourceOverviewWidgetProps,
                           ResourceOverviewMapWidgetTabProps
                         >({
-                          previewConfig,
+                          previewConfig: previewConfig,
                           subWidgetKey: 'resourceOverviewMapWidget',
                           updateConfig,
                           updatePreview,
@@ -121,6 +123,19 @@ export default function WidgetResourceOverview({ apiUrl }: WithApiUrlProps) {
                     </TabsContent>
                     <TabsContent value="buttons" className="p-0">
                       <WidgetResourcesMapButton
+                        {...extractConfig<
+                          ResourceOverviewWidgetProps,
+                          ResourceOverviewMapWidgetTabProps
+                        >({
+                          previewConfig: previewConfig,
+                          subWidgetKey: 'resourceOverviewMapWidget',
+                          updateConfig,
+                          updatePreview,
+                        })}
+                      />
+                    </TabsContent>
+                    <TabsContent value="polygons" className="p-0">
+                      <WidgetResourcesMapPolygons
                         {...extractConfig<
                           ResourceOverviewWidgetProps,
                           ResourceOverviewMapWidgetTabProps

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourcesmap/[id]/polygons.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourcesmap/[id]/polygons.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Form,
@@ -19,6 +18,7 @@ import * as z from 'zod';
 import { ResourceOverviewMapWidgetTabProps } from '.';
 import useAreas from '@/hooks/use-areas';
 import { Checkbox } from '@/components/ui/checkbox';
+import { useRouter } from 'next/router';
 
 const formSchema = z.object({
   customPolygon: z.array(z.object({ id: z.number(), name: z.string() })).optional(),
@@ -55,8 +55,10 @@ export default function WidgetResourcesMapButton(
       customPolygonUrl: props?.customPolygonUrl || []
     },
   });
+  const router = useRouter();
+  const projectId = router.query.project as string;
 
-  const { data: areas } = useAreas(props.projectId) as { data: { id: string, name: string }[] } ?? [];
+  const { data: areas } = useAreas(props.projectId === undefined ? projectId : props.projectId) as { data: { id: string, name: string }[] } ?? [];
 
   return (
     <div className="p-6 bg-white rounded-md">
@@ -85,7 +87,7 @@ export default function WidgetResourcesMapButton(
                           checked={isChecked}
                           onCheckedChange={(checked) => {
                             let values = form.getValues('customPolygon') || [];
-                            
+
                             if (checked) {
                               if (!values.some(obj => obj.id === Number(item.id))) {
                                 const { name } = item;

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourcewithmap/[id]/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourcewithmap/[id]/index.tsx
@@ -9,7 +9,7 @@ import {
 import { useRouter } from 'next/router';
 import { useWidgetConfig } from '@/hooks/use-widget-config';
 import { useWidgetPreview } from '@/hooks/useWidgetPreview';
-import { ResourceOverviewWithMapWidgetProps } from '@openstad-headless/resource-overview-with-map/src/resourceOverviewWithMap';
+import { ResourceOverviewWidgetProps } from '@openstad-headless/resource-overview/src/resource-overview';
 import WidgetPreview from '@/components/widget-preview';
 import WidgetPublish from '@/components/widget-publish';
 import {
@@ -23,11 +23,9 @@ import WidgetResourceOverviewInclude from '../../resourceoverview/[id]/include';
 import WidgetResourceOverviewPagination from '../../resourceoverview/[id]/pagination';
 import WidgetResourceOverviewSorting from '../../resourceoverview/[id]/sorting';
 import WidgetResourceOverviewTags from '../../resourceoverview/[id]/tags';
-import { EditFieldProps } from '@/lib/form-widget-helpers/EditFieldProps';
 import WidgetResourcesMapMap from '../../resourcesmap/[id]/map';
 import WidgetResourcesMapButtons from '../../resourcesmap/[id]/buttons';
-import { ResourceOverviewWidgetProps } from '@openstad-headless/resource-overview/src/resource-overview';
-import { ResourceOverviewMapWidgetProps } from '@openstad-headless/leaflet-map/src/types/resource-overview-map-widget-props';
+import WidgetResourcesMapPolygons from '../../resourcesmap/[id]/polygons';
 import { extractConfig } from '@/lib/sub-widget-helper';
 import { ResourceOverviewMapWidgetTabProps } from '../../resourcesmap/[id]';
 
@@ -39,9 +37,9 @@ export default function WidgetResourceOverview({ apiUrl }: WithApiUrlProps) {
   const projectId = router.query.project as string;
 
   const { data: widget, updateConfig } =
-    useWidgetConfig<ResourceOverviewWithMapWidgetProps>();
+    useWidgetConfig<ResourceOverviewWidgetProps>();
   const { previewConfig, updatePreview } =
-    useWidgetPreview<ResourceOverviewWithMapWidgetProps>({
+    useWidgetPreview<ResourceOverviewWidgetProps>({
       projectId,
     });
 
@@ -146,13 +144,14 @@ export default function WidgetResourceOverview({ apiUrl }: WithApiUrlProps) {
                   <Tabs defaultValue="map">
                     <TabsList className="w-full bg-white border-b-0 mb-4 rounded-md">
                       <TabsTrigger value="map">Kaart</TabsTrigger>
+                      <TabsTrigger value="polygons">Polygonen</TabsTrigger>
                       <TabsTrigger value="button">Knoppen</TabsTrigger>
                     </TabsList>
 
                     <TabsContent value="map" className="p-0">
                       <WidgetResourcesMapMap
                         {...extractConfig<
-                          ResourceOverviewWithMapWidgetProps,
+                          ResourceOverviewWidgetProps,
                           ResourceOverviewMapWidgetTabProps
                         >({
                           previewConfig,
@@ -165,7 +164,20 @@ export default function WidgetResourceOverview({ apiUrl }: WithApiUrlProps) {
                     <TabsContent value="button" className="p-0">
                       <WidgetResourcesMapButtons
                         {...extractConfig<
-                          ResourceOverviewWithMapWidgetProps,
+                          ResourceOverviewWidgetProps,
+                          ResourceOverviewMapWidgetTabProps
+                        >({
+                          previewConfig,
+                          subWidgetKey: 'resourceOverviewMapWidget',
+                          updateConfig,
+                          updatePreview,
+                        })}
+                      />
+                    </TabsContent>
+                    <TabsContent value="polygons" className="p-0">
+                      <WidgetResourcesMapPolygons
+                        {...extractConfig<
+                          ResourceOverviewWidgetProps,
                           ResourceOverviewMapWidgetTabProps
                         >({
                           previewConfig,

--- a/packages/resource-overview-with-map/src/resourceOverviewWithMap.tsx
+++ b/packages/resource-overview-with-map/src/resourceOverviewWithMap.tsx
@@ -21,7 +21,10 @@ const ResourceOverviewWithMap = (props: ResourceOverviewWithMapWidgetProps) => {
       <div className="detail-container" tabIndex={0}>
         <ResourceOverview {...props} />
       </div>
-      <ResourceOverviewMap {...props} />
+      <ResourceOverviewMap
+          {...props}
+          {...props.resourceOverviewMapWidget}
+        />
     </div>
   );
 }


### PR DESCRIPTION
- Polygonen toegevoegd aan resource overview (with map)
- resource overview with map map opties updaten niet wanneer je een wijziging deed. Dat is opgelost.