### PR TITLE
Fix/document map bugs

### DIFF
--- a/packages/document-map/src/document-map.css
+++ b/packages/document-map/src/document-map.css
@@ -204,6 +204,7 @@ a + .url-list:before {
   width: 100%;
   display: flex;
   justify-content: space-between;
+  color: black !important;
 }
 
 .documentMap--container #stem-begroot-filter {

--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -55,7 +55,6 @@ export type DocumentMapProps = BaseProps &
     statusId?: string;
     includeOrExclude?: string;
     onlyIncludeOrExcludeTagIds?: string;
-    displayTagFilters?: boolean;
     tagGroups?: Array<{ type: string; label?: string; multiple: boolean }>;
     extraFieldsTagGroups?: Array<{ type: string; label?: string; multiple: boolean }>;
     displayTagGroupName?: boolean;
@@ -76,7 +75,6 @@ function DocumentMap({
   statusId,
   includeOrExclude = 'include',
   onlyIncludeOrExcludeTagIds = '',
-  displayTagFilters = false,
   tagGroups = [],
   extraFieldsTagGroups = [],
   displayTagGroupName = false,
@@ -450,7 +448,7 @@ function DocumentMap({
                 defaultSorting=""
                 displaySearch={false}
                 displaySorting={false}
-                displayTagFilters={displayTagFilters}
+                displayTagFilters={true}
                 onUpdateFilter={(f) => {
                   if (f.tags.length === 0) {
                     setSelectedTags([]);

--- a/packages/ui/src/stem-begroot-and-resource-overview/filter/index.tsx
+++ b/packages/ui/src/stem-begroot-and-resource-overview/filter/index.tsx
@@ -139,7 +139,7 @@ export function Filters({
             />
           </div>
         ) : null}
-        {props.displayTagFilters ? (
+        {( props.displayTagFilters && tagGroups && Array.isArray(tagGroups) && tagGroups.length > 0) ? (
           <>
             {tagGroups.map((tagGroup, index) => {
               if (tagGroup.multiple) {


### PR DESCRIPTION
Deze PR lost een bug op voor de document map. De filters werden niet getoond als je ze had aangevinkt in de admin. Dit kwam doordat een extra (onnodige) check was weggehaald uit de admin.