### PR TITLE
feat: use broader regex to allow `-`, `_` and `/`

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/settings/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/settings/index.tsx
@@ -35,8 +35,8 @@ const formSchema = z.object({
   }),
   cssUrl: z.string().optional(),
   // We don't want to restrict this URL too much
-  url: z.string().regex(/^(?:([a-z0-9.:]+))?$/g, {
-    message: 'De URL mag alleen kleine letters, cijfers en punten bevatten. Tip: gebruik geen https:// voor de URL'
+  url: z.string().regex(/^(?:([a-z0-9.:-_\/]+))?$/g, {
+    message: 'De URL mag alleen kleine letters, cijfers, punten, dubbele punten, koppeltekens, onderstrepingstekens en schuine strepen bevatten.'
   }).optional(),
   basicAuthActive: z.coerce.boolean().optional(),
 });


### PR DESCRIPTION
When creating / updating a project URL the regex was too restrictive, which didn't allow for subdirectories and dashes / underscores.