### PR TITLE
feat: Change scope so the filtered resources have all tags included

### DIFF
--- a/apps/api-server/src/models/Resource.js
+++ b/apps/api-server/src/models/Resource.js
@@ -668,18 +668,14 @@ module.exports = function (db, sequelize, DataTypes) {
 
       selectTags: function (tags) {
         return {
-          include: [
-            {
-              model: db.Tag,
-              attributes: ['id', 'name'],
-              through: { attributes: [] },
-              where: {
-                id: {
-                  [db.Sequelize.Op.in]: tags,
-                },
-              },
+          where: {
+            id: {
+              [db.Sequelize.Op.in]: db.Sequelize.literal(`
+                (SELECT resourceId FROM resource_tags 
+                WHERE tagId IN (${tags.map(tag => `'${tag}'`).join(', ')}))
+              `),
             },
-          ],
+          },
         };
       },
 


### PR DESCRIPTION
Deze PR lost dit punt op:

> Als je een standaardafbeelding hebt gekozen bij een idee, en vervolgens in het overzicht de Wijken filter gebruikt om op dat idee te filteren, verdwijnt de standaardafbeelding (maar alleen in het overzicht)