### PR TITLE
feat: Add that the comment component can refresh itself

### DIFF
--- a/packages/comments/src/parts/comment.tsx
+++ b/packages/comments/src/parts/comment.tsx
@@ -29,6 +29,7 @@ function Comment({
   index,
   adminLabel,
   disableSubmit = false,
+  setRefreshComments,
   ...props
 }: CommentProps) {
   const widgetContext = useContext(CommentWidgetContext);
@@ -114,7 +115,7 @@ function Comment({
         } else if (oldVotes !== newVotes && attempts < maxAttempts) {
           attempts++;
           if (widgetContext && widgetContext.setRefreshComments) {
-            widgetContext.setRefreshComments((prev) => !prev);
+            widgetContext.setRefreshComments((prev: boolean) => !prev);
           }
         } else if (attempts < maxAttempts) {
           attempts++;

--- a/packages/comments/src/types/comment-props.ts
+++ b/packages/comments/src/types/comment-props.ts
@@ -1,4 +1,5 @@
 import {Comment} from '@openstad-headless/types';
+import React, { Dispatch, SetStateAction } from "react";
 
 export type CommentProps = {
   comment: Comment;
@@ -7,6 +8,7 @@ export type CommentProps = {
   index?: number;
   showDateSeperately?: boolean;
   submitComment?: (e: any) => void;
+  setRefreshComments: () => void;
   adminLabel?: string;
   disableSubmit?: boolean;
 };


### PR DESCRIPTION
Als een <Comments /> component in een andere widget wordt gebruikt kan de setRefreshComments props gebruikt worden om de widget te refreshen nadat een reactie of like is geplaatst. Wanneer de <Comments /> als los component in de site stond werkte het refreshen niet. Door de <Comments /> te verplaatsen naar de <CommentsInner /> is het mogelijk om het refreshen aan te roepen voor zichzelf.