### PR TITLE
feat: Make mapIcon for tags and statuses work

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/statuses/[status]/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/statuses/[status]/index.tsx
@@ -29,6 +29,8 @@ import { useRouter } from 'next/router';
 import useStatus from '@/hooks/use-status';
 import { useCallback, useEffect } from 'react';
 import toast from 'react-hot-toast';
+import { X } from "lucide-react";
+import { ImageUploader } from "@/components/image-uploader";
 
 const formSchema = z.object({
   name: z.string(),
@@ -37,7 +39,8 @@ const formSchema = z.object({
   addToNewResources: z.boolean().optional(),
   color: z.string().optional(),
   label: z.string().optional(),
-  mapIcon: z.string().max(5000).optional(),
+  mapIcon: z.string().optional(),
+  mapIconUploader: z.string().optional(),
   listIcon: z.string().optional(),
   editableByUser: z.boolean().optional(),
   canComment: z.boolean().optional(),
@@ -60,6 +63,7 @@ export default function ProjectStatusEdit() {
       color: data?.color || undefined,
       label: data?.label || undefined,
       mapIcon: data?.mapIcon || undefined,
+      mapIconUploader: '',
       listIcon: data?.listIcon || undefined,
       editableByUser: data?.extraFunctionality?.editableByUser ?? true,
       canComment: data?.extraFunctionality?.canComment ?? true,
@@ -69,7 +73,7 @@ export default function ProjectStatusEdit() {
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver<any>(formSchema),
-    defaultValues: {},
+    defaultValues: defaults(),
   });
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
@@ -271,19 +275,44 @@ export default function ProjectStatusEdit() {
                         </FormItem>
                       )}
                     />
-                    <FormField
-                      control={form.control}
-                      name="mapIcon"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>Kaart icon</FormLabel>
-                          <FormControl>
-                            <Input placeholder="" {...field} />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
+
+                  <div className="grid grid-cols-2 gap-2">
+                    <ImageUploader
+                      form={form}
+                      fieldName="mapIconUploader"
+                      imageLabel="Icoon op de kaart"
+                      description="De geüploade afbeelding wordt automatisch ingesteld als de marker op de kaart voor de resource die aan deze status is gekoppeld. De ideale afmetingen voor een icoon zijn 30x40 pixels. Het ideale type is een .png of .svg"
+                      allowedTypes={['image/*']}
+                      onImageUploaded={(imageResult) => {
+                        const result = typeof (imageResult.url) !== 'undefined' ? imageResult.url : '';
+                        form.setValue('mapIcon', result);
+                        form.resetField('mapIconUploader');
+                        form.trigger('mapIcon');
+                      }}
                     />
+                    <div className="space-y-2 col-span-full md:col-span-1 flex flex-col">
+                      {!!form.watch('mapIcon') && (
+                        <>
+                          <label
+                            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Geüpload icoon</label>
+                          <section className="grid col-span-full grid-cols-3 gap-x-4 gap-y-8 ">
+                                <div className="relative">
+                                  <img src={form.watch('mapIcon')} alt=""/>
+                                  <Button
+                                    color="red"
+                                    onClick={() => {
+                                      form.setValue('mapIcon', '');
+                                    }}
+                                    className="absolute right-0 top-0">
+                                    <X size={24}/>
+                                  </Button>
+                                </div>
+                          </section>
+                        </>
+                      )}
+                    </div>
+                  </div>
+
                     <FormField
                       control={form.control}
                       name="listIcon"

--- a/apps/admin-server/src/pages/projects/[project]/tags/[tag]/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/tags/[tag]/index.tsx
@@ -36,7 +36,8 @@ const formSchema = z.object({
   backgroundColor: z.string().optional(),
   color: z.string().optional(),
   label: z.string().optional(),
-  mapIcon: z.string().max(5000).optional(),
+  mapIcon: z.string().optional(),
+  mapIconUploader: z.string().optional(),
   listIcon: z.string().optional(),
   useDifferentSubmitAddress: z.boolean().optional(),
   image: z.string().optional(),
@@ -64,6 +65,7 @@ export default function ProjectTagEdit() {
       color: data?.color || undefined,
       label: data?.label || undefined,
       mapIcon: data?.mapIcon || undefined,
+      mapIconUploader: '',
       listIcon: data?.listIcon || undefined,
       useDifferentSubmitAddress: undefinedToTrueOrProp(data?.useDifferentSubmitAddress),
       emails: data?.newSubmitAddress
@@ -76,9 +78,7 @@ export default function ProjectTagEdit() {
   );
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver<any>(formSchema),
-    defaultValues: {
-      newSubmitAddress: data?.newSubmitAddress || '',
-    },
+    defaultValues: defaults(),
   });
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
@@ -275,19 +275,44 @@ export default function ProjectTagEdit() {
                         </FormItem>
                       )}
                     />
-                    <FormField
-                      control={form.control}
-                      name="mapIcon"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>Kaart icon</FormLabel>
-                          <FormControl>
-                            <Input placeholder="" {...field} />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
+
+                  <div className="grid grid-cols-2 gap-2">
+                    <ImageUploader
+                      form={form}
+                      fieldName="mapIconUploader"
+                      imageLabel="Icoon op de kaart"
+                      description="De geüploade afbeelding wordt automatisch ingesteld als de marker op de kaart voor de resource die aan deze tag is gekoppeld. De ideale afmetingen voor een icoon zijn 30x40 pixels. Het ideale type is een .png of .svg"
+                      allowedTypes={['image/*']}
+                      onImageUploaded={(imageResult) => {
+                        const result = typeof (imageResult.url) !== 'undefined' ? imageResult.url : '';
+                        form.setValue('mapIcon', result);
+                        form.resetField('mapIconUploader');
+                        form.trigger('mapIcon');
+                      }}
                     />
+                    <div className="space-y-2 col-span-full md:col-span-1 flex flex-col">
+                      {!!form.watch('mapIcon') && (
+                        <>
+                          <label
+                            className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Geüpload icoon</label>
+                          <section className="grid col-span-full grid-cols-3 gap-x-4 gap-y-8 ">
+                                <div className="relative">
+                                  <img src={form.watch('mapIcon')} alt=""/>
+                                  <Button
+                                    color="red"
+                                    onClick={() => {
+                                      form.setValue('mapIcon', '');
+                                    }}
+                                    className="absolute right-0 top-0">
+                                    <X size={24}/>
+                                  </Button>
+                                </div>
+                          </section>
+                        </>
+                      )}
+                    </div>
+                  </div>
+
                     <FormField
                       control={form.control}
                       name="listIcon"

--- a/apps/api-server/src/models/Resource.js
+++ b/apps/api-server/src/models/Resource.js
@@ -519,7 +519,7 @@ module.exports = function (db, sequelize, DataTypes) {
           {
             model: db.Status,
             as: 'statuses',
-            attributes: ['id', 'name', 'label', 'extraFunctionality', 'color', 'backgroundColor'],
+            attributes: ['id', 'name', 'label', 'extraFunctionality', 'color', 'backgroundColor', 'mapIcon'],
             through: { attributes: [] },
             required: false,
           },
@@ -647,7 +647,7 @@ module.exports = function (db, sequelize, DataTypes) {
         include: [
           {
             model: db.Tag,
-            attributes: ['id', 'type', 'name', 'label', 'defaultResourceImage', 'documentMapIconColor'],
+            attributes: ['id', 'type', 'name', 'label', 'defaultResourceImage', 'documentMapIconColor', 'mapIcon'],
             through: { attributes: [] },
             required: false,
           },
@@ -659,7 +659,7 @@ module.exports = function (db, sequelize, DataTypes) {
           {
             model: db.Status,
             as: 'statuses',
-            attributes: ['id', 'name', 'label', 'extraFunctionality', 'color', 'backgroundColor'],
+            attributes: ['id', 'name', 'label', 'extraFunctionality', 'color', 'backgroundColor', 'mapIcon'],
             through: { attributes: [] },
             required: false,
           },

--- a/packages/leaflet-map/src/resource-overview-map.tsx
+++ b/packages/leaflet-map/src/resource-overview-map.tsx
@@ -18,6 +18,7 @@ import type {DataLayer, ResourceOverviewMapWidgetProps } from './types/resource-
 import { BaseMap } from './base-map';
 import React, { useState } from 'react';
 import { LocationType } from '@openstad-headless/leaflet-map/src/types/location.js';
+import L from 'leaflet';
 
 type Point = {
   lat: number;
@@ -91,7 +92,11 @@ const ResourceOverviewMap = ({
         }
       }
 
+      const firstStatus = resource.statuses && resource.statuses[0];
+      let MapIconImage = firstStatus && firstStatus.mapIcon ? firstStatus.mapIcon : '';
+
       const firstTag = resource.tags && resource.tags[0];
+      MapIconImage = firstTag && firstTag.mapIcon ? firstTag.mapIcon : '';
       const MapIconColor = firstTag && firstTag.documentMapIconColor ? firstTag.documentMapIconColor : '';
 
       // Set the resource name
@@ -102,6 +107,16 @@ const ResourceOverviewMap = ({
       // Set the icon color
       if (MapIconColor) {
         marker.icon.color = MapIconColor;
+      }
+
+      // Set the icon
+      if (MapIconImage) {
+        marker.icon = L.icon({
+          iconUrl: MapIconImage,
+          iconSize: [30, 40],
+          iconAnchor: [15, 40],
+          className: 'custom-image-icon',
+        });
       }
 
       return marker;


### PR DESCRIPTION
Deze PR zorgt ervoor dat je een icoon bij de tags en statussen kan uploaden, zodat deze op de interactieve kaart getoond worden als ze zijn gekoppeld aan een resource.