### PR TITLE
fix(widget): add check for `window.createRoot`

### DIFF
--- a/apps/api-server/src/util/react-check.js
+++ b/apps/api-server/src/util/react-check.js
@@ -15,6 +15,9 @@ module.exports = `
       const script = document.createElement('script');
       script.src = '${reactDomJs}';
       script.onload = function() {
+        if (typeof window.createRoot === 'undefined' && typeof ReactDOM !== 'undefined' && typeof ReactDOM.createRoot !== 'undefined') {
+          window.createRoot = ReactDOM.createRoot;
+        }
         document.addEventListener('OpenStadReactLoaded', renderWidget);
         triggerEvent();
       }


### PR DESCRIPTION
In some instances the `window.createRoot` was empty, while ReactDOM was loaded. This PR adds a check so we move the ReactDOM.createRoot to the global window object, if it is loaded.