### PR TITLE
Fix k8s helm hooks getting stuck

### DIFF
--- a/charts/openstad-headless/templates/persistence-claim.yml
+++ b/charts/openstad-headless/templates/persistence-claim.yml
@@ -10,7 +10,7 @@ spec:
   storageClassName: {{ .Values.persistence.storageClassName }}
 {{- end }}
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
       storage: {{ .Values.image.volumes.data.size }}
@@ -26,7 +26,7 @@ spec:
   storageClassName: {{ .Values.persistence.storageClassName }}
 {{- end }}
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   resources:
     requests:
       storage: {{ .Values.image.volumes.data.size }}

--- a/charts/openstad-headless/templates/pre-install-job.yml
+++ b/charts/openstad-headless/templates/pre-install-job.yml
@@ -8,6 +8,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -19,6 +20,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "20"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
   - apiGroups: ['']
     resources: ['secrets']
@@ -34,6 +36,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "30"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: ''
   kind: Role
@@ -54,6 +57,7 @@ metadata:
     "helm.sh/hook-weight": "40"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  ttlSecondsAfterFinished: 10
   template:
     metadata:
       name: "{{ .Release.Name }}-batch"

--- a/charts/openstad-headless/templates/pre-install-job.yml
+++ b/charts/openstad-headless/templates/pre-install-job.yml
@@ -58,6 +58,7 @@ spec:
     metadata:
       name: "{{ .Release.Name }}-batch"
     spec:
+      ttlSecondsAfterFinished: 10
       serviceAccountName: openstad-secrets-sa
       volumes:
         - name: keys-volume

--- a/charts/openstad-headless/templates/pre-install-job.yml
+++ b/charts/openstad-headless/templates/pre-install-job.yml
@@ -8,7 +8,6 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "10"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -20,7 +19,6 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "20"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
   - apiGroups: ['']
     resources: ['secrets']
@@ -36,7 +34,6 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "30"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: ''
   kind: Role
@@ -57,7 +54,6 @@ metadata:
     "helm.sh/hook-weight": "40"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  ttlSecondsAfterFinished: 10
   template:
     metadata:
       name: "{{ .Release.Name }}-batch"

--- a/charts/openstad-headless/templates/pre-install-job.yml
+++ b/charts/openstad-headless/templates/pre-install-job.yml
@@ -20,6 +20,7 @@ metadata:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
     "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-weight": "20"
 rules:
   - apiGroups: ['']

--- a/charts/openstad-headless/templates/pre-install-job.yml
+++ b/charts/openstad-headless/templates/pre-install-job.yml
@@ -54,11 +54,11 @@ metadata:
     "helm.sh/hook-weight": "40"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  ttlSecondsAfterFinished: 10
   template:
     metadata:
       name: "{{ .Release.Name }}-batch"
     spec:
-      ttlSecondsAfterFinished: 10
       serviceAccountName: openstad-secrets-sa
       volumes:
         - name: keys-volume

--- a/charts/openstad-headless/templates/pre-install-job.yml
+++ b/charts/openstad-headless/templates/pre-install-job.yml
@@ -8,6 +8,8 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/charts/openstad-headless/templates/pre-install-job.yml
+++ b/charts/openstad-headless/templates/pre-install-job.yml
@@ -3,12 +3,6 @@ kind: ServiceAccount
 metadata:
   namespace: {{ .Release.Namespace }}
   name: openstad-secrets-sa
-  annotations:
-    # This is what defines this resource as a hook. Without this line, the
-    # job is considered part of the release.
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "10"
-    "helm.sh/hook-delete-policy": before-hook-creation
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -16,12 +10,6 @@ kind: Role
 metadata:
   namespace: {{ .Release.Namespace }}
   name: secret-creator
-  annotations:
-    # This is what defines this resource as a hook. Without this line, the
-    # job is considered part of the release.
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "20"
 rules:
   - apiGroups: ['']
     resources: ['secrets']
@@ -32,11 +20,6 @@ kind: RoleBinding
 metadata:
   name: secret-creator-role-to-openstad-secrets-sa
   namespace: {{ .Release.Namespace }}
-  annotations:
-    # This is what defines this resource as a hook. Without this line, the
-    # job is considered part of the release.
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "30"
 roleRef:
   apiGroup: ''
   kind: Role
@@ -50,12 +33,6 @@ kind: Job
 metadata:
   name: "{{ .Release.Name }}"
   namespace: {{ .Release.Namespace }}
-  annotations:
-    # This is what defines this resource as a hook. Without this line, the
-    # job is considered part of the release.
-    "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "40"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   ttlSecondsAfterFinished: 10
   template:

--- a/charts/openstad-headless/templates/pre-install-job.yml
+++ b/charts/openstad-headless/templates/pre-install-job.yml
@@ -33,6 +33,12 @@ kind: Job
 metadata:
   name: "{{ .Release.Name }}"
   namespace: {{ .Release.Namespace }}
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "40"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   ttlSecondsAfterFinished: 10
   template:

--- a/charts/openstad-headless/templates/secrets/admin-secret.yaml
+++ b/charts/openstad-headless/templates/secrets/admin-secret.yaml
@@ -7,7 +7,6 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
     "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 type: Opaque
 data:
   cookieSecret: {{ .Values.admin.secrets.cookieSecret | default (randAlphaNum 32) | b64enc }}

--- a/charts/openstad-headless/templates/secrets/admin-secret.yaml
+++ b/charts/openstad-headless/templates/secrets/admin-secret.yaml
@@ -4,9 +4,6 @@ kind: Secret
 metadata:
   name: {{ template "openstad.admin.secret.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/resource-policy": keep
-    "helm.sh/hook": "pre-install"
 type: Opaque
 data:
   cookieSecret: {{ .Values.admin.secrets.cookieSecret | default (randAlphaNum 32) | b64enc }}

--- a/charts/openstad-headless/templates/secrets/database.yaml
+++ b/charts/openstad-headless/templates/secrets/database.yaml
@@ -7,7 +7,6 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
     "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
   type: {{ .Values.secrets.database.type | default "mysql" | b64enc }}
   database: {{ .Values.secrets.database.dbName | default "mysql" | b64enc }}

--- a/charts/openstad-headless/templates/secrets/database.yaml
+++ b/charts/openstad-headless/templates/secrets/database.yaml
@@ -4,9 +4,6 @@ kind: Secret
 metadata:
   name: openstad-db-credentials
   namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/resource-policy": keep
-    "helm.sh/hook": "pre-install"
 data:
   type: {{ .Values.secrets.database.type | default "mysql" | b64enc }}
   database: {{ .Values.secrets.database.dbName | default "mysql" | b64enc }}

--- a/charts/openstad-headless/templates/secrets/database.yaml
+++ b/charts/openstad-headless/templates/secrets/database.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
     "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 data:
   type: {{ .Values.secrets.database.type | default "mysql" | b64enc }}
   database: {{ .Values.secrets.database.dbName | default "mysql" | b64enc }}

--- a/charts/openstad-headless/templates/secrets/database.yaml
+++ b/charts/openstad-headless/templates/secrets/database.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
     "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
   type: {{ .Values.secrets.database.type | default "mysql" | b64enc }}
   database: {{ .Values.secrets.database.dbName | default "mysql" | b64enc }}

--- a/charts/openstad-headless/templates/secrets/email-secret.yaml
+++ b/charts/openstad-headless/templates/secrets/email-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
     "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 type: Opaque
 data:
   host: {{ .Values.secrets.mail.host | b64enc }}

--- a/charts/openstad-headless/templates/secrets/email-secret.yaml
+++ b/charts/openstad-headless/templates/secrets/email-secret.yaml
@@ -4,9 +4,6 @@ kind: Secret
 metadata:
   name: {{ template "openstad.email.secret.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/resource-policy": keep
-    "helm.sh/hook": "pre-install"
 type: Opaque
 data:
   host: {{ .Values.secrets.mail.host | b64enc }}

--- a/charts/openstad-headless/templates/secrets/email-secret.yaml
+++ b/charts/openstad-headless/templates/secrets/email-secret.yaml
@@ -7,7 +7,6 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
     "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 type: Opaque
 data:
   host: {{ .Values.secrets.mail.host | b64enc }}

--- a/charts/openstad-headless/templates/secrets/email-secret.yaml
+++ b/charts/openstad-headless/templates/secrets/email-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
     "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 type: Opaque
 data:
   host: {{ .Values.secrets.mail.host | b64enc }}

--- a/charts/openstad-headless/templates/secrets/image-secret.yaml
+++ b/charts/openstad-headless/templates/secrets/image-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
     "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 type: Opaque
 data:
   verificationToken: {{ .Values.image.secrets.verificationToken | default (randAlphaNum 32) | b64enc }}

--- a/charts/openstad-headless/templates/secrets/image-secret.yaml
+++ b/charts/openstad-headless/templates/secrets/image-secret.yaml
@@ -4,9 +4,6 @@ kind: Secret
 metadata:
   name: {{ template "openstad.image.secret.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/resource-policy": keep
-    "helm.sh/hook": "pre-install"
 type: Opaque
 data:
   verificationToken: {{ .Values.image.secrets.verificationToken | default (randAlphaNum 32) | b64enc }}

--- a/charts/openstad-headless/templates/secrets/image-secret.yaml
+++ b/charts/openstad-headless/templates/secrets/image-secret.yaml
@@ -7,7 +7,6 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
     "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 type: Opaque
 data:
   verificationToken: {{ .Values.image.secrets.verificationToken | default (randAlphaNum 32) | b64enc }}

--- a/charts/openstad-headless/templates/secrets/image-secret.yaml
+++ b/charts/openstad-headless/templates/secrets/image-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
     "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 type: Opaque
 data:
   verificationToken: {{ .Values.image.secrets.verificationToken | default (randAlphaNum 32) | b64enc }}

--- a/charts/openstad-headless/templates/secrets/mysql-secret.yaml
+++ b/charts/openstad-headless/templates/secrets/mysql-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
     "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
   mysql-root-password: {{ .Values.secrets.database.rootPassword | default ( randAlphaNum 12 ) | b64enc }}
   mysql-replication-password: {{ .Values.secrets.database.replicationPassword | default ( randAlphaNum 12 ) | b64enc }}

--- a/charts/openstad-headless/templates/secrets/mysql-secret.yaml
+++ b/charts/openstad-headless/templates/secrets/mysql-secret.yaml
@@ -10,4 +10,4 @@ metadata:
 data:
   mysql-root-password: {{ .Values.secrets.database.rootPassword | default ( randAlphaNum 12 ) | b64enc }}
   mysql-replication-password: {{ .Values.secrets.database.replicationPassword | default ( randAlphaNum 12 ) | b64enc }}
-  mysql-password: {{ .Values.mysql.db.password | default ( randAlphaNum 12 ) | b64enc }}
+  mysql-password: {{ .Values.secrets.database.password | default ( randAlphaNum 12 ) | b64enc }}

--- a/charts/openstad-headless/templates/secrets/mysql-secret.yaml
+++ b/charts/openstad-headless/templates/secrets/mysql-secret.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
     "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 data:
   mysql-root-password: {{ .Values.secrets.database.rootPassword | default ( randAlphaNum 12 ) | b64enc }}
   mysql-replication-password: {{ .Values.secrets.database.replicationPassword | default ( randAlphaNum 12 ) | b64enc }}

--- a/charts/openstad-headless/templates/secrets/mysql-secret.yaml
+++ b/charts/openstad-headless/templates/secrets/mysql-secret.yaml
@@ -4,9 +4,6 @@ kind: Secret
 metadata:
   name: mysql-secret
   namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/resource-policy": keep
-    "helm.sh/hook": "pre-install"
 data:
   mysql-root-password: {{ .Values.secrets.database.rootPassword | default ( randAlphaNum 12 ) | b64enc }}
   mysql-replication-password: {{ .Values.secrets.database.replicationPassword | default ( randAlphaNum 12 ) | b64enc }}

--- a/charts/openstad-headless/templates/secrets/mysql-secret.yaml
+++ b/charts/openstad-headless/templates/secrets/mysql-secret.yaml
@@ -7,7 +7,6 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
     "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
   mysql-root-password: {{ .Values.secrets.database.rootPassword | default ( randAlphaNum 12 ) | b64enc }}
   mysql-replication-password: {{ .Values.secrets.database.replicationPassword | default ( randAlphaNum 12 ) | b64enc }}

--- a/charts/openstad-headless/templates/secrets/session.yaml
+++ b/charts/openstad-headless/templates/secrets/session.yaml
@@ -4,8 +4,5 @@ kind: Secret
 metadata:
   name: openstad-session-secret
   namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/resource-policy": keep
-    "helm.sh/hook": "pre-install"
 data:
   secret: {{ ( randAlphaNum 12 ) | b64enc }}

--- a/charts/openstad-headless/templates/secrets/session.yaml
+++ b/charts/openstad-headless/templates/secrets/session.yaml
@@ -7,6 +7,6 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
     "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 data:
   secret: {{ ( randAlphaNum 12 ) | b64enc }}

--- a/charts/openstad-headless/templates/secrets/session.yaml
+++ b/charts/openstad-headless/templates/secrets/session.yaml
@@ -5,4 +5,4 @@ metadata:
   name: openstad-session-secret
   namespace: {{ .Release.Namespace }}
 data:
-  secret: {{ ( randAlphaNum 12 ) | b64enc }}
+  secret: {{ .Values.secrets.auth.sessionSecret | default ( randAlphaNum 12 ) | b64enc }}

--- a/charts/openstad-headless/templates/secrets/session.yaml
+++ b/charts/openstad-headless/templates/secrets/session.yaml
@@ -7,6 +7,5 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
     "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
   secret: {{ ( randAlphaNum 12 ) | b64enc }}

--- a/charts/openstad-headless/templates/secrets/session.yaml
+++ b/charts/openstad-headless/templates/secrets/session.yaml
@@ -7,6 +7,6 @@ metadata:
   annotations:
     "helm.sh/resource-policy": keep
     "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 data:
   secret: {{ ( randAlphaNum 12 ) | b64enc }}

--- a/charts/openstad-headless/values.yaml
+++ b/charts/openstad-headless/values.yaml
@@ -476,6 +476,9 @@ secrets:
   api:
     jwtSecret:
 
+  auth:
+    sessionSecret:
+
   cms:
     apiKey:
     mongodbUri:

--- a/operations/deployments/openstad-headless/environments/acc/images.yml
+++ b/operations/deployments/openstad-headless/environments/acc/images.yml
@@ -1,15 +1,15 @@
 admin:
   deploymentContainer:
-    image: ghcr.io/openstad/admin-server:main-b4d6786
+    image: ghcr.io/openstad/admin-server:main-10f3e2d
 api:
   deploymentContainer:
-    image: ghcr.io/openstad/api-server:main-b4d6786
+    image: ghcr.io/openstad/api-server:main-10f3e2d
 auth:
   deploymentContainer:
-    image: ghcr.io/openstad/auth-server:main-b4d6786
+    image: ghcr.io/openstad/auth-server:main-10f3e2d
 image:
   deploymentContainer:
-    image: ghcr.io/openstad/image-server:main-b4d6786
+    image: ghcr.io/openstad/image-server:main-10f3e2d
 cms:
   deploymentContainer:
-    image: ghcr.io/openstad/cms-server:main-b4d6786
+    image: ghcr.io/openstad/cms-server:main-10f3e2d

--- a/operations/deployments/openstad-headless/environments/acc/images.yml
+++ b/operations/deployments/openstad-headless/environments/acc/images.yml
@@ -1,15 +1,15 @@
 admin:
   deploymentContainer:
-    image: ghcr.io/openstad/admin-server:main-10f3e2d
+    image: ghcr.io/openstad/admin-server:main-b4d6786
 api:
   deploymentContainer:
-    image: ghcr.io/openstad/api-server:main-10f3e2d
+    image: ghcr.io/openstad/api-server:main-b4d6786
 auth:
   deploymentContainer:
-    image: ghcr.io/openstad/auth-server:main-10f3e2d
+    image: ghcr.io/openstad/auth-server:main-b4d6786
 image:
   deploymentContainer:
-    image: ghcr.io/openstad/image-server:main-10f3e2d
+    image: ghcr.io/openstad/image-server:main-b4d6786
 cms:
   deploymentContainer:
-    image: ghcr.io/openstad/cms-server:main-10f3e2d
+    image: ghcr.io/openstad/cms-server:main-b4d6786


### PR DESCRIPTION
Dit lost het probleem op met ArgoCD waarin de hooks van de secrets blijven hangen bij deployment. Ook worden de PVCs op ReadWriteMany gezet, zodat we bij alle deployments 'RollingUpdate' kunnen gebruiken.