### PR TITLE
zoom bug fix

### DIFF
--- a/packages/leaflet-map/src/base-map.tsx
+++ b/packages/leaflet-map/src/base-map.tsx
@@ -136,7 +136,7 @@ const BaseMap = ({
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mapRef, markers]);
+  }, [mapRef, area]);
 
   // markers
   useEffect(() => {


### PR DESCRIPTION
UseEffect luisterde naar de markers, waardoor er een endless loop was. Dit veranderd naar area, zodat de map nog wel kan zoom op de betreffende area.