### PR TITLE
feat: Add default image for when no real default image is set

### DIFF
--- a/packages/resource-detail-with-map/src/resourceDetailWithMap.css
+++ b/packages/resource-detail-with-map/src/resourceDetailWithMap.css
@@ -140,3 +140,19 @@
     padding-inline: 0;
   }
 }
+
+.osc-resource-detail-content.osc-resource-detail-grid .osc-resource-detail-content-items.resource-has-no-images .osc-carousel .carousel-items .image-container {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  aspect-ratio: 16 / 9;
+  background-color: #e6e6e6;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='121' height='106' viewBox='0 0 121 106' fill='none'%3E%3Cpath d='M36.625 21.125C42.7188 21.125 47.875 26.2812 47.875 32.375C47.875 38.7031 42.7188 43.625 36.625 43.625C30.2969 43.625 25.375 38.7031 25.375 32.375C25.375 26.2812 30.2969 21.125 36.625 21.125ZM105.766 0.5C114.203 0.5 120.766 7.29688 120.766 15.5V90.5C120.766 98.9375 113.969 105.5 105.766 105.5H15.7656C7.5625 105.5 0.765625 98.9375 0.765625 90.5V15.5C0.765625 7.29688 7.5625 0.5 15.7656 0.5H105.766ZM109.516 89.0938V15.5C109.516 13.625 107.875 11.75 105.766 11.75H15.7656C13.8906 11.75 12.0156 13.625 12.0156 15.5L12.25 90.5L29.8281 68.4688C30.7656 67.5312 31.9375 66.8281 33.3438 66.8281C34.75 66.8281 35.9219 67.5312 36.8594 68.4688L45.5312 79.25L70.375 45.5C71.3125 44.3281 72.4844 43.625 74.125 43.625C75.5312 43.625 76.7031 44.3281 77.4062 45.5L109.516 89.0938Z' fill='%23AAAAAA'/%3E%3C/svg%3E");
+  background-size: 9%;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+.osc-resource-detail-content.osc-resource-detail-grid .osc-resource-detail-content-items.resource-has-no-images .osc-carousel .carousel-items .image-container img {
+  display: none;
+}

--- a/packages/resource-detail-with-map/src/resourceDetailWithMap.tsx
+++ b/packages/resource-detail-with-map/src/resourceDetailWithMap.tsx
@@ -149,7 +149,7 @@ function ResourceDetailWithMap({
 
   if (!resource) return null;
 
-  let tagDefaultResourceImage = '';
+  let defaultImage = '';
 
   interface Tag {
     name: string;
@@ -160,20 +160,21 @@ function ResourceDetailWithMap({
     const sortedTags = resource.tags.sort((a: Tag, b: Tag) => a.name.localeCompare(b.name));
 
     const tagWithImage = sortedTags.find((tag: Tag) => tag.defaultResourceImage);
-    tagDefaultResourceImage = tagWithImage?.defaultResourceImage;
+    defaultImage = tagWithImage?.defaultResourceImage || '';
   }
 
-  const defaultImage = !!tagDefaultResourceImage ? [{ url: tagDefaultResourceImage }] : [{ url: '' }];
+  const resourceImages = (Array.isArray(resource.images) && resource.images.length > 0) ? resource.images : [{ url: defaultImage }];
+  const hasImages = (Array.isArray(resourceImages) && resourceImages.length > 0 && resourceImages[0].url !== '') ? '' : 'resource-has-no-images';
 
   return (
     <section className="osc-resource-detail-content osc-resource-detail-grid">
       {resource ? (
         <>
           <a href={backUrl} className="back-to-overview">Terug naar overzicht</a>
-          <article className="osc-resource-detail-content-items">
+          <article className={`osc-resource-detail-content-items ${hasImages}`}>
             {displayImage && (
               <Carousel
-                items={(Array.isArray(resource.images) && resource.images.length > 0) ? resource.images : defaultImage}
+                items={resourceImages}
                 itemRenderer={(i) => (
                   <Image
                     src={i.url}

--- a/packages/resource-detail/src/resource-detail.css
+++ b/packages/resource-detail/src/resource-detail.css
@@ -138,3 +138,19 @@
 .back-url a{
   display: inline-block;
 }
+
+.osc-resource-detail-content .osc-resource-detail-content-items.resource-has-no-images .image-container {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  aspect-ratio: 16 / 9;
+  background-color: #e6e6e6;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='121' height='106' viewBox='0 0 121 106' fill='none'%3E%3Cpath d='M36.625 21.125C42.7188 21.125 47.875 26.2812 47.875 32.375C47.875 38.7031 42.7188 43.625 36.625 43.625C30.2969 43.625 25.375 38.7031 25.375 32.375C25.375 26.2812 30.2969 21.125 36.625 21.125ZM105.766 0.5C114.203 0.5 120.766 7.29688 120.766 15.5V90.5C120.766 98.9375 113.969 105.5 105.766 105.5H15.7656C7.5625 105.5 0.765625 98.9375 0.765625 90.5V15.5C0.765625 7.29688 7.5625 0.5 15.7656 0.5H105.766ZM109.516 89.0938V15.5C109.516 13.625 107.875 11.75 105.766 11.75H15.7656C13.8906 11.75 12.0156 13.625 12.0156 15.5L12.25 90.5L29.8281 68.4688C30.7656 67.5312 31.9375 66.8281 33.3438 66.8281C34.75 66.8281 35.9219 67.5312 36.8594 68.4688L45.5312 79.25L70.375 45.5C71.3125 44.3281 72.4844 43.625 74.125 43.625C75.5312 43.625 76.7031 44.3281 77.4062 45.5L109.516 89.0938Z' fill='%23AAAAAA'/%3E%3C/svg%3E");
+  background-size: 9%;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+.osc-resource-detail-content .osc-resource-detail-content-items.resource-has-no-images .image-container img {
+  display: none;
+}

--- a/packages/resource-detail/src/resource-detail.tsx
+++ b/packages/resource-detail/src/resource-detail.tsx
@@ -123,7 +123,7 @@ function ResourceDetail({
   const shouldHaveSideColumn =
     displayLikes || displayTags || displayStatus || displaySocials || displayDocuments;
 
-  let tagDefaultResourceImage = '';
+  let defaultImage = '';
 
   interface Tag {
     name: string;
@@ -134,10 +134,11 @@ function ResourceDetail({
     const sortedTags = resource.tags.sort((a: Tag, b: Tag) => a.name.localeCompare(b.name));
 
     const tagWithImage = sortedTags.find((tag: Tag) => tag.defaultResourceImage);
-    tagDefaultResourceImage = tagWithImage?.defaultResourceImage;
+    defaultImage = tagWithImage?.defaultResourceImage || '';
   }
 
-  const defaultImage = !!tagDefaultResourceImage ? [{ url: tagDefaultResourceImage }] : [{ url: '' }];
+  const resourceImages = (Array.isArray(resource.images) && resource.images.length > 0) ? resource.images : [{ url: defaultImage }];
+  const hasImages = (Array.isArray(resourceImages) && resourceImages.length > 0 && resourceImages[0].url !== '') ? '' : 'resource-has-no-images';
 
   const getPageHash = () => {
     if (window.location.hash.includes('#doc')) {
@@ -157,10 +158,10 @@ function ResourceDetail({
         <section className="osc-resource-detail-content osc-resource-detail-content--span-2">
           {getPageHash()}
           {resource ? (
-            <article className="osc-resource-detail-content-items">
+            <article className={`osc-resource-detail-content-items ${hasImages}`}>
               {displayImage && (
                 <Carousel
-                  items={(Array.isArray(resource.images) && resource.images.length > 0) ? resource.images : defaultImage}
+                  items={resourceImages}
                   itemRenderer={(i) => (
                     <Image
                       src={i.url}

--- a/packages/resource-overview/src/gridder-resource-detail.tsx
+++ b/packages/resource-overview/src/gridder-resource-detail.tsx
@@ -61,12 +61,15 @@ export const GridderResourceDetail = ({
     defaultImage = tagWithImage?.defaultResourceImage || '';
   }
 
+  const resourceImages = (Array.isArray(resource.images) && resource.images.length > 0) ? resource.images?.at(0)?.url : defaultImage;
+  const hasImages = !!resourceImages ? '' : 'resource-has-no-images';
+
   return (
     <>
       <div className="osc-gridder-resource-detail">
-        <section className="osc-gridder-resource-detail-photo">
+        <section className={`osc-gridder-resource-detail-photo ${hasImages}`}>
           <Image
-            src={resource.images?.at(0)?.url || defaultImage}
+            src={resourceImages}
             style={{ aspectRatio: 16 / 9 }}
           />
           {/* <div>

--- a/packages/resource-overview/src/resource-overview.css
+++ b/packages/resource-overview/src/resource-overview.css
@@ -229,3 +229,21 @@ p.osc-searchtext {
   z-index: 10;
   margin-top: -38px;
 }
+
+.osc-resource-overview-content .resource-has-no-images .osc-carousel .carousel-items .image-container,
+.osc-carousel .carousel-items .osc-gridder-resource-detail .resource-has-no-images .image-container {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  aspect-ratio: 16 / 9;
+  background-color: #e6e6e6;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='121' height='106' viewBox='0 0 121 106' fill='none'%3E%3Cpath d='M36.625 21.125C42.7188 21.125 47.875 26.2812 47.875 32.375C47.875 38.7031 42.7188 43.625 36.625 43.625C30.2969 43.625 25.375 38.7031 25.375 32.375C25.375 26.2812 30.2969 21.125 36.625 21.125ZM105.766 0.5C114.203 0.5 120.766 7.29688 120.766 15.5V90.5C120.766 98.9375 113.969 105.5 105.766 105.5H15.7656C7.5625 105.5 0.765625 98.9375 0.765625 90.5V15.5C0.765625 7.29688 7.5625 0.5 15.7656 0.5H105.766ZM109.516 89.0938V15.5C109.516 13.625 107.875 11.75 105.766 11.75H15.7656C13.8906 11.75 12.0156 13.625 12.0156 15.5L12.25 90.5L29.8281 68.4688C30.7656 67.5312 31.9375 66.8281 33.3438 66.8281C34.75 66.8281 35.9219 67.5312 36.8594 68.4688L45.5312 79.25L70.375 45.5C71.3125 44.3281 72.4844 43.625 74.125 43.625C75.5312 43.625 76.7031 44.3281 77.4062 45.5L109.516 89.0938Z' fill='%23AAAAAA'/%3E%3C/svg%3E");
+  background-size: 9%;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+.osc-resource-overview-content .resource-has-no-images .osc-carousel .carousel-items .image-container img,
+.osc-carousel .carousel-items .osc-gridder-resource-detail .resource-has-no-images .image-container img {
+  display: none;
+}

--- a/packages/resource-overview/src/resource-overview.tsx
+++ b/packages/resource-overview/src/resource-overview.tsx
@@ -190,14 +190,17 @@ const defaultItemRenderer = (
     return newUrl
   }
 
+  const resourceImages = (Array.isArray(resource.images) && resource.images.length > 0) ? resource.images : [{ url: defaultImage }];
+  const hasImages = (Array.isArray(resourceImages) && resourceImages.length > 0 && resourceImages[0].url !== '') ? '' : 'resource-has-no-images';
+
   return (
     <>
       {props.displayType === 'cardrow' ? (
         <div
-          className="resource-card--link">
+          className={`resource - card--link ${hasImages}`}>
 
           <Carousel
-            items={(Array.isArray(resource.images) && resource.images.length > 0) ? resource.images : [{ url: '' }]}
+            items={resourceImages}
             itemRenderer={(i) => (
               <Image
                 src={i.url}
@@ -257,9 +260,9 @@ const defaultItemRenderer = (
         </div>
 
       ) : (
-        <div className="resource-card--link">
+        <div className={`resource-card--link ${hasImages}`}>
           <Carousel
-            items={(Array.isArray(resource.images) && resource.images.length > 0) ? resource.images : [{ url: '' }]}
+            items={resourceImages}
             itemRenderer={(i) => (
               <Image
                 src={i.url}

--- a/packages/stem-begroot/src/stem-begroot.css
+++ b/packages/stem-begroot/src/stem-begroot.css
@@ -239,3 +239,25 @@ section.osc-begrootmodule-resource-detail-photo
   flex-shrink: unset;
   left: unset;
 }
+
+#stem-begroot-resource-selections-list .stem-begroot--container.resource-has-no-images .image-container,
+.budget-list-container .budget-list-selections .budget-list-selection-indicaction-container .budget-list-selection-indicaction.resource-has-no-images.image-container,
+.budget-overview-panel .budget-two-text-row-spaced .budget-overview-row.resource-has-no-images .image-container,
+.osc-begrootmodule-resource-detail .osc-begrootmodule-resource-detail-photo.resource-has-no-images .image-container {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  aspect-ratio: 16 / 9;
+  background-color: #e6e6e6;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='121' height='106' viewBox='0 0 121 106' fill='none'%3E%3Cpath d='M36.625 21.125C42.7188 21.125 47.875 26.2812 47.875 32.375C47.875 38.7031 42.7188 43.625 36.625 43.625C30.2969 43.625 25.375 38.7031 25.375 32.375C25.375 26.2812 30.2969 21.125 36.625 21.125ZM105.766 0.5C114.203 0.5 120.766 7.29688 120.766 15.5V90.5C120.766 98.9375 113.969 105.5 105.766 105.5H15.7656C7.5625 105.5 0.765625 98.9375 0.765625 90.5V15.5C0.765625 7.29688 7.5625 0.5 15.7656 0.5H105.766ZM109.516 89.0938V15.5C109.516 13.625 107.875 11.75 105.766 11.75H15.7656C13.8906 11.75 12.0156 13.625 12.0156 15.5L12.25 90.5L29.8281 68.4688C30.7656 67.5312 31.9375 66.8281 33.3438 66.8281C34.75 66.8281 35.9219 67.5312 36.8594 68.4688L45.5312 79.25L70.375 45.5C71.3125 44.3281 72.4844 43.625 74.125 43.625C75.5312 43.625 76.7031 44.3281 77.4062 45.5L109.516 89.0938Z' fill='%23AAAAAA'/%3E%3C/svg%3E");
+  background-size: 9%;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+#stem-begroot-resource-selections-list .stem-begroot--container.resource-has-no-images .image-container img,
+.budget-list-container .budget-list-selections .budget-list-selection-indicaction-container .budget-list-selection-indicaction.resource-has-no-images.image-container img,
+.budget-overview-panel .budget-two-text-row-spaced .budget-overview-row.resource-has-no-images .image-container img,
+.osc-begrootmodule-resource-detail .osc-begrootmodule-resource-detail-photo.resource-has-no-images .image-container img {
+  display: none;
+}

--- a/packages/stem-begroot/src/step-1/begroot-budget-list/stem-begroot-budget-list.tsx
+++ b/packages/stem-begroot/src/step-1/begroot-budget-list/stem-begroot-budget-list.tsx
@@ -92,6 +92,9 @@ export const StemBegrootBudgetList = ({
                 defaultImage = tagWithImage?.defaultResourceImage || '';
               }
 
+              const resourceImages = (Array.isArray(resource.images) && resource.images.length > 0) ? resource.images?.at(0)?.url : defaultImage;
+              const hasImages = !!resourceImages ? '' : 'resource-has-no-images';
+
               return (
                 <Image
                   imageHeader={
@@ -114,8 +117,8 @@ export const StemBegrootBudgetList = ({
                     </div>
                   }
                   key={`resource-detail-image-${resource.id}`}
-                  className="budget-list-selection-indicaction"
-                  src={resource.images?.at(0)?.url || defaultImage}
+                  className={`budget-list-selection-indicaction ${hasImages}`}
+                  src={resourceImages}
                 />
               )
             })}

--- a/packages/stem-begroot/src/step-1/begroot-detail-dialog/stem-begroot-detail-dialog.tsx
+++ b/packages/stem-begroot/src/step-1/begroot-detail-dialog/stem-begroot-detail-dialog.tsx
@@ -83,19 +83,22 @@ export const StemBegrootResourceDetailDialog = ({
             defaultImage = tagWithImage?.defaultResourceImage || '';
           }
 
-          let resourceImages = (Array.isArray(resource.images) && resource.images.length > 0)
-              ? [...resource.images, { resource: resource }]
-              : ( resource.location
-                    ? [{ location: resource.location }]
-                    : ''
-                );
+            let resourceImages: any[] = [];
 
-          let hasImages = '' ;
+            if (resource.location) {
+                resourceImages.push({ location: resource.location });
+            }
 
-          if ( resourceImages === '' ) {
-            resourceImages = [{ url: defaultImage || '' }];
-            hasImages = 'resource-has-no-images';
-          }
+            if (Array.isArray(resource.images) && resource.images.length > 0) {
+                resourceImages = [...resource.images, ...resourceImages];
+            }
+
+            let hasImages = '';
+
+            if (resourceImages.length === 0) {
+                resourceImages = [{ url: defaultImage || '' }];
+                hasImages = 'resource-has-no-images';
+            }
 
           return (
             <>

--- a/packages/stem-begroot/src/step-1/begroot-detail-dialog/stem-begroot-detail-dialog.tsx
+++ b/packages/stem-begroot/src/step-1/begroot-detail-dialog/stem-begroot-detail-dialog.tsx
@@ -83,17 +83,27 @@ export const StemBegrootResourceDetailDialog = ({
             defaultImage = tagWithImage?.defaultResourceImage || '';
           }
 
+          let resourceImages = (Array.isArray(resource.images) && resource.images.length > 0)
+              ? [...resource.images, { resource: resource }]
+              : ( resource.location
+                    ? [{ location: resource.location }]
+                    : ''
+                );
+
+          let hasImages = '' ;
+
+          if ( resourceImages === '' ) {
+            resourceImages = [{ url: defaultImage || '' }];
+            hasImages = 'resource-has-no-images';
+          }
+
           return (
             <>
               <div className="osc-begrootmodule-resource-detail">
-                <section className="osc-begrootmodule-resource-detail-photo">
+                <section className={`osc-begrootmodule-resource-detail-photo ${hasImages}`}>
 
                   <Carousel
-                    items={
-                      Array.isArray(resource.images) && resource.images.length > 0
-                        ? [...resource.images, { resource: resource }]
-                        : [{ location: resource.location }]
-                    }
+                    items={resourceImages}
                     itemRenderer={(i) => {
                       if (i.url) {
                         return <Image src={i.url} />

--- a/packages/stem-begroot/src/step-1/begroot-resource-list/stem-begroot-resource-list.tsx
+++ b/packages/stem-begroot/src/step-1/begroot-resource-list/stem-begroot-resource-list.tsx
@@ -73,12 +73,15 @@ export const StemBegrootResourceList = ({
           defaultImage = tagWithImage?.defaultResourceImage || '';
         }
 
+        const resourceImages = (Array.isArray(resource.images) && resource.images.length > 0) ? resource.images : [{ url: defaultImage }];
+        const hasImages = (Array.isArray(resourceImages) && resourceImages.length > 0 && resourceImages[0].url !== '') ? '' : 'resource-has-no-images';
+
         return (
           <>
-            <article className="stem-begroot--container">
+            <article className={`stem-begroot--container ${hasImages}`}>
 
               <Carousel
-                items={(Array.isArray(resource.images) && resource.images.length > 0) ? resource.images : [{ url: '' }]}
+                items={resourceImages}
                 itemRenderer={(i) => (
                   <Image src={i.url} />
                 )}

--- a/packages/stem-begroot/src/step-2/selected-overview.tsx
+++ b/packages/stem-begroot/src/step-2/selected-overview.tsx
@@ -71,13 +71,16 @@ export const BegrotenSelectedOverview = ({
             defaultImage = tagWithImage?.defaultResourceImage || '';
           }
 
+          const resourceImages = (Array.isArray(resource.images) && resource.images.length > 0) ? resource.images?.at(0)?.url : defaultImage;
+          const hasImages = !!resourceImages ? '' : 'resource-has-no-images';
+
           return (
             <div key={`budget-overview-row-${resource.id}`} className="budget-two-text-row-spaced">
-              <section className='budget-overview-row'>
+              <section className={`budget-overview-row ${hasImages}`}>
                 <Image
                   height={'4rem'}
                   width={'4rem'}
-                  src={resource.images?.at(0)?.url || defaultImage}
+                  src={resourceImages}
                 />
                 <div className="budget-resource-container">
                   <Paragraph>{resource.title}</Paragraph>


### PR DESCRIPTION
Dit lost de volgende punten op:

> Standaardafbeeldingen die aan tags zijn gekoppeld bij de ideeën worden niet getoond in het overzicht, maar wel in de detailpagina

> Er moet een standaardafbeelding komen als iemand geen tag kiest en geen afbeelding upload