### PR TITLE
fix: show custom css for now

### DIFF
--- a/apps/cms-server/views/partials/css.html
+++ b/apps/cms-server/views/partials/css.html
@@ -1,3 +1,9 @@
+{% if data.global.cssExtras %}
+<style>
+  {{data.global.cssExtras}}
+</style>
+{% endif %}
+
 {% if data.global.customCssLink %}
   {% for link in data.global.customCssLink %}
     <link rel="stylesheet" href="{{ link.item }}">


### PR DESCRIPTION
It's no longer editable, but this gives us the opportunity to see the current custom CSS, and move it to the admin panel.