### PR TITLE
Fix/general enschede fixes 0210

### DIFF
--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -902,6 +902,13 @@ function DocumentMap({
           )}
         </div>
 
+        <button
+              className={`back-to-top ${showButton ? "show" : ""}`}
+              onClick={scrollToTop}
+          >
+            <i className="ri-arrow-up-line"></i>
+          </button>
+
       </div>
 
     );

--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -193,6 +193,12 @@ function DocumentMap({
 
   const handleCommentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setCommentValue(e.target.value);
+
+    if (e.target.value.length > 0) {
+      characterHelpText(e.target.value.length);
+    } else {
+      setHelpText('');
+    }
   };
 
 
@@ -324,8 +330,6 @@ function DocumentMap({
   const addComment = async (e: any, position: any) => {
     e.preventDefault();
     e.stopPropagation();
-
-    characterHelpText(commentValue.length);
 
     if (
       commentValue.length >= props.comments?.descriptionMinLength


### PR DESCRIPTION
Deze PR lost de volgende 2 punten op:

- https://gyazo.com/7ae35e2971d9213a44144ba98e6525e2 Deze mis ik nog. Er is wel een melding als je op 'submit' klikt, maar niet tijdens het typen
- Op mobiel is deze widget een lange lijst met comments. Als je een marker plaatst, ga je helemaal naar onderen. Zou er een sticky 'back to top' knop kunnen komen voor op mobiel, zodat je weer makkelijk terug kunt naar de afbeelding?