### PR TITLE
Feature/checkboxes for resource form tags

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourceform/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourceform/[id]/items.tsx
@@ -718,8 +718,7 @@ export default function WidgetResourceFormItems(
                                                     <FormMessage />
                                                 </FormItem>
                                                 )}
-                                                >
-                                            </FormField>
+                                            />
                                           </>
                                         )}
                                         {form.watch('type') !== 'none' && (

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourceform/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourceform/[id]/items.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@/components/ui/button';
 import {
     Form,
-    FormControl,
+    FormControl, FormDescription,
     FormField,
     FormItem,
     FormLabel,
@@ -647,6 +647,7 @@ export default function WidgetResourceFormItems(
                                             />
                                         )}
                                         {form.watch('type') === 'tags' && (
+                                          <>
                                             <FormField
                                                 control={form.control}
                                                 name="tags"
@@ -692,6 +693,34 @@ export default function WidgetResourceFormItems(
                                                     )
                                                 }}
                                             />
+
+                                            <FormField
+                                                control={form.control}
+                                                name="fieldType"
+                                                render={({ field }) => (
+                                                <FormItem>
+                                                    <FormLabel>Hoe wil je de tags weergeven in het formulier?</FormLabel>
+                                                    <FormDescription>De weergave heeft niet alleen invloed op het uiterlijk, maar ook op de werking. Met de keuze voor checkboxes sta je ook toe dat er meerdere tags gekozen kunnen worden.</FormDescription>
+                                                    <Select
+                                                        value={field.value}
+                                                        onValueChange={field.onChange}
+                                                    >
+                                                        <FormControl>
+                                                            <SelectTrigger>
+                                                                <SelectValue placeholder="Kies type" />
+                                                            </SelectTrigger>
+                                                        </FormControl>
+                                                        <SelectContent>
+                                                            <SelectItem value="select">Dropdown</SelectItem>
+                                                            <SelectItem value="checkbox">Checkbox</SelectItem>
+                                                        </SelectContent>
+                                                    </Select>
+                                                    <FormMessage />
+                                                </FormItem>
+                                                )}
+                                                >
+                                            </FormField>
+                                          </>
                                         )}
                                         {form.watch('type') !== 'none' && (
                                             <FormField

--- a/packages/resource-form/src/parts/init-fields.tsx
+++ b/packages/resource-form/src/parts/init-fields.tsx
@@ -58,7 +58,7 @@ export const InitializeFormFields = (items, data) => {
                         item.options.length > 0
                     ) {
                         fieldData['choices'] = item.options.map((option) => {
-                            return option.titles[0].key
+                            return { value: option.titles[0].key, label: option.titles[0].key }
                         });
                     }
                     break;
@@ -71,7 +71,7 @@ export const InitializeFormFields = (items, data) => {
                         item.options.length > 0
                     ) {
                         fieldData['choices'] = item.options.map((option) => {
-                            return option.titles[0].text
+                            return { value: (option.titles[0].key).toString(), label: option.titles[0].text }
                         });
                     }
                     break;

--- a/packages/resource-form/src/resource-form.tsx
+++ b/packages/resource-form/src/resource-form.tsx
@@ -42,7 +42,17 @@ function ResourceFormWidget(props: ResourceFormWidgetProps) {
         for (const key in formData) {
             if (formData.hasOwnProperty(key)) {
                 if (key.startsWith('tags[')) {
-                    tags.push(formData[key]);
+
+                    const tagsArray = JSON.parse(formData[key]);
+
+                    if (typeof tagsArray === 'object') {
+                        tagsArray?.map((value) => {
+                            tags.push(value);
+                        });
+                    } else if ( typeof tagsArray === 'string' || typeof tagsArray === 'number' ) {
+                        tags.push(tagsArray);
+                    }
+
                     delete formData[key];
                 }
             }

--- a/packages/ui/src/form-elements/checkbox/index.tsx
+++ b/packages/ui/src/form-elements/checkbox/index.tsx
@@ -86,7 +86,7 @@ const CheckboxField: FC<CheckboxFieldProps> = ({
                                     name={fieldKey}
                                     value={choice && choice.value}
                                     required={fieldRequired}
-                                    checked={choice && choice.value && selectedChoices.includes(choice.value)}
+                                    checked={choice && choice.value ? selectedChoices.includes(choice.value) : false}
                                     onChange={handleChoiceChange}
                                     disabled={disabled}
                                 />

--- a/packages/ui/src/form-elements/checkbox/index.tsx
+++ b/packages/ui/src/form-elements/checkbox/index.tsx
@@ -12,7 +12,7 @@ import { Spacer } from '@openstad-headless/ui/src';
 export type CheckboxFieldProps = {
     title: string;
     description?: string;
-    choices: string[];
+    choices?: string[] | [{value: string, label: string}];
     fieldRequired?: boolean;
     requiredWarning?: string;
     fieldKey: string;
@@ -50,6 +50,16 @@ const CheckboxField: FC<CheckboxFieldProps> = ({
         }
     };
 
+    if (choices) {
+        choices = choices?.map((choice) => {
+            if (typeof choice === 'string') {
+                return {value: choice, label: choice}
+            } else {
+                return choice;
+            }
+        }) as [{ value: string, label: string }];
+    }
+
     return (
         <div className="question">
             <Fieldset role="group">
@@ -74,13 +84,13 @@ const CheckboxField: FC<CheckboxFieldProps> = ({
                                     className="utrecht-form-field__input"
                                     id={`${fieldKey}_${index}`}
                                     name={fieldKey}
-                                    value={choice}
+                                    value={choice && choice.value}
                                     required={fieldRequired}
-                                    checked={selectedChoices.includes(choice)}
+                                    checked={choice && choice.value && selectedChoices.includes(choice.value)}
                                     onChange={handleChoiceChange}
                                     disabled={disabled}
                                 />
-                                <span>{choice}</span>
+                                <span>{choice && choice.label}</span>
                             </FormLabel>
                         </Paragraph>
                     </FormField>

--- a/packages/ui/src/form-elements/radio/index.tsx
+++ b/packages/ui/src/form-elements/radio/index.tsx
@@ -12,7 +12,7 @@ import { Spacer } from '@openstad-headless/ui/src';
 export type RadioboxFieldProps = {
     title: string;
     description?: string;
-    choices: string[];
+    choices?: string[] | [{value: string, label: string}];
     fieldRequired?: boolean;
     requiredWarning?: string;
     fieldKey: string;
@@ -30,6 +30,17 @@ const RadioboxField: FC<RadioboxFieldProps> = ({
     onChange,
     disabled = false,
 }) => {
+
+    if (choices) {
+        choices = choices?.map((choice) => {
+            if (typeof choice === 'string') {
+                return {value: choice, label: choice}
+            } else {
+                return choice;
+            }
+        }) as [{ value: string, label: string }];
+    }
+
     return (
         <div className="question">
             <Fieldset role="radiogroup">
@@ -57,11 +68,12 @@ const RadioboxField: FC<RadioboxFieldProps> = ({
                                     required={fieldRequired}
                                     onChange={() => onChange ? onChange({
                                         name: fieldKey,
-                                        value: choice
+                                        value: choice.value
                                     }) : null}
                                     disabled={disabled}
+                                    value={choice && choice.value}
                                 />
-                                <span>{choice}</span>
+                                <span>{choice && choice.label}</span>
                             </FormLabel>
                         </Paragraph>
                     </FormField>


### PR DESCRIPTION
Deze PR lost het volgende punt op:

> Het is bij Makelpunt gewenst om meerdere tags van 1 tag groep tegelijk te kunnen koppelen aan een resource. Daarvoor moet je nu naar de admin, waar dat als checkboxes staat. Maar dat kan beter via het resource form, zodat ze niet voor iedere resource naar de admin moeten.