### PR TITLE
feat: Add 'Other, because' field in enquete choice options

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/items.tsx
@@ -28,6 +28,7 @@ import React, { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 import InfoDialog from '@/components/ui/info-hover';
+import {Checkbox} from "@/components/ui/checkbox";
 
 const formSchema = z.object({
   trigger: z.string(),
@@ -43,7 +44,7 @@ const formSchema = z.object({
     .array(
       z.object({
         trigger: z.string(),
-        titles: z.array(z.object({ text: z.string(), key: z.string() })),
+        titles: z.array(z.object({ text: z.string(), key: z.string(), isOtherOption: z.boolean().optional() })),
       })
     )
     .optional(),
@@ -433,6 +434,31 @@ export default function WidgetEnqueteItems(
                               <FormMessage />
                             </FormItem>
                           )}
+                        />
+
+                        <FormField
+                            control={form.control}
+                            // @ts-ignore
+                            name={`options.${options.length - 1}.isOtherOption`}
+                            render={({ field }) => (
+                                <>
+                                <FormItem
+                                    style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-start', flexDirection: 'row', marginTop: '10px' }}>
+                                  <Checkbox
+                                      onCheckedChange={(checked: boolean) => {
+                                        form.setValue(`options.${options.length - 1}.titles.0.isOtherOption`, checked );
+                                      }}
+                                  />
+                                  <FormLabel
+                                      style={{ marginTop: 0, marginLeft: '6px' }}>Is &apos;Anders, namelijk...&apos;</FormLabel>
+                                  <FormMessage />
+                                </FormItem>
+                              <FormDescription>
+                              Als je deze optie selecteert, wordt er automatisch een tekstveld toegevoegd aan het formulier.
+                              Het tekstveld wordt zichtbaar wanneer deze optie wordt geselecteerd.
+                              </FormDescription>
+                                </>
+                              )}
                         />
                       </>
                     )}

--- a/packages/enquete/src/enquete.tsx
+++ b/packages/enquete/src/enquete.tsx
@@ -88,7 +88,11 @@ function Enquete(props: EnqueteWidgetProps) {
                         item.options.length > 0
                     ) {
                         fieldData['choices'] = item.options.map((option) => {
-                            return option.titles[0].key
+                            return {
+                                value: option.titles[0].key,
+                                label: option.titles[0].key,
+                                isOtherOption: option.titles[0].isOtherOption
+                            };
                         });
                     }
                     break;

--- a/packages/enquete/src/types/enquete-props.ts
+++ b/packages/enquete/src/types/enquete-props.ts
@@ -45,4 +45,5 @@ export type Option = {
 export type Title = {
   text: string;
   key: string;
+  isOtherOption?: boolean;
 };

--- a/packages/ui/src/form-elements/text/index.tsx
+++ b/packages/ui/src/form-elements/text/index.tsx
@@ -60,9 +60,11 @@ const TextInput: FC<TextInputProps> = ({
 
     return (
         <FormField type="text">
-            <Paragraph className="utrecht-form-field__label">
-                <FormLabel htmlFor={randomID}>{title}</FormLabel>
-            </Paragraph>
+            {title && (
+                <Paragraph className="utrecht-form-field__label">
+                    <FormLabel htmlFor={randomID}>{title}</FormLabel>
+                </Paragraph>
+            )}
             {description &&
                 <>
                     <FormFieldDescription>


### PR DESCRIPTION
Deze PR voegt een keuze toe bij radio buttons en checkboxes om een 'Anders, namelijk' veld toe te voegen. Het veld blijft vrij invulbaar