### PR TITLE
feat: Add display dislike choice to document map component

### DIFF
--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -692,6 +692,7 @@ function DocumentMap({
                     progressBarDescription={
                       props.likeWidget?.progressBarDescription
                     }
+                    displayDislike={props.likeWidget?.displayDislike}
                   />
                   <Spacer size={1} />
                 </>


### PR DESCRIPTION
Deze PR zorgt ervoor dat de instellingen om de dislike button wel/niet te tonen doorgegeven worden in de document map component. Dat was niet zo. waardoor het standaard niet werd getoond