### PR TITLE
feat: Set resource details as HTML so text markup is shown

### DIFF
--- a/packages/lib/ui-helpers.tsx
+++ b/packages/lib/ui-helpers.tsx
@@ -4,3 +4,47 @@ export function elipsize(value: string, maxLength: number) {
   }
   return value;
 }
+
+export function elipsizeHTML(value: string, maxLength: number) {
+  const tempDiv = document.createElement('div');
+  tempDiv.innerHTML = value;
+
+  let currentLength = 0;
+  let truncatedHTML = '';
+
+  function truncateNode(node: any) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const text = node.nodeValue || '';
+      if (currentLength + text.length > maxLength) {
+        truncatedHTML += text.substring(0, maxLength - currentLength) + '...';
+        currentLength = maxLength;
+      } else {
+        truncatedHTML += text;
+        currentLength += text.length;
+      }
+    } else if (node.nodeType === Node.ELEMENT_NODE) {
+      const tagName = node.nodeName.toLowerCase();
+      truncatedHTML += `<${tagName}`;
+
+      for (let i = 0; i < node.attributes.length; i++) {
+        const attr = node.attributes[i];
+        truncatedHTML += ` ${attr.name}="${attr.value}"`;
+      }
+      truncatedHTML += '>';
+
+      for (let i = 0; i < node.childNodes.length; i++) {
+        if (currentLength >= maxLength) break;
+        truncateNode(node.childNodes[i]);
+      }
+
+      truncatedHTML += `</${tagName}>`;
+    }
+  }
+
+  for (let i = 0; i < tempDiv.childNodes.length; i++) {
+    if (currentLength >= maxLength) break;
+    truncateNode(tempDiv.childNodes[i]);
+  }
+
+  return truncatedHTML;
+}

--- a/packages/resource-detail-with-map/src/resourceDetailWithMap.tsx
+++ b/packages/resource-detail-with-map/src/resourceDetailWithMap.tsx
@@ -194,7 +194,7 @@ function ResourceDetailWithMap({
             )}
 
             {displayTitle && resource.title && (
-              <Heading level={1} appearance="utrecht-heading-2">{resource.title}</Heading>
+              <Heading level={1} appearance="utrecht-heading-2" dangerouslySetInnerHTML={{__html: resource.title}}/>
             )}
             <div className="osc-resource-detail-content-item-row">
               {displayUser && resource?.user?.displayName && (
@@ -229,9 +229,9 @@ function ResourceDetailWithMap({
               )}
             </div>
             <div className="resource-detail-content">
-              {displaySummary && <Heading level={2} appearance='utrecht-heading-4'>{resource.summary}</Heading>}
+              {displaySummary && <Heading level={2} appearance='utrecht-heading-4' dangerouslySetInnerHTML={{__html: resource.summary}} />}
               {displayDescription && (
-                <Paragraph>{resource.description}</Paragraph>
+                <Paragraph dangerouslySetInnerHTML={{__html: resource.description}}/>
               )}
             </div>
             {displaySocials ? (

--- a/packages/resource-detail/src/resource-detail.tsx
+++ b/packages/resource-detail/src/resource-detail.tsx
@@ -194,9 +194,7 @@ function ResourceDetail({
               )}
 
               {displayTitle && resource.title && (
-                <Heading level={1} appearance="utrecht-heading-2">
-                  {resource.title}
-                </Heading>
+                <Heading level={1} appearance="utrecht-heading-2" dangerouslySetInnerHTML={{__html: resource.title}}></Heading>
               )}
 
               {displayModBreak && resource.modBreak && (
@@ -243,9 +241,9 @@ function ResourceDetail({
                 )}
               </div>
               <div className="resource-detail-content">
-                {displaySummary && <Heading level={2} appearance='utrecht-heading-4'>{resource.summary}</Heading>}
+                {displaySummary && <Heading level={2} appearance='utrecht-heading-4' dangerouslySetInnerHTML={{__html: resource.summary}}></Heading>}
                 {displayDescription && (
-                  <Paragraph>{resource.description}</Paragraph>
+                  <Paragraph dangerouslySetInnerHTML={{__html: resource.description}}></Paragraph>
                 )}
               </div>
               {displayLocation && resource.location && (

--- a/packages/resource-overview/src/resource-overview.tsx
+++ b/packages/resource-overview/src/resource-overview.tsx
@@ -9,7 +9,7 @@ import { Dialog } from '@openstad-headless/ui/src';
 import { BaseProps, ProjectSettingProps } from '@openstad-headless/types';
 import { Filters } from '@openstad-headless/ui/src/stem-begroot-and-resource-overview/filter';
 import { loadWidget } from '@openstad-headless/lib/load-widget';
-import { elipsize } from '../../lib/ui-helpers';
+import {elipsizeHTML} from '../../lib/ui-helpers';
 import { GridderResourceDetail } from './gridder-resource-detail';
 import { hasRole } from '@openstad-headless/lib';
 import nunjucks from 'nunjucks';
@@ -237,21 +237,20 @@ const defaultItemRenderer = (
           <div>
             <Spacer size={1}/>
             {props.displayTitle ? (
-                <Heading4>
-                  <a href={getUrl()} className="resource-card--link_trigger"> {elipsize(resource.title, props.titleMaxLength || 20)} </a>
+               <Heading4>
+                 <a href={getUrl()} className="resource-card--link_trigger" dangerouslySetInnerHTML={{__html: elipsizeHTML(resource.title, props.titleMaxLength || 20)}}/>
               </Heading4>
             ) : null}
 
             {props.displaySummary ? (
-              <Paragraph>
-                {elipsize(resource.summary, props.summaryMaxLength || 20)}
-              </Paragraph>
+              <Paragraph dangerouslySetInnerHTML={{__html: elipsizeHTML(resource.summary, props.summaryMaxLength || 20)}}/>
             ) : null}
 
             {props.displayDescription ? (
-              <Paragraph className="osc-resource-overview-content-item-description">
-                {elipsize(resource.description, props.descriptionMaxLength || 30)}
-              </Paragraph>
+              <Paragraph
+                className="osc-resource-overview-content-item-description"
+                dangerouslySetInnerHTML={{__html: elipsizeHTML(resource.description, props.descriptionMaxLength || 30)}}
+              />
             ) : null}
           </div>
 
@@ -302,20 +301,16 @@ const defaultItemRenderer = (
             <Spacer size={1} />
             {props.displayTitle ? (
               <Heading4>
-                <button className="resource-card--link_trigger" onClick={() => onItemClick && onItemClick()}>{elipsize(resource.title, props.titleMaxLength || 20)}</button>
+                <button className="resource-card--link_trigger" onClick={() => onItemClick && onItemClick()} dangerouslySetInnerHTML={{__html: elipsizeHTML(resource.title, props.titleMaxLength || 20)}}></button>
               </Heading4>
             ) : null}
 
             {props.displaySummary ? (
-              <Paragraph>
-                {elipsize(resource.summary, props.summaryMaxLength || 20)}
-              </Paragraph>
+              <Paragraph dangerouslySetInnerHTML={{__html: elipsizeHTML(resource.summary, props.summaryMaxLength || 20)}}/>
             ) : null}
 
             {props.displayDescription ? (
-              <Paragraph className="osc-resource-overview-content-item-description">
-                {elipsize(resource.description, props.descriptionMaxLength || 30)}
-              </Paragraph>
+              <Paragraph className="osc-resource-overview-content-item-description" dangerouslySetInnerHTML={{__html: elipsizeHTML(resource.description, props.descriptionMaxLength || 30)}}/>
             ) : null}
           </div>
 

--- a/packages/stem-begroot/src/step-1/begroot-detail-dialog/stem-begroot-detail-dialog.tsx
+++ b/packages/stem-begroot/src/step-1/begroot-detail-dialog/stem-begroot-detail-dialog.tsx
@@ -147,9 +147,9 @@ export const StemBegrootResourceDetailDialog = ({
 
                     <div>
                       <div>
-                        <Heading1>{resource.title}</Heading1>
-                        <Paragraph className="strong">{resource.summary}</Paragraph>
-                        <Paragraph>{resource.description}</Paragraph>
+                        <Heading1 dangerouslySetInnerHTML={{__html: resource.title}}/>
+                        <Paragraph className="strong" dangerouslySetInnerHTML={{__html: resource.summary}}/>
+                        <Paragraph dangerouslySetInnerHTML={{__html: resource.description}}/>
                       </div>
                     </div>
 

--- a/packages/stem-begroot/src/step-1/begroot-resource-list/stem-begroot-resource-list.tsx
+++ b/packages/stem-begroot/src/step-1/begroot-resource-list/stem-begroot-resource-list.tsx
@@ -8,7 +8,7 @@ import {
   Spacer,
 } from '@openstad-headless/ui/src';
 
-import { elipsize } from '@openstad-headless/lib/ui-helpers';
+import {elipsizeHTML} from '@openstad-headless/lib/ui-helpers';
 
 import "@utrecht/component-library-css";
 import "@utrecht/design-tokens/dist/root.css";
@@ -97,9 +97,9 @@ export const StemBegrootResourceList = ({
                   </div>
                 </div>
               </section>
-              <Heading level={2} appearance="utrecht-heading-4">{resource.title}</Heading>
-              <Paragraph>{elipsize(resource.summary, 100)}</Paragraph>
-              <Paragraph>{elipsize(resource.description, 200)}</Paragraph>
+              <Heading level={2} appearance="utrecht-heading-4" dangerouslySetInnerHTML={{__html: resource.title}}/>
+              <Paragraph dangerouslySetInnerHTML={{__html: elipsizeHTML(resource.summary, 100)}}/>
+              <Paragraph dangerouslySetInnerHTML={{__html: elipsizeHTML(resource.description, 200)}}/>
 
               {
                 originalUrl ? (


### PR DESCRIPTION
Deze PR zorgt ervoor dat je op meerdere plekken HTML kan gebruiken voor de resource titel, samenvatting en beschrijvingen.