### PR TITLE
feat: Disable submit button when resource is submitting

### DIFF
--- a/packages/resource-form/src/resource-form.tsx
+++ b/packages/resource-form/src/resource-form.tsx
@@ -106,10 +106,10 @@ function ResourceFormWidget(props: ResourceFormWidgetProps) {
                     if (!redirectUrl.startsWith('http://') && !redirectUrl.startsWith('https://')) {
                         redirectUrl = document.location.origin + '/' + (redirectUrl.startsWith('/') ? redirectUrl.substring(1) : redirectUrl);
                     }
-                    document.location.href = redirectUrl.replace("[id]", result.id)
+                    document.location.href = redirectUrl.replace("[id]", result.id);
+                } else {
+                    setDisableSubmit(false);
                 }
-
-                setDisableSubmit(false);
             }
         } catch (e) {
             notifyFailed();

--- a/packages/resource-form/src/resource-form.tsx
+++ b/packages/resource-form/src/resource-form.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import hasRole from '../../lib/has-role';
 import type {ResourceFormWidgetProps} from "./props.js";
 import {Banner, Button, Spacer} from "@openstad-headless/ui/src/index.js";
@@ -12,6 +12,7 @@ function ResourceFormWidget(props: ResourceFormWidgetProps) {
     const { submitButton, saveConceptButton} = props.submit  || {}; //TODO add saveButton variable. Unused variables cause errors in the admin
     const { loginText, loginButtonText} = props.info  || {}; //TODO add nameInHeader variable. Unused variables cause errors in the admin
     const { confirmationUser, confirmationAdmin} = props.confirmation  || {};
+    const [disableSubmit, setDisableSubmit] = useState(false);
 
     const datastore: any = new DataStore({
         projectId: props.projectId,
@@ -91,34 +92,28 @@ function ResourceFormWidget(props: ResourceFormWidgetProps) {
     }
 
     async function onSubmit(formData: any) {
-        // TODO: Redirect user to afterSubmitUrl when set
-        // const result = await createResource(formData, widgetId);
-
-        // if (result) {
-        //     if(props.afterSubmitUrl) {
-        //         location.href = props.afterSubmitUrl.replace("[id]", result.id)
-        //     } else {
-        //         notifyCreate();
-        //     }
-        // }
+        setDisableSubmit(true);
 
         const finalFormData = configureFormData(formData, true);
 
         try {
             const result = await createResource(finalFormData, props.widgetId);
             if (result) {
+                notifySuccess();
+
                 if(props.redirectUrl) {
                     let redirectUrl = props.redirectUrl.replace("[id]", result.id);
                     if (!redirectUrl.startsWith('http://') && !redirectUrl.startsWith('https://')) {
                         redirectUrl = document.location.origin + '/' + (redirectUrl.startsWith('/') ? redirectUrl.substring(1) : redirectUrl);
                     }
                     document.location.href = redirectUrl.replace("[id]", result.id)
-                } else {
-                    notifySuccess();
                 }
+
+                setDisableSubmit(false);
             }
         } catch (e) {
             notifyFailed();
+            setDisableSubmit(false);
         }
     }
 
@@ -153,6 +148,7 @@ function ResourceFormWidget(props: ResourceFormWidgetProps) {
                         submitHandler={onSubmit}
                         submitText={submitButton || "Versturen"}
                         title=""
+                        submitDisabled={disableSubmit}
                         {...props}
                     />
                 )}


### PR DESCRIPTION
Dit lost het volgende punt op:

> Na het versturen van een reactie kan ik op de 'Verstuur' knop blijven klikken en zo plaats ik binnen enkele seconden dezelfde reactie 3 keer. Die knop moet 'disabled' zijn na de eerste klikt en er moet een duidelijke melding komen dat het indienen wel/niet gelukt is.