### PR TITLE
Feat/default sorting

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourceoverview/[id]/sorting.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourceoverview/[id]/sorting.tsx
@@ -120,7 +120,7 @@ export default function WidgetResourceOverviewSorting(
                 <FormLabel>Standaard manier van sorteren</FormLabel>
                 <Select
                   onValueChange={(value) => {
-                    field.onChange;
+                    field.onChange(value);
                     props.onFieldChanged(field.name, value);
                   }}
                   value={field.value}>

--- a/packages/ui/src/select/index.tsx
+++ b/packages/ui/src/select/index.tsx
@@ -8,11 +8,13 @@ import { Select as NLDS_Select, SelectOption } from "@utrecht/component-library-
 type Props = {
   onValueChange?: (resource: any) => void;
   options?: Array<{ value: string; label: string }>;
+  disableDefaultOption?: boolean;
 } & React.SelectHTMLAttributes<HTMLSelectElement>;
 
 const Select = forwardRef<HTMLSelectElement, Props>(
   ({ onValueChange, ...props }, ref) => {
     const selectOptions = props.options ?? [];
+    const disableDefaultOption = props.disableDefaultOption || false;
 
     return (
       <NLDS_Select
@@ -24,9 +26,12 @@ const Select = forwardRef<HTMLSelectElement, Props>(
           ((e) => onValueChange && onValueChange(e.target.value))
         }>
         {props.children}
-          <SelectOption className="select-item" value={''}>
-            Selecteer optie
-          </SelectOption>
+
+          {!disableDefaultOption && (
+              <SelectOption className="select-item" value={''}>
+                Selecteer optie
+              </SelectOption>
+          )}
 
         {selectOptions.map((option) => (
           <React.Fragment key={`select-item-${option.label}`}>

--- a/packages/ui/src/stem-begroot-and-resource-overview/filter/index.tsx
+++ b/packages/ui/src/stem-begroot-and-resource-overview/filter/index.tsx
@@ -180,11 +180,16 @@ export function Filters({
         ) : null}
 
         {props.displaySorting ? (
-          <div className="form-element">
-            <FormLabel htmlFor={'sortField'}>Sorteer op</FormLabel>
-            <Select onValueChange={setSort} options={sorting} id="sortField">
-            </Select>
-          </div>
+            <div className="form-element">
+              <FormLabel htmlFor={'sortField'}>Sorteer op</FormLabel>
+              <Select
+                  onValueChange={setSort}
+                  options={sorting}
+                  id="sortField"
+                  defaultValue={props.defaultSorting || 'createdAt_desc'}
+                  disableDefaultOption={true}
+              />
+            </div>
         ) : null}
 
 


### PR DESCRIPTION
Deze PR lost de volgende punten op:

- Bij de filters kun je ook sorteren. Hij staat standaard op 'selecteer een optie', terwijl eigenlijk al een van de filters is geselecteerd als standaardoptie (bijv nieuwste eerst). Die zou daar dan moeten staan. Er kan eigenlijk nooit 'selecteer een optie' staan bij de sortering, want hij is altijd gesorteerd op iets.
- De optie 'nieuwste eerst' kan nu niet worden gewijzigd als standaard optie