### PR TITLE
fix: load ReactDOM in same version as React

### DIFF
--- a/apps/api-server/src/util/react-check.js
+++ b/apps/api-server/src/util/react-check.js
@@ -3,7 +3,7 @@ const reactJs =
   'https://unpkg.com/react@18.2.0/umd/react.production.min.js';
 const reactDomJs =
   process.env.REACT_DOM_CDN ||
-  'https://unpkg.com/react-dom@18.2.0/umd/react-dom.production.min.js';
+  'https://unpkg.com/react-dom@{VERSION}/umd/react-dom.production.min.js';
 
 module.exports = `
   function triggerEvent() {
@@ -12,8 +12,20 @@ module.exports = `
   
   function checkReactDom() {
     if (!hasReactDom && !reactDomLoaded) {
+    
+      if (!reactVersion) {
+        reactVersion = React.version;
+      }
+      
+      // Get same version of react-dom as react, ensuring we have a xx.x.x format
+      if (!/18\.\d{1,2}\.\d{1,2}/.test(reactVersion) === false) {
+        throw new Error('React version 18 is required');
+      }
+      
+      const reactDomUrl = '${reactDomJs}'.replace('{VERSION}', reactVersion);
+    
       const script = document.createElement('script');
-      script.src = '${reactDomJs}';
+      script.src = reactDomUrl;
       script.onload = function() {
         if (typeof window.createRoot === 'undefined' && typeof ReactDOM !== 'undefined' && typeof ReactDOM.createRoot !== 'undefined') {
           window.createRoot = ReactDOM.createRoot;
@@ -37,6 +49,7 @@ module.exports = `
   const reactLoaded = window.OpenStadReactLoaded;
   const hasReactDom = typeof ReactDOM !== 'undefined';
   const reactDomLoaded = window.OSReactDomLoaded;
+  let reactVersion = hasReact ? React.version : '';
 
   if (!hasReact && !reactLoaded) {
     const script = document.createElement('script');


### PR DESCRIPTION
This ensures the ReactDOM operates correctly with React.

To enable this with a custom CDN, add {VERSION} to the URL, which will be replaced with the same version as React, e.g. 18.2.0