### PR TITLE
feat: Set default fill for images to none and add more heights

### DIFF
--- a/apps/cms-server/modules/openstad-assets/ui/src/vendor/bootstrap/scss/_images.scss
+++ b/apps/cms-server/modules/openstad-assets/ui/src/vendor/bootstrap/scss/_images.scss
@@ -44,25 +44,33 @@
 
 // image component
 .image-component {
-  --image-height: 12.5rem;
   --image-width: 100%;
-  --image-object-fit: fill;
+  --image-object-fit: none;
 
   height: var(--image-height);
   object-fit: var(--image-object-fit);
   width: var(--image-width);
 
+  &.--xsmall {
+    --image-height: 9.375rem;
+  }
+
   &.--small {
-    --image-height: 12.5rem;
+    --image-height: 15.625rem;
   }
 
   &.--normal {
-    --image-height: 31.25rem;
+    --image-height: 21.875rem;
   }
 
   &.--large {
-    --image-height: 50rem;
+    --image-height: 28.125rem;
   }
+
+  &.--xlarge {
+    --image-height: 34.375rem;
+  }
+
 
   &.--contain {
     --image-object-fit: contain;
@@ -77,7 +85,7 @@
   }
 
   &.--none {
-    --image-object-fit: unset;
+    --image-object-fit: none;
   }
 }
 

--- a/apps/cms-server/modules/openstad-image-widget/index.js
+++ b/apps/cms-server/modules/openstad-image-widget/index.js
@@ -31,16 +31,24 @@ module.exports = {
         label: 'Hoogte',
         choices: [
           {
-            label: 'klein',
+            label: 'Extra klein',
+            value: '--xsmall',
+          },
+          {
+            label: 'Klein',
             value: '--small',
           },
           {
-            label: 'middel',
+            label: 'Normaal',
             value: '--normal',
           },
           {
-            label: 'groot',
+            label: 'Groot',
             value: '--large',
+          },
+          {
+            label: 'Extra groot',
+            value: '--xlarge',
           }
         ],
         required: true,
@@ -48,7 +56,7 @@ module.exports = {
 
       objectFit: {
         type: 'select',
-        def: '--fill',
+        def: '--none',
         label: 'Weergave',
         choices: [
           {


### PR DESCRIPTION
Deze PR zorgt ervoor dat de afbeeldingen standaard niet gefilled worden. Ook zijn er meerdere keuzes voor de hoogtes gemaakt, evenals een keuze om de originele hoogte van de afbeelding te gebruiken.