### PR TITLE
direct duidelijk feedback punten

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/general.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/general.tsx
@@ -23,8 +23,6 @@ import * as Switch from '@radix-ui/react-switch';
 
 const formSchema = z.object({
   resourceId: z.string().optional(),
-  documentWidth: z.number().optional(),
-  documentHeight: z.number().optional(),
   zoom: z.number().optional(),
   minZoom: z.number().optional(),
   maxZoom: z.number().optional(),
@@ -51,8 +49,7 @@ export default function DocumentGeneral(
   const form = useForm<DocumentMapProps>({
     defaultValues: {
       resourceId: props.resourceId || undefined,
-      documentWidth: props.documentWidth || 1920,
-      documentHeight: props.documentHeight || 1080,
+
       zoom: props.zoom || 1,
       minZoom: props.minZoom || -6,
       maxZoom: props.maxZoom || 10,
@@ -134,48 +131,6 @@ export default function DocumentGeneral(
             )}
           />
         ) : null}
-
-
-        <FormField
-          control={form.control}
-          name="documentWidth"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Breedte van het document</FormLabel>
-              <FormControl>
-                <Input
-                  placeholder="1080"
-                  defaultValue={field.value}
-                  onChange={(e) => {
-                    field.onChange(e);
-                    onFieldChange(field.name, e.target.value);
-                  }}
-                />
-              </FormControl>
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={form.control}
-          name="documentHeight"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Hoogte van het document</FormLabel>
-              <FormControl>
-                <Input
-                  placeholder="1920"
-                  defaultValue={field.value}
-                  onChange={(e) => {
-                    field.onChange(e);
-                    onFieldChange(field.name, e.target.value);
-                  }}
-                />
-              </FormControl>
-            </FormItem>
-
-          )}
-        />
 
         <FormField
           control={form.control}

--- a/packages/comments/src/comments.tsx
+++ b/packages/comments/src/comments.tsx
@@ -46,7 +46,7 @@ function Comments({
   title = '[[nr]] reacties',
   sentiment = 'no sentiment',
   emptyListText = 'Nog geen reacties',
-  placeholder = 'type hier uw reactie',
+  placeholder = 'Typ hier uw reactie',
   formIntro = '',
   selectedComment,
   ...props

--- a/packages/comments/src/parts/comment-form.tsx
+++ b/packages/comments/src/parts/comment-form.tsx
@@ -13,7 +13,7 @@ function CommentForm({
   descriptionMinLength = 30,
   descriptionMaxLength = 500,
   formIntro = 'Test',
-  placeholder = 'Type hier uw reactie',
+  placeholder = 'Typ hier uw reactie',
   parentId = 0,
   activeMode = '',
   sentiment = '',

--- a/packages/comments/src/parts/comment.tsx
+++ b/packages/comments/src/parts/comment.tsx
@@ -35,6 +35,7 @@ function Comment({
   const args = {
     comment,
     selected,
+    adminLabel,
     ...props,
   } as CommentProps;
 

--- a/packages/document-map/src/document-map.css
+++ b/packages/document-map/src/document-map.css
@@ -103,6 +103,10 @@
   font-size: 14px;
 }
 
+.leaflet-fade-anim .leaflet-map-pane .leaflet-popup{
+  bottom: 10px !important; 
+}
+
 .documentMap--header {
   display: flex;
   gap: 0.5rem;

--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -56,8 +56,6 @@ function DocumentMap({
   maxZoom = 10,
   iconDefault,
   iconHighlight = 'https://cdn.pixabay.com/photo/2014/04/03/10/03/google-309740_1280.png',
-  documentWidth = 1920,
-  documentHeight = 1080,
   sentiment = 'no sentiment',
   accessibilityUrlVisible,
   definitiveUrlVisible,
@@ -90,7 +88,23 @@ function DocumentMap({
   const [popupPosition, setPopupPosition] = useState<any>(null);
   const [selectedCommentIndex, setSelectedCommentIndex] = useState<Number>();
   const [selectedMarkerIndex, setSelectedMarkerIndex] = useState<Number>();
-  const imageBounds: LatLngBoundsLiteral = [[-documentHeight, -documentWidth], [documentHeight, documentWidth]];
+
+
+  const [docWidth, setDocumentWidth] = useState<number>(1920);
+  const [docHeight, setDocumentHeight] = useState<number>(1080)
+  const imageUrl = resource.images ? resource.images[0].url : '';
+  const img = new Image();
+  img.src = imageUrl;
+  img.onload = () => {
+    const imageWidth = img.width;
+    const imageHeight = img.height;
+    setDocumentWidth(imageWidth);
+    setDocumentHeight(imageHeight);
+  };
+  const verticalOffset = docHeight * .20;
+  const imageBounds: LatLngBoundsLiteral = [[-docHeight + verticalOffset, -docWidth/2], [verticalOffset, docWidth/2]];
+
+
   const contentRef = useRef<HTMLDivElement>(null);
   const [shortLengthError, setShortLengthError] = useState(false);
   const [longLengthError, setLongLengthError] = useState(false);
@@ -119,15 +133,15 @@ function DocumentMap({
     e.preventDefault();
     e.stopPropagation();
 
-    if (value.length < 30) {
+    if (value.length < props.comments?.descriptionMinLength) {
       setShortLengthError(true);
     }
 
-    if (value.length > 500) {
+    if (value.length > props.comments?.descriptionMaxLength) {
       setLongLengthError(true);
     }
 
-    if (value.length >= 30 && value.length <= 500) {
+    if (value.length >= props.comments?.descriptionMinLength && value.length <= props.comments?.descriptionMaxLength) {
 
       comments.create({
         description: value,
@@ -174,7 +188,7 @@ function DocumentMap({
       if (status.extraFunctionality?.canComment === false) {
         setCanComment(false)
       }
-      if(status.id === Number(statusId)) {
+      if (status.id === Number(statusId)) {
         setIsDefinitive(true)
       }
     }
@@ -291,7 +305,7 @@ function DocumentMap({
         )}
       </div>
       <div className={`map-container ${!toggleMarker ? '--hideMarkers' : ''}`}>
-        <MapContainer center={[0, 0]} crs={CRS.Simple} maxZoom={maxZoom} minZoom={minZoom} zoom={zoom} >
+        <MapContainer center={[0, 0]} crs={CRS.Simple} maxZoom={maxZoom} minZoom={minZoom} zoom={zoom}  >
           <MapEvents />
           {comments
             .filter((comment: any) => !!comment.location)
@@ -316,8 +330,8 @@ function DocumentMap({
               ) :
                 <form>
                   <FormLabel htmlFor="commentBox">Voeg een opmerking toe</FormLabel>
-                  {shortLengthError && <Paragraph className="--error">De opmerking moet minimaal 30 tekens bevatten</Paragraph>}
-                  {longLengthError && <Paragraph className="--error">De opmerking mag maximaal 500 tekens bevatten</Paragraph>}
+                  {shortLengthError && <Paragraph className="--error">De opmerking moet minimaal {props.comments?.descriptionMinLength} tekens bevatten</Paragraph>}
+                  {longLengthError && <Paragraph className="--error">De opmerking mag maximaal {props.comments?.descriptionMaxLength} tekens bevatten</Paragraph>}
                   <Textarea name="comment" rows={3} id="commentBox"></Textarea>
                   <Button appearance="primary-action-button" type="submit" onClick={(e) => addComment(e, popupPosition)}>Insturen</Button>
                 </form>}

--- a/packages/document-map/src/main.tsx
+++ b/packages/document-map/src/main.tsx
@@ -16,9 +16,7 @@ const config: DocumentMapProps = {
     },
   },
   documentUrl: 'https://fastly.picsum.photos/id/48/1920/1080.jpg?hmac=r2li6k6k9q34DhZiETPlmLsPPGgOChYumNm6weWMflI',
-  documentHeight: 1080,
-  documentWidth: 1920,
-  zoom: -2,
+  zoom: 0,
   titleTekst: 'Dit is een interactief document.',
   introTekst: 'Klik op de markers om de opmerkingen te bekijken.',
 };


### PR DESCRIPTION
- De hoogte/breedte van het document wordt nu uit de afbeelding zelf gehaald. Dus deze hoef je niet meer in te stellen in de admin.
- popup iets omhoog verschoven, zodat je beter ziet waar je op geklikt hebt.
- Document wordt niet meer gecentreerd, maar probeert aan de bovenkant uit te lijnen. (Dit gaat niet altijd soepel, ligt ook aan het zoom niveau)
- Popup reactie lengte luistert nu ook naar de project instellingen.
- Reactie op reacties hebben nu ook het admin label.
- typo fix.