### PR TITLE
fix: replace `new Buffer()` calls with `Buffer.from()`

### DIFF
--- a/apps/api-server/src/adapter/openstad/service.js
+++ b/apps/api-server/src/adapter/openstad/service.js
@@ -13,12 +13,12 @@ service.fetchUserData = async function fetchUserData({ authConfig, userId, email
   let headers = {};
   if ( userId ) {
     path = `/api/admin/user/${userId}?client_id=${authConfig.clientId}`;
-	  headers = { Authorization: `Basic ${new Buffer(`${authConfig.clientId}:${authConfig.clientSecret}`).toString('base64')}` };
+	  headers = { Authorization: `Basic ${Buffer.from(`${authConfig.clientId}:${authConfig.clientSecret}`).toString('base64')}` };
   }
 
   if ( email  ) {
     path = `/api/admin/users?email=${encodeURIComponent(email)}`;
-	  headers = { Authorization: `Basic ${new Buffer(`${authConfig.clientId}:${authConfig.clientSecret}`).toString('base64')}` };
+	  headers = { Authorization: `Basic ${Buffer.from(`${authConfig.clientId}:${authConfig.clientSecret}`).toString('base64')}` };
   }
 
   if ( accessToken ) {
@@ -81,7 +81,7 @@ service.createUser = async function({ authConfig, userData = {} }) {
 
     let response = await fetch(url, {
 	    headers: {
-        Authorization: `Basic ${new Buffer(`${authConfig.clientId}:${authConfig.clientSecret}`).toString('base64')}`,
+        Authorization: `Basic ${Buffer.from(`${authConfig.clientId}:${authConfig.clientSecret}`).toString('base64')}`,
         'Content-type': 'application/json',
       },
       method: 'post',
@@ -147,7 +147,7 @@ service.updateUser = async function({ authConfig, userData = {} }) {
 
     let response = await fetch(url, {
 	    headers: {
-        Authorization: `Basic ${new Buffer(`${authConfig.clientId}:${authConfig.clientSecret}`).toString('base64')}`,
+        Authorization: `Basic ${Buffer.from(`${authConfig.clientId}:${authConfig.clientSecret}`).toString('base64')}`,
         'Content-type': 'application/json',
       },
       method: 'post',
@@ -181,7 +181,7 @@ service.deleteUser = async function({ authConfig, userData = {} }) {
 
     let response = await fetch(url, {
 	    headers: {
-        Authorization: `Basic ${new Buffer(`${authConfig.clientId}:${authConfig.clientSecret}`).toString('base64')}`,
+        Authorization: `Basic ${Buffer.from(`${authConfig.clientId}:${authConfig.clientSecret}`).toString('base64')}`,
         'Content-type': 'application/json',
       },
       method: 'post',
@@ -211,7 +211,7 @@ service.fetchClient = async function({ authConfig, project }) {
     let url = `${authConfig.serverUrlInternal}/api/admin/client/${clientId}`;
     let response = await fetch(url, {
 	    headers: {
-        Authorization: `Basic ${new Buffer(`${authConfig.clientId}:${authConfig.clientSecret}`).toString('base64')}`,
+        Authorization: `Basic ${Buffer.from(`${authConfig.clientId}:${authConfig.clientSecret}`).toString('base64')}`,
       },
     })
     if (!response.ok) {
@@ -257,7 +257,7 @@ service.createClient = async function({ authConfig, project }) {
     let url = `${adminAuthConfig.serverUrlInternal}/api/admin/client`;
     let response = await fetch(url, {
 	    headers: {
-        Authorization: `Basic ${new Buffer(`${adminAuthConfig.clientId}:${adminAuthConfig.clientSecret}`).toString('base64')}`,
+        Authorization: `Basic ${Buffer.from(`${adminAuthConfig.clientId}:${adminAuthConfig.clientSecret}`).toString('base64')}`,
         'Content-type': 'application/json',
       },
       method: 'post',
@@ -354,7 +354,7 @@ service.updateClient = async function({ authConfig, project }) {
     let url = `${authConfig.serverUrlInternal}/api/admin/client/${clientId}`;
     let response = await fetch(url, {
 	    headers: {
-        Authorization: `Basic ${new Buffer(`${authConfig.clientId}:${authConfig.clientSecret}`).toString('base64')}`,
+        Authorization: `Basic ${Buffer.from(`${authConfig.clientId}:${authConfig.clientSecret}`).toString('base64')}`,
         'Content-type': 'application/json',
       },
       method: 'post',
@@ -382,7 +382,7 @@ service.fetchUniqueCode = async function({ authConfig }) {
     let url = `${authConfig.serverUrlInternal}/api/admin/unique-codes?clientId=${clientId}&amount=3`;
     let response = await fetch(url, {
 	    headers: {
-        Authorization: `Basic ${new Buffer(`${authConfig.clientId}:${authConfig.clientSecret}`).toString('base64')}`,
+        Authorization: `Basic ${Buffer.from(`${authConfig.clientId}:${authConfig.clientSecret}`).toString('base64')}`,
       },
     })
     if (!response.ok) {
@@ -408,7 +408,7 @@ service.createUniqueCode = async function({ authConfig, amount }) {
     let url = `${authConfig.serverUrlInternal}/api/admin/unique-code?clientId=${clientId}&amount=${amount}`;
     let response = await fetch(url, {
 	    headers: {
-        Authorization: `Basic ${new Buffer(`${authConfig.clientId}:${authConfig.clientSecret}`).toString('base64')}`,
+        Authorization: `Basic ${Buffer.from(`${authConfig.clientId}:${authConfig.clientSecret}`).toString('base64')}`,
       },
       method: 'post',
       body: '{}',
@@ -441,7 +441,7 @@ service.resetUniqueCode = async function({ authConfig, uniqueCodeId }) {
     let url = `${authConfig.serverUrlInternal}/api/admin/unique-code/${uniqueCodeId}/reset?clientId=${clientId}`;
     let response = await fetch(url, {
 	    headers: {
-        Authorization: `Basic ${new Buffer(`${authConfig.clientId}:${authConfig.clientSecret}`).toString('base64')}`,
+        Authorization: `Basic ${Buffer.from(`${authConfig.clientId}:${authConfig.clientSecret}`).toString('base64')}`,
       },
       method: 'post',
       body: '{}',

--- a/apps/auth-server/test/integration/admin.test.js
+++ b/apps/auth-server/test/integration/admin.test.js
@@ -31,7 +31,7 @@ describe('Grant Type Client', () => {
     const clientId = 'trustedClient';
     const clientSecret = 'ssh-otherpassword';
 
-    const basicAuth = new Buffer(`${clientId}:${clientSecret}`).toString('base64');
+    const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
 
     agent.get('/api/admin/users')
       .set('Content-Type', 'application/json')
@@ -44,7 +44,7 @@ describe('Grant Type Client', () => {
     const clientId = 'trustedClient';
     const clientSecret = 'ssh-otherpassword';
 
-    const basicAuth = new Buffer(`${clientId}:${clientSecret}`).toString('base64');
+    const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
 
     agent.get('/api/admin/users')
       .set('Content-Type', 'application/json')

--- a/apps/auth-server/test/integration/common/helper.js
+++ b/apps/auth-server/test/integration/common/helper.js
@@ -54,7 +54,7 @@ module.exports = {
    * @returns {Promise} OAuthPassword resolved
    */
   postOAuthPassword : (scope) => {
-    const basicAuth = new Buffer(`${clientId}:${clientSecret}`).toString('base64');
+    const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
     return post(token, {
       form : {
         username,
@@ -74,7 +74,7 @@ module.exports = {
    * @returns {Promise}  post resolved
    */
   postOAuthClient: (scope) => {
-    const basicAuth = new Buffer(`${clientId}:${clientSecret}`).toString('base64');
+    const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
     return post(token, {
       form : {
         username,
@@ -94,7 +94,7 @@ module.exports = {
    * @returns {Promise} refresh token resolved
    */
   postRefeshToken: (refreshToken) => {
-    const basicAuth = new Buffer(`${clientId}:${clientSecret}`).toString('base64');
+    const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
     return post(
       token, {
         form : {

--- a/apps/auth-server/test/integration/grant_type_client.test.js
+++ b/apps/auth-server/test/integration/grant_type_client.test.js
@@ -31,7 +31,7 @@ describe('Grant Type Client', () => {
 
 
   it('should get an 401 when asking for an access token', (done) => {
-    const basicAuth = new Buffer(`${clientId}:${clientSecret}`).toString('base64');
+    const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString('base64');
 
     agent.post(token, {
       form: {


### PR DESCRIPTION
The `new Buffer()` constructor is [deprecated](https://nodejs.org/api/deprecations.html#dep0005-buffer-constructor). Since this is only used to created buffers from strings, we can safely replace all instances of `new Buffer()` with `Buffer.from()`.

