### PR TITLE
Fix/enquete not showing description

### DIFF
--- a/packages/form/src/form.tsx
+++ b/packages/form/src/form.tsx
@@ -34,6 +34,9 @@ function Form({
       ...props
 }: FormProps) {
     const initialFormValues: { [key: string]: FormValue } = {};
+
+    console.log( 'Fields', fields );
+
     fields.forEach((field) => {
         if (field.fieldKey) {
             //@ts-expect-error
@@ -111,11 +114,11 @@ function Form({
         if (Component) {
             return (
                 <Component
-                    {...field}
+                    {...props}
                     index={index}
                     onChange={handleInputChange}
                     reset={(resetFn: () => void) => resetFunctions.current.push(resetFn)}
-                    {...props}
+                    {...field}
                 />
             );
         }

--- a/packages/form/src/form.tsx
+++ b/packages/form/src/form.tsx
@@ -34,9 +34,6 @@ function Form({
       ...props
 }: FormProps) {
     const initialFormValues: { [key: string]: FormValue } = {};
-
-    console.log( 'Fields', fields );
-
     fields.forEach((field) => {
         if (field.fieldKey) {
             //@ts-expect-error


### PR DESCRIPTION
In de props zit bij de enquete widget ook een description. Als die leeg is werd de description overschreven van het veld. De description van het veld moet leidend zijn en als die leeg is wordt het ook leeg meegegeven.