### PR TITLE
feat: Enable notifications to users and admin for enquete widget

### DIFF
--- a/apps/admin-server/src/components/notification-form.tsx
+++ b/apps/admin-server/src/components/notification-form.tsx
@@ -98,7 +98,9 @@ type Props = {
   | 'new published resource - user feedback'
   | 'new published resource - admin update'
   | 'updated resource - user feedback'
-  | 'user account about to expire';
+  | 'user account about to expire'
+  | 'new enquete - admin'
+  | 'new enquete - user';
   engine?: 'email' | 'sms';
   id?: string;
   label?: string;
@@ -112,7 +114,9 @@ const notificationTypes = {
   'new published resource - user feedback': 'Nieuwe resource gepubliceerd - Notificatie naar de gebruiker',
   'new published resource - admin update': 'Nieuwe resource gepubliceerd - Notificatie naar de admin',
   'updated resource - user feedback': 'Resource bijgewerkt - Notificatie naar de gebruiker',
-  'user account about to expire': 'Gebruikersaccount staat op het punt te verlopen'
+  'user account about to expire': 'Gebruikersaccount staat op het punt te verlopen',
+  'new enquete - admin': 'Nieuwe formulier inzending - Notificatie naar de admin',
+  'new enquete - user': 'Nieuwe formulier inzending - Notificatie naar de gebruiker'
 };
 
 const formSchema = z.object({

--- a/apps/admin-server/src/pages/projects/[project]/notifications/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/notifications/index.tsx
@@ -7,8 +7,27 @@ import { Separator } from '@/components/ui/separator';
 import AccordionUI from "@/components/ui/accordion";
 
 export default function ProjectNotifications() {
-  type NotificationType = 'login email' | 'login sms' | 'new published resource - user feedback' | 'new published resource - admin update' | 'updated resource - user feedback' | 'user account about to expire';
-  const defaultDefinitions: { [type in NotificationType]: any[] } = { "login email": [], "login sms": [], "new published resource - user feedback": [], "new published resource - admin update": [], "updated resource - user feedback": [], "user account about to expire": [] };
+  type NotificationType =
+      'login email'
+      | 'login sms'
+      | 'new published resource - user feedback'
+      | 'new published resource - admin update'
+      | 'updated resource - user feedback'
+      | 'user account about to expire'
+      | 'new enquete - admin'
+      | 'new enquete - user';
+
+  const defaultDefinitions: { [type in NotificationType]: any[] } = {
+    "login email": [],
+    "login sms": [],
+    "new published resource - user feedback": [],
+    "new published resource - admin update": [],
+    "updated resource - user feedback": [],
+    "user account about to expire": [],
+    "new enquete - admin": [],
+    "new enquete - user": []
+  };
+
   const [typeDefinitions, setTypeDefinitions] = React.useState<{ [type in NotificationType]: any[] }>(defaultDefinitions);
 
   const router = useRouter();

--- a/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/confirmation.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/confirmation.tsx
@@ -1,0 +1,194 @@
+import { Button } from '@/components/ui/button';
+import {
+    Form,
+    FormField,
+    FormItem,
+    FormLabel,
+    FormMessage,
+    FormDescription, FormControl,
+} from '@/components/ui/form';
+import { Separator } from '@/components/ui/separator';
+import { Heading } from '@/components/ui/typography';
+import { useWidgetConfig } from '@/hooks/use-widget-config';
+import { zodResolver } from '@hookform/resolvers/zod';
+import React, { useCallback, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import * as z from 'zod';
+import * as Switch from '@radix-ui/react-switch';
+import {Input} from "@/components/ui/input";
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from "@/components/ui/select";
+
+const formSchema = z.object({
+    confirmationUser: z.boolean().optional(),
+    confirmationAdmin: z.boolean().optional(),
+    overwriteEmailAddress: z.string().optional(),
+    userEmailAddress: z.string().optional(),
+});
+
+export default function WidgetEnqueteConfirmation() {
+    type FormData = z.infer<typeof formSchema>;
+    const category = 'confirmation';
+
+    // TODO should use the passed props widget, this is the old way and is not advised
+    const {
+        data: widget,
+        isLoading: isLoadingWidget,
+        updateConfig,
+    } = useWidgetConfig<any>();
+
+    const defaults = useCallback(
+        () => {
+            const confirmationUser = widget?.config?.[category]?.confirmationUser !== null ? widget?.config?.[category]?.confirmationUser : true;
+            const confirmationAdmin = widget?.config?.[category]?.confirmationAdmin !== null ? widget?.config?.[category]?.confirmationAdmin : true;
+            const overwriteEmailAddress = widget?.config?.[category]?.overwriteEmailAddress !== null ? widget?.config?.[category]?.overwriteEmailAddress : '';
+            const userEmailAddress = widget?.config?.[category]?.userEmailAddress !== null ? widget?.config?.[category]?.userEmailAddress : '';
+            return { confirmationUser, confirmationAdmin, overwriteEmailAddress, userEmailAddress };
+        },
+        [widget?.config]
+    );
+
+    async function onSubmit(values: FormData) {
+        try {
+            await updateConfig({ [category]: values });
+        } catch (error) {
+            console.error('could not update', error);
+        }
+    }
+
+    const form = useForm<FormData>({
+        resolver: zodResolver<any>(formSchema),
+        defaultValues: defaults(),
+    });
+
+    useEffect(() => {
+        form.reset(defaults());
+    }, [form, defaults]);
+
+    const visibility = widget?.config?.formVisibility || 'always';
+    const items = widget?.config?.items || [];
+
+    const confirmationUserError = visibility === 'always' && (
+        items.length === 0
+            ? 'Je moet eerst velden aanmaken om dit te kunnen doen.'
+            : !items.some(item => item.questionType === 'open')
+                ? 'Je moet eerst een tekstveld aanmaken om dit te kunnen doen.'
+                : null
+    );
+
+    return (
+        <div className="p-6 bg-white rounded-md">
+            <Form {...form}>
+                <Heading size="xl">Bevestiging</Heading>
+                <Separator className="my-4" />
+                <form
+                    onSubmit={form.handleSubmit(onSubmit)}
+                    className="lg:w-2/3 grid grid-cols-1 gap-4">
+                    <FormField
+                        control={form.control}
+                        name="confirmationUser"
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormLabel>
+                                    Krijgt de gebruiker een bevestiging per mail van zijn inzending?
+                                </FormLabel>
+                                <Switch.Root
+                                    className="block w-[50px] h-[25px] bg-stone-300 rounded-full relative focus:shadow-[0_0_0_2px] focus:shadow-black data-[state=checked]:bg-primary outline-none cursor-default"
+                                    onCheckedChange={(e: boolean) => {
+                                        console.log('confirmationUserError', confirmationUserError);
+
+                                        if (!confirmationUserError) {
+                                            field.onChange(e);
+                                        }
+                                    }}
+                                    disabled={!!confirmationUserError}
+                                    checked={field.value && !confirmationUserError}>
+                                    <Switch.Thumb className="block w-[21px] h-[21px] bg-white rounded-full transition-transform duration-100 translate-x-0.5 will-change-transform data-[state=checked]:translate-x-[27px]" />
+                                </Switch.Root>
+                                {confirmationUserError && (
+                                    <FormMessage>{confirmationUserError}</FormMessage>
+                                )}
+                            </FormItem>
+                        )}
+                    />
+
+                    {form.watch('confirmationUser') && visibility === 'always' && (
+                        <FormField
+                            control={form.control}
+                            name="userEmailAddress"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>Welk veld moet er worden gebruikt voor de bevestiging naar de gebruiker</FormLabel>
+                                    <FormDescription>
+                                        In de 'Weergave' opties is ingesteld dat je niet hoeft in te loggen om dit formulier te zien. Hierdoor kan iedereen het formulier invullen en is er geen e-mailadres van de gebruiker beschikbaar om de notificatie naartoe te sturen. Kies hier een veld uit het formulier dat gebruikt wordt om de bevestiging naar de gebruiker te sturen.
+                                    </FormDescription>
+                                    <Select
+                                        value={field.value || ''}
+                                        onValueChange={field.onChange}>
+                                        <FormControl>
+                                            <SelectTrigger>
+                                                <SelectValue placeholder="Kies een veld" />
+                                            </SelectTrigger>
+                                        </FormControl>
+                                        <SelectContent>
+                                            {items
+                                                .filter(item => item.questionType === 'open')
+                                                .map(item => (
+                                                    <SelectItem key={item.fieldKey} value={item.fieldKey}>
+                                                        {item.title}
+                                                    </SelectItem>
+                                                ))}
+                                        </SelectContent>
+                                    </Select>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+                    )}
+
+                    <FormField
+                        control={form.control}
+                        name="confirmationAdmin"
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormLabel>
+                                    Krijgt de beheerder een bevestiging per mail bij een nieuwe inzending?
+                                </FormLabel>
+                                <Switch.Root
+                                    className="block w-[50px] h-[25px] bg-stone-300 rounded-full relative focus:shadow-[0_0_0_2px] focus:shadow-black data-[state=checked]:bg-primary outline-none cursor-default"
+                                    onCheckedChange={(e: boolean) => {
+                                        field.onChange(e);
+                                    }}
+                                    checked={field.value}>
+                                    <Switch.Thumb className="block w-[21px] h-[21px] bg-white rounded-full transition-transform duration-100 translate-x-0.5 will-change-transform data-[state=checked]:translate-x-[27px]" />
+                                </Switch.Root>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+
+                    { form.watch('confirmationAdmin') && (
+                        <FormField
+                            control={form.control}
+                            name="overwriteEmailAddress"
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>Overschrijf het e-mailadres waar de bevesting naartoe wordt gestuurd</FormLabel>
+                                    <FormDescription>
+                                        De bevestiging gaat standaard naar de beheerder. Vul hier een ander e-mailadres in om dit te overschrijven. Meerdere e-mailadressen zijn mogelijk, mits ze gescheiden zijn met een komma.
+                                    </FormDescription>
+                                    <Input
+                                        {...field}
+                                    />
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+                    )}
+                    <Button className="w-fit col-span-full" type="submit">
+                        Opslaan
+                    </Button>
+                </form>
+            </Form>
+        </div>
+    );
+}

--- a/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/confirmation.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/confirmation.tsx
@@ -70,7 +70,7 @@ export default function WidgetEnqueteConfirmation() {
     const confirmationUserError = visibility === 'always' && (
         items.length === 0
             ? 'Je moet eerst velden aanmaken om dit te kunnen doen.'
-            : !items.some(item => item.questionType === 'open')
+            : !items.some((item: {questionType: string}) => item.questionType === 'open')
                 ? 'Je moet eerst een tekstveld aanmaken om dit te kunnen doen.'
                 : null
     );
@@ -119,7 +119,7 @@ export default function WidgetEnqueteConfirmation() {
                                 <FormItem>
                                     <FormLabel>Welk veld moet er worden gebruikt voor de bevestiging naar de gebruiker</FormLabel>
                                     <FormDescription>
-                                        In de 'Weergave' opties is ingesteld dat je niet hoeft in te loggen om dit formulier te zien. Hierdoor kan iedereen het formulier invullen en is er geen e-mailadres van de gebruiker beschikbaar om de notificatie naartoe te sturen. Kies hier een veld uit het formulier dat gebruikt wordt om de bevestiging naar de gebruiker te sturen.
+                                        In de &apos;Weergave&apos; opties is ingesteld dat je niet hoeft in te loggen om dit formulier te zien. Hierdoor kan iedereen het formulier invullen en is er geen e-mailadres van de gebruiker beschikbaar om de notificatie naartoe te sturen. Kies hier een veld uit het formulier dat gebruikt wordt om de bevestiging naar de gebruiker te sturen.
                                     </FormDescription>
                                     <Select
                                         value={field.value || ''}
@@ -131,8 +131,8 @@ export default function WidgetEnqueteConfirmation() {
                                         </FormControl>
                                         <SelectContent>
                                             {items
-                                                .filter(item => item.questionType === 'open')
-                                                .map(item => (
+                                                .filter((item: {questionType: string}) => item.questionType === 'open')
+                                                .map((item: {fieldKey: string, title: string}) => (
                                                     <SelectItem key={item.fieldKey} value={item.fieldKey}>
                                                         {item.title}
                                                     </SelectItem>

--- a/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/index.tsx
@@ -18,6 +18,8 @@ import {
 import WidgetEnqueteDisplay from './display';
 import WidgetEnqueteGeneral from './general';
 import WidgetEnqueteItems from './items';
+import React from "react";
+import WidgetEnqueteConfirmation from "./confirmation";
 
 export const getServerSideProps = withApiUrl;
 export default function WidgetEnquete({ apiUrl }: WithApiUrlProps) {
@@ -56,6 +58,7 @@ export default function WidgetEnquete({ apiUrl }: WithApiUrlProps) {
               <TabsTrigger value="general">Algemeen</TabsTrigger>
               <TabsTrigger value="items">Items</TabsTrigger>
               <TabsTrigger value="display">Weergave</TabsTrigger>
+              <TabsTrigger value="confirmation">Bevestiging</TabsTrigger>
               <TabsTrigger value="publish">Publiceren</TabsTrigger>
             </TabsList>
             <TabsContent value="general" className="p-0">
@@ -111,6 +114,9 @@ export default function WidgetEnquete({ apiUrl }: WithApiUrlProps) {
                   }}
                 />
               )}
+            </TabsContent>
+            <TabsContent value="confirmation" className="p-0">
+              <WidgetEnqueteConfirmation />
             </TabsContent>
             <TabsContent value="publish" className="p-0">
               <WidgetPublish apiUrl={apiUrl} />

--- a/apps/api-server/src/models/Notification.js
+++ b/apps/api-server/src/models/Notification.js
@@ -66,7 +66,17 @@ module.exports = ( db, sequelize, DataTypes ) => {
         // to
         let user;
         if (!instance.to) {
-          let managerTypes = ['new published resource - admin update', 'updated resource - admin update', 'project issues warning', 'new or updated comment - admin update', 'submission', 'action', 'message by carrier pigeon'];
+          let managerTypes = [
+            'new published resource - admin update',
+            'updated resource - admin update',
+            'new enquete - admin',
+            'project issues warning',
+            'new or updated comment - admin update',
+            'submission',
+            'action',
+            'message by carrier pigeon'
+          ];
+
           if (managerTypes.find(type => type == instance.type)) {
             let defaultRecipient = project.emailConfig?.notifications?.projectmanagerAddress;
 
@@ -99,7 +109,22 @@ module.exports = ( db, sequelize, DataTypes ) => {
           await instance.update({ status: 'pending' });
           
           // send immediatly or wait for cron
-          let immediateTypes = ['new concept resource - user feedback', 'new published resource - user feedback', 'updated resource - user feedback', 'new published resource - admin update', 'updated resource - admin update', 'login email', 'login sms', 'user account about to expire', 'project issues warning', 'system issues warning', 'action', 'message by carrier pigeon'];
+          let immediateTypes = [
+            'new concept resource - user feedback',
+            'new published resource - user feedback',
+            'updated resource - user feedback',
+            'new enquete - admin',
+            'new enquete - user',
+            'new published resource - admin update',
+            'updated resource - admin update',
+            'login email', 'login sms',
+            'user account about to expire',
+            'project issues warning',
+            'system issues warning',
+            'action',
+            'message by carrier pigeon'
+          ];
+
           if (immediateTypes.find(type => type == instance.type)) {
             let messageData = {
               projectId: instance.projectId,
@@ -115,7 +140,7 @@ module.exports = ( db, sequelize, DataTypes ) => {
               include: [{ model: db.Tag, attributes: ['name', 'type'] }]
             });
 
-            const widget = await db.Widget.findByPk(resource.widgetId);
+            const widget = !!resource ? await db.Widget.findByPk(resource.widgetId) : instance.widgetId || null;
 
             let htmlContent = '';
 

--- a/apps/api-server/src/models/Submission.js
+++ b/apps/api-server/src/models/Submission.js
@@ -30,23 +30,6 @@ module.exports = function (db, sequelize, DataTypes) {
         default: {},
         allowNull: false,
       },
-    },
-    {
-      hooks: {
-        afterCreate: (instance, options) => {
-          try {
-            db.Notification.create({
-              type: "submission",
-			        projectId: instance.projectId,
-              data: {
-                submissionId: instance.id
-              }
-					  })
-          } catch (error) {
-            console.error(error);
-          }
-        },
-      },
     }
   );
 

--- a/packages/enquete/src/enquete.tsx
+++ b/packages/enquete/src/enquete.tsx
@@ -39,7 +39,26 @@ function Enquete(props: EnqueteWidgetProps) {
         isLoading: currentUserIsLoading,
     } = datastore.useCurrentUser({ ...props });
 
+    const formOnlyVisibleForUsers = (
+        (!!props.formVisibility && props.formVisibility === 'users')
+        || !props.formVisibility
+    );
+
     async function onSubmit(formData: any) {
+        formData.confirmationUser = props?.confirmation?.confirmationUser || false;
+        formData.confirmationAdmin = props?.confirmation?.confirmationAdmin || false;
+        formData.overwriteEmailAddress = (formData.confirmationAdmin && props?.confirmation?.overwriteEmailAddress) ? props?.confirmation?.overwriteEmailAddress : '';
+
+        const getUserEmailFromField = formData.confirmationUser && !formOnlyVisibleForUsers;
+
+        if (getUserEmailFromField) {
+            const userEmailAddressFieldKey = props?.confirmation?.userEmailAddress || null;
+
+            if (formData.hasOwnProperty(userEmailAddressFieldKey) && userEmailAddressFieldKey) {
+                formData.userEmailAddress = formData[userEmailAddressFieldKey] || '';
+            }
+        }
+
         const result = await createSubmission(formData, props.widgetId);
 
         if (result) {
@@ -50,11 +69,6 @@ function Enquete(props: EnqueteWidgetProps) {
             }
         }
     }
-
-    const formOnlyVisibleForUsers = (
-        (!!props.formVisibility && props.formVisibility === 'users')
-        || !props.formVisibility
-    );
 
 
     const formFields: FieldProps[] = [];

--- a/packages/enquete/src/types/enquete-props.ts
+++ b/packages/enquete/src/types/enquete-props.ts
@@ -9,6 +9,7 @@ export type EnqueteProps = {
   formVisibility?: string;
   imageUrl?: string;
   multiple?: boolean;
+  confirmation?: Confirmation;
 };
 
 export type Item = {
@@ -46,4 +47,11 @@ export type Title = {
   text: string;
   key: string;
   isOtherOption?: boolean;
+};
+
+export type Confirmation = {
+  confirmationUser?: boolean;
+  confirmationAdmin?: boolean;
+  overwriteEmailAddress?: string;
+  userEmailAddress?: string;
 };


### PR DESCRIPTION
Deze PR lost het volgende punt op:

> Wie ontvangt een melding als het contactformulier (enquete widget) wordt ingevuld? Waar kun je die instellen als dat mogelijk is? Zo niet, is dat mogelijk te maken deze week?