### PR TITLE
Feat/deventer general fixes

### DIFF
--- a/apps/admin-server/src/lib/export-helpers/csv-export.tsx
+++ b/apps/admin-server/src/lib/export-helpers/csv-export.tsx
@@ -1,4 +1,27 @@
-export const exportDataToCSV = (data: any, widgetName: string) => {
+export const exportDataToCSV = (data: any, widgetName: string, selectedWidget: any) => {
+
+  if ( selectedWidget && selectedWidget?.config && selectedWidget?.config?.items ) {
+
+    const fieldKeyToTitleMap = selectedWidget?.config?.items.reduce((acc: any, item: any) => {
+      acc[item.fieldKey] = item.title;
+      return acc;
+    }, {});
+
+    data = data.map((row: any) => {
+      const updatedSubmittedData = Object.keys(row?.submittedData).reduce((acc: any, key: any) => {
+        const newKey = fieldKeyToTitleMap[key] || key;
+        acc[newKey] = row?.submittedData[key];
+        return acc;
+      }, {});
+
+      return {
+        ...row,
+        submittedData: updatedSubmittedData
+      };
+    });
+
+  }
+
   function transformString() {
     widgetName = widgetName.replace(/\s+/g, '-').toLowerCase();
     widgetName = widgetName.replace(/[^a-z0-9-]/g, '');

--- a/apps/admin-server/src/pages/projects/[project]/submissions/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/submissions/index.tsx
@@ -59,7 +59,7 @@ export default function ProjectSubmissions() {
 
   const selectClick = (value: any) => {
     const ID = value !== "0" ? value?.split(" - ")[0] : "0";
-    const filteredData = ID === "0" ? data : data?.filter((submission: any) => (submission.widgetId).toString() === ID);
+    const filteredData = ID === "0" ? data : data?.filter((submission: any) => (submission.widgetId || 0).toString() === ID);
 
     setFilterData(filteredData);
     setActiveWidget(value);

--- a/apps/admin-server/src/pages/projects/[project]/submissions/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/submissions/index.tsx
@@ -24,6 +24,8 @@ export default function ProjectSubmissions() {
   const [activeWidget, setActiveWidget] = useState("0");
   const [allWidgets, setAllWidgets] = useState<{ id: number; name: string }[]>([]);
 
+  const [selectedWidget, setSelectedWidget] = useState<any>(null);
+
   useEffect(() => {
     let loadedSubmissions = (data || []) as { createdAt: string }[];
 
@@ -63,6 +65,9 @@ export default function ProjectSubmissions() {
 
     setFilterData(filteredData);
     setActiveWidget(value);
+
+    const selectedWidget = widgetData.find((widget: any) => widget.id.toString() === ID);
+    setSelectedWidget(selectedWidget);
   }
 
   if (!data) return null;
@@ -104,7 +109,7 @@ export default function ProjectSubmissions() {
             <Button
               className="text-xs p-2"
               type="submit"
-              onClick={() => exportDataToCSV(filterData, activeWidget)}
+              onClick={() => exportDataToCSV(filterData, activeWidget, selectedWidget)}
               disabled={activeWidget === "0"}
             >
               Exporteer inzendingen .csv

--- a/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/display.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/display.tsx
@@ -64,7 +64,7 @@ export default function WidgetEnqueteDisplay(
             name="displayDescription"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Enquête bechrijving weergeven</FormLabel>
+                <FormLabel>Enquête beschrijving weergeven</FormLabel>
                 {YesNoSelect(field, props)}
                 <FormMessage />
               </FormItem>

--- a/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/items.tsx
@@ -74,6 +74,7 @@ export default function WidgetEnqueteItems(
   const [selectedOption, setOption] = useState<Option | null>(null);
   const [settingOptions, setSettingOptions] = useState<boolean>(false);
   const [file, setFile] = useState<File>();
+  const [isFieldKeyUnique, setIsFieldKeyUnique] = useState(true);
 
   // adds item to items array if no item is selected, otherwise updates the selected item
   async function onSubmit(values: FormData) {
@@ -326,6 +327,18 @@ export default function WidgetEnqueteItems(
     setSettingOptions(false);
   }
 
+  useEffect(() => {
+    const key = form.watch("fieldKey");
+
+    if (key) {
+      const isUnique = items.every((item) =>
+        (selectedItem && item.trigger === selectedItem.trigger) || item.fieldKey !== key
+      );
+
+      setIsFieldKeyUnique(isUnique);
+    }
+  }, [form.watch("fieldKey"), selectedItem]);
+
   return (
     <div>
       <Form {...form}>
@@ -566,7 +579,11 @@ export default function WidgetEnqueteItems(
                             </FormLabel>
                             <em className='text-xs'>Deze moet uniek zijn bijvoorbeeld: ‘samenvatting’</em>
                             <Input {...field} />
-                            <FormMessage />
+                            {(!field.value || !isFieldKeyUnique) && (
+                              <FormMessage>
+                                { !field.value ? 'Key is verplicht' : 'Key moet uniek zijn' }
+                              </FormMessage>
+                            )}
                           </FormItem>
                         )}
                       />
@@ -901,29 +918,39 @@ export default function WidgetEnqueteItems(
                     )}
                   </div>
                 </div>
-                <div className="flex gap-2">
-                  {selectedItem && (
+
+                <div>
+                  <div className="flex gap-2">
+                    {selectedItem && (
+                      <Button
+                        className="w-fit mt-4 bg-secondary text-black hover:text-white"
+                        type="button"
+                        onClick={() => {
+                          resetForm();
+                        }}>
+                        Annuleer
+                      </Button>
+                    )}
+
                     <Button
-                      className="w-fit mt-4 bg-secondary text-black hover:text-white"
-                      type="button"
-                      onClick={() => {
-                        resetForm();
-                      }}>
-                      Annuleer
+                      className="w-fit mt-4"
+                      type="submit"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        onSubmit(form.getValues())
+                      }}
+                      disabled={(!form.watch('fieldKey') || !isFieldKeyUnique) && form.watch('questionType') !== 'none'}
+                    >
+                      {selectedItem
+                        ? 'Sla wijzigingen op'
+                        : 'Voeg item toe aan lijst'}
                     </Button>
+                  </div>
+                  {(!form.watch('fieldKey') || !isFieldKeyUnique) && (
+                    <FormMessage>
+                      { !form.watch('fieldKey') ? 'Key is verplicht' : 'Key moet uniek zijn' }
+                    </FormMessage>
                   )}
-                  <Button
-                    className="w-fit mt-4"
-                    type="submit"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      onSubmit(form.getValues())
-                    }}
-                  >
-                    {selectedItem
-                      ? 'Sla wijzigingen op'
-                      : 'Voeg item toe aan lijst'}
-                  </Button>
                 </div>
               </div>
             )}

--- a/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/items.tsx
@@ -2,7 +2,7 @@ import { ImageUploader } from '@/components/image-uploader';
 import { Button } from '@/components/ui/button';
 import {
   Form,
-  FormControl,
+  FormControl, FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -60,6 +60,8 @@ const formSchema = z.object({
   imageAlt: z.string().optional(),
   imageDescription: z.string().optional(),
   imageUpload: z.string().optional(),
+  fieldRequired: z.boolean().optional(),
+  showSmileys: z.boolean().optional(),
 });
 
 export default function WidgetEnqueteItems(
@@ -109,6 +111,8 @@ export default function WidgetEnqueteItems(
           image: values.image || '',
           imageAlt: values.imageAlt || '',
           imageDescription: values.imageDescription || '',
+          fieldRequired: values.fieldRequired || false,
+          showSmileys: values.showSmileys || false,
         },
       ]);
     }
@@ -167,7 +171,9 @@ export default function WidgetEnqueteItems(
     multiple: false,
     image: '',
     imageAlt: '',
-    imageDescription: ''
+    imageDescription: '',
+    fieldRequired: false,
+    showSmileys: false,
   });
 
   const form = useForm<FormData>({
@@ -209,6 +215,8 @@ export default function WidgetEnqueteItems(
         image: selectedItem.image || '',
         imageAlt: selectedItem.imageAlt || '',
         imageDescription: selectedItem.imageDescription || '',
+        fieldRequired: selectedItem.fieldRequired || false,
+        showSmileys: selectedItem.showSmileys || false,
       });
       setOptions(selectedItem.options || []);
     }
@@ -813,6 +821,65 @@ export default function WidgetEnqueteItems(
                               <SelectContent>
                                 <SelectItem value="true">Ja</SelectItem>
                                 <SelectItem value="false">Nee</SelectItem>
+                              </SelectContent>
+                            </Select>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    )}
+
+                    <FormField
+                      control={form.control}
+                      name="fieldRequired"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>
+                            Is dit veld verplicht?
+                          </FormLabel>
+                          <Select
+                            onValueChange={(e: string) => field.onChange(e === 'true')}
+                            value={field.value ? 'true' : 'false'}
+                          >
+                            <FormControl>
+                              <SelectTrigger>
+                                <SelectValue placeholder="Kies een optie" />
+                              </SelectTrigger>
+                            </FormControl>
+                            <SelectContent>
+                              <SelectItem value="false">Nee</SelectItem>
+                              <SelectItem value="true">Ja</SelectItem>
+                            </SelectContent>
+                          </Select>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    {form.watch('questionType') === 'scale' && (
+                      <FormField
+                        control={form.control}
+                        name="showSmileys"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>
+                              Wil je smileys tonen in plaats van een schaal?
+                            </FormLabel>
+                            <FormDescription>
+                              De schaal toont normaal gesproken een getal van 1 tot 5. Als je smileys wilt tonen, kies dan voor ja.
+                            </FormDescription>
+                            <Select
+                              onValueChange={(e: string) => field.onChange(e === 'true')}
+                              value={field.value ? 'true' : 'false'}
+                            >
+                              <FormControl>
+                                <SelectTrigger>
+                                  <SelectValue placeholder="Kies een optie" />
+                                </SelectTrigger>
+                              </FormControl>
+                              <SelectContent>
+                                <SelectItem value="false">Nee</SelectItem>
+                                <SelectItem value="true">Ja</SelectItem>
                               </SelectContent>
                             </Select>
                             <FormMessage />

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourceform/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourceform/[id]/items.tsx
@@ -70,6 +70,7 @@ export default function WidgetResourceFormItems(
     const [selectedOption, setOption] = useState<Option | null>(null);
     const [settingOptions, setSettingOptions] = useState<boolean>(false);
     const [file, setFile] = useState<File>();
+    const [isFieldKeyUnique, setIsFieldKeyUnique] = useState(true);
 
     const router = useRouter();
     const { project } = router.query;
@@ -334,6 +335,18 @@ export default function WidgetResourceFormItems(
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [form.watch("type")]);
+
+    useEffect(() => {
+        const key = form.watch("fieldKey");
+
+        if (key) {
+            const isUnique = items.every((item) =>
+              (selectedItem && item.trigger === selectedItem.trigger) || item.fieldKey !== key
+            );
+
+            setIsFieldKeyUnique(isUnique);
+        }
+    }, [form.watch("fieldKey"), selectedItem]);
 
     return (
         <div>
@@ -640,7 +653,11 @@ export default function WidgetResourceFormItems(
                                                             <em className='text-xs'>Deze moet uniek zijn bijvoorbeeld: ‘samenvatting’</em>
 
                                                             <Input {...field} disabled={!!fieldKey} />
-                                                            <FormMessage />
+                                                            {(!field.value || !isFieldKeyUnique) && (
+                                                              <FormMessage>
+                                                                  { !field.value ? 'Key is verplicht' : 'Key moet uniek zijn' }
+                                                              </FormMessage>
+                                                            )}
                                                         </FormItem>
                                                     )
                                                 }}
@@ -887,22 +904,34 @@ export default function WidgetResourceFormItems(
                                         )}
                                     </div>
                                 </div>
-                                <div className="flex gap-2">
-                                    {selectedItem && (
+
+                                <div>
+                                    <div className="flex gap-2">
+                                        {selectedItem && (
+                                            <Button
+                                                className="w-fit mt-4 bg-secondary text-black hover:text-white"
+                                                type="button"
+                                                onClick={() => {
+                                                    resetForm();
+                                                }}>
+                                                Annuleer
+                                            </Button>
+                                        )}
                                         <Button
-                                            className="w-fit mt-4 bg-secondary text-black hover:text-white"
-                                            type="button"
-                                            onClick={() => {
-                                                resetForm();
-                                            }}>
-                                            Annuleer
+                                            className="w-fit mt-4"
+                                            type="submit"
+                                            disabled={(form.watch('type') === 'tags' && allTags.length === 0) || ((!form.watch('fieldKey') || !isFieldKeyUnique) && form.watch('type') !== 'none')}
+                                        >
+                                            {selectedItem
+                                                ? 'Sla wijzigingen op'
+                                                : 'Voeg item toe aan lijst'}
                                         </Button>
+                                    </div>
+                                    {(!form.watch('fieldKey') || !isFieldKeyUnique) && (
+                                      <FormMessage>
+                                          { !form.watch('fieldKey') ? 'Key is verplicht' : 'Key moet uniek zijn' }
+                                      </FormMessage>
                                     )}
-                                    <Button className="w-fit mt-4" type="submit" disabled={form.watch('type') === 'tags' && allTags.length === 0}>
-                                        {selectedItem
-                                            ? 'Sla wijzigingen op'
-                                            : 'Voeg item toe aan lijst'}
-                                    </Button>
                                 </div>
                             </div>
                         )}

--- a/apps/cms-server/modules/asset/ui/src/index.scss
+++ b/apps/cms-server/modules/asset/ui/src/index.scss
@@ -7,3 +7,4 @@
 @import './scss/_welcome';
 @import './scss/_widgets';
 @import './scss/_news';
+@import './scss/_custom-modal';

--- a/apps/cms-server/modules/asset/ui/src/scss/_custom-modal.scss
+++ b/apps/cms-server/modules/asset/ui/src/scss/_custom-modal.scss
@@ -1,0 +1,17 @@
+html #apos-modals .apos-modal__overlay + .apos-modal__inner {
+    .apos-link-control__dialog {
+        left: auto;
+        right: -15px;
+    }
+
+    .apos-link-control__dialog .apos-context-menu__tip {
+        left: auto;
+        right: 20px;
+    }
+
+    &,
+    .apos-modal__main,
+    .apos-modal__main .apos-modal__body {
+        overflow: visible;
+    }
+}

--- a/apps/cms-server/modules/asset/ui/src/scss/_custom-modal.scss
+++ b/apps/cms-server/modules/asset/ui/src/scss/_custom-modal.scss
@@ -1,17 +1,17 @@
 html #apos-modals .apos-modal__overlay + .apos-modal__inner {
     .apos-link-control__dialog {
         left: auto;
-        right: -15px;
+        right: -90px;
     }
 
-    .apos-link-control__dialog .apos-context-menu__tip {
-        left: auto;
-        right: 20px;
-    }
+    .apos-link-control__dialog {
+        .apos-context-menu__tip {
+            left: auto;
+            right: 90px;
+        }
 
-    &,
-    .apos-modal__main,
-    .apos-modal__main .apos-modal__body {
-        overflow: visible;
+        .apos-context-menu__dialog {
+            width: 380px
+        }
     }
 }

--- a/apps/cms-server/modules/openstad-rte-widget/index.js
+++ b/apps/cms-server/modules/openstad-rte-widget/index.js
@@ -1,43 +1,40 @@
-// TODO: Onderstaande code zou ervoor moeten zorgen dat de toolbar in de rich-text editor werkt, maar dat doet het niet.
-//  Door de code uit te zetten werkt de toolbar wel in de modal. Het lijkt mij wel wenselijk dat je ook buiten de modal de toolbar kan gebruiken.
-
-// const contentWidgets = {
-//   '@apostrophecms/rich-text': {
-//     toolbar: [
-//       'styles',
-//       '|',
-//       'bold',
-//       'italic',
-//       'strike',
-//       'link',
-//       '|',
-//       'bulletList',
-//       'orderedList'
-//     ],
-//     styles: [
-//       {
-//         tag: 'p',
-//         label: 'Paragraph (P)',
-//       },
-//       {
-//         tag: 'h1',
-//         label: 'Heading 1 (H1)',
-//       },
-//       {
-//         tag: 'h2',
-//         label: 'Heading 2 (H2)',
-//       },
-//       {
-//         tag: 'h3',
-//         label: 'Heading 3 (H3)',
-//       },
-//       {
-//         tag: 'h4',
-//         label: 'Heading 4 (H4)',
-//       }
-//     ]
-//   }
-// };
+const contentWidgets = {
+  '@apostrophecms/rich-text': {
+    toolbar: [
+      'styles',
+      '|',
+      'bold',
+      'italic',
+      'strike',
+      'link',
+      '|',
+      'bulletList',
+      'orderedList'
+    ],
+    styles: [
+      {
+        tag: 'p',
+        label: 'Paragraph (P)',
+      },
+      {
+        tag: 'h1',
+        label: 'Heading 1 (H1)',
+      },
+      {
+        tag: 'h2',
+        label: 'Heading 2 (H2)',
+      },
+      {
+        tag: 'h3',
+        label: 'Heading 3 (H3)',
+      },
+      {
+        tag: 'h4',
+        label: 'Heading 4 (H4)',
+      }
+    ]
+  }
+};
 
 module.exports = {
   extend: '@apostrophecms/widget-type',
@@ -49,13 +46,7 @@ module.exports = {
       text: {
         type: 'area',
         options: {
-
-          // TODO: De todo van boven heeft deze code nodig
-          // widgets: contentWidgets,
-
-          widgets: {
-            '@apostrophecms/rich-text': {}
-          }
+          widgets: contentWidgets,
         },
         max: 1
       },

--- a/apps/cms-server/modules/openstad-rte-widget/index.js
+++ b/apps/cms-server/modules/openstad-rte-widget/index.js
@@ -1,40 +1,43 @@
-const contentWidgets = {
-  '@apostrophecms/rich-text': {
-    toolbar: [
-      'styles',
-      '|',
-      'bold',
-      'italic',
-      'strike',
-      'link',
-      '|',
-      'bulletList',
-      'orderedList'
-    ],
-    styles: [
-      {
-        tag: 'p',
-        label: 'Paragraph (P)',
-      },
-      {
-        tag: 'h1',
-        label: 'Heading 1 (H1)',
-      },
-      {
-        tag: 'h2',
-        label: 'Heading 2 (H2)',
-      },
-      {
-        tag: 'h3',
-        label: 'Heading 3 (H3)',
-      },
-      {
-        tag: 'h4',
-        label: 'Heading 4 (H4)',
-      }
-    ]
-  }
-};
+// TODO: Onderstaande code zou ervoor moeten zorgen dat de toolbar in de rich-text editor werkt, maar dat doet het niet.
+//  Door de code uit te zetten werkt de toolbar wel in de modal. Het lijkt mij wel wenselijk dat je ook buiten de modal de toolbar kan gebruiken.
+
+// const contentWidgets = {
+//   '@apostrophecms/rich-text': {
+//     toolbar: [
+//       'styles',
+//       '|',
+//       'bold',
+//       'italic',
+//       'strike',
+//       'link',
+//       '|',
+//       'bulletList',
+//       'orderedList'
+//     ],
+//     styles: [
+//       {
+//         tag: 'p',
+//         label: 'Paragraph (P)',
+//       },
+//       {
+//         tag: 'h1',
+//         label: 'Heading 1 (H1)',
+//       },
+//       {
+//         tag: 'h2',
+//         label: 'Heading 2 (H2)',
+//       },
+//       {
+//         tag: 'h3',
+//         label: 'Heading 3 (H3)',
+//       },
+//       {
+//         tag: 'h4',
+//         label: 'Heading 4 (H4)',
+//       }
+//     ]
+//   }
+// };
 
 module.exports = {
   extend: '@apostrophecms/widget-type',
@@ -46,7 +49,13 @@ module.exports = {
       text: {
         type: 'area',
         options: {
-          widgets: contentWidgets,
+
+          // TODO: De todo van boven heeft deze code nodig
+          // widgets: contentWidgets,
+
+          widgets: {
+            '@apostrophecms/rich-text': {}
+          }
         },
         max: 1
       },

--- a/packages/enquete/src/enquete.tsx
+++ b/packages/enquete/src/enquete.tsx
@@ -68,6 +68,7 @@ function Enquete(props: EnqueteWidgetProps) {
                 description: item.description,
                 fieldKey: item.fieldKey,
                 disabled: !hasRole(currentUser, 'member') && formOnlyVisibleForUsers,
+                fieldRequired: item.fieldRequired,
             };
 
             switch (item.questionType) {
@@ -115,13 +116,23 @@ function Enquete(props: EnqueteWidgetProps) {
                     break;
                 case 'scale':
                     fieldData['type'] = 'tickmark-slider';
-                    fieldData['fieldOptions'] = [
-                        { value: '1', label: 1 },
-                        { value: '2', label: 2 },
-                        { value: '3', label: 3 },
-                        { value: '4', label: 4 },
-                        { value: '5', label: 5 },
-                    ];
+                    fieldData['showSmileys'] = item.showSmileys;
+
+                    const labelOptions = [
+                      <Icon icon="ri-emotion-unhappy-line" key={1} />,
+                      <Icon icon="ri-emotion-sad-line" key={2} />,
+                      <Icon icon="ri-emotion-normal-line" key={3} />,
+                      <Icon icon="ri-emotion-happy-line" key={4} />,
+                      <Icon icon="ri-emotion-laugh-line" key={5} />
+                    ]
+
+                    fieldData['fieldOptions'] = labelOptions.map((label, index) => {
+                        const currentValue = index + 1;
+                          return {
+                            value: currentValue,
+                            label: item.showSmileys ? label : currentValue,
+                          }
+                        });
                     break;
                 case 'none':
                     fieldData['type'] = 'none';

--- a/packages/enquete/src/types/enquete-props.ts
+++ b/packages/enquete/src/types/enquete-props.ts
@@ -33,6 +33,8 @@ export type Item = {
   image?: string;
   imageAlt?: string;
   imageDescription?: string;
+  fieldRequired?: boolean;
+  showSmileys?: boolean;
 };
 
 export type Option = {

--- a/packages/ui/src/form-elements/tickmark-slider/index.tsx
+++ b/packages/ui/src/form-elements/tickmark-slider/index.tsx
@@ -1,6 +1,7 @@
 import { FormLabel, FormFieldDescription , Paragraph} from '@utrecht/component-library-react';
 import React, { FC, useState } from 'react';
 import { Spacer } from '@openstad-headless/ui/src';
+import './style.css';
 
 export type TickmarkSliderProps = {
     index: number;
@@ -15,6 +16,7 @@ export type TickmarkSliderProps = {
     disabled?: boolean;
     onChange?: (e: { name: string, value: string | Record<number, never> | [] }) => void;
     type?: string;
+    showSmileys?: boolean;
 }
 
 const TickmarkSlider: FC<TickmarkSliderProps> = ({
@@ -22,6 +24,7 @@ const TickmarkSlider: FC<TickmarkSliderProps> = ({
     description = '',
     fieldOptions = [],
     fieldRequired = false,
+    showSmileys = false,
     fieldKey,
     imageSrc = '',
     imageAlt = '',
@@ -85,7 +88,7 @@ const TickmarkSlider: FC<TickmarkSliderProps> = ({
                     </option>
                 ))}
             </datalist>
-            <div className="range-slider-labels">
+            <div className={`range-slider-labels ${showSmileys && 'smiley-scale'}`}>
                 {fieldOptions.map((option, key) => (
                     <label key={key} htmlFor={`a-to-b-range--${index}`} className={value === option.value ? 'active' : ''}>
                         {option.label}

--- a/packages/ui/src/form-elements/tickmark-slider/style.css
+++ b/packages/ui/src/form-elements/tickmark-slider/style.css
@@ -1,0 +1,9 @@
+.a-b-slider-container .range-slider-labels i::before {
+ font-size: 22px;
+ font-weight: 400;
+}
+
+.a-b-slider-container .range-slider-labels.smiley-scale {
+ padding-left: 0;
+ padding-right: 0;
+}


### PR DESCRIPTION
Deze PR bevat de volgende uitbreidingen / wijzigingen:

1. In de enquete widget heb je een schaal als veld. Dat veld heeft normaal de nummers 1 tot 5. Nu is er een optie toegevoegd waarmee je kan kiezen voor smileys i.p.v. de nummers.
2. In de rich text editor kon je wel een link maken van een stuk tekst, maar de pop-up viel vaak buiten beeld. Dat is nu opgelost met wat styling.
3. De export van submissions gebruikte fieldKeys als headers. Dat zijn altijd simpele woorden voor het opslaan in de database. Nu is er een koppeling gemaakt met de widgets, waardoor de titels van de vraagvelden worden gebruikt
4. FieldKey was niet verplicht in de enquete en resource form. Bij Deventer werden bij een test daardoor waardes niet opgeslagen. Het is nu verplicht gemaakt en het moet ook uniek zijn, anders kun je een item niet toevoegen.