### PR TITLE
Fix/dh general fixes 1810

### DIFF
--- a/apps/api-server/src/util/react-check.js
+++ b/apps/api-server/src/util/react-check.js
@@ -71,16 +71,8 @@ module.exports = `
     
     document.body.appendChild(script);
     window.OpenStadReactLoaded = true;
-  } else if (hasReact && hasReactWithScheduler && !hasReactDom) {
-    window.OpenStadReactLoaded = true;
-    checkReactDom();
-  } else if (hasReact && hasReactWithScheduler && hasReactDom) {
+  } else {
+    // React has been loaded by a previous component on the page, render the widget when ReactDOM is loaded
     document.addEventListener('OpenStadReactDomLoaded', renderWidget);
-  
-    if (!window.OpenStadReactDOMLoaded) {
-      window.OpenStadReactLoaded = true;
-      window.OpenStadReactDOMLoaded = true;
-      triggerEvent('OpenStadReactDomLoaded');
-    }
   }
 `;

--- a/packages/leaflet-map/src/resource-overview-map.tsx
+++ b/packages/leaflet-map/src/resource-overview-map.tsx
@@ -96,7 +96,7 @@ const ResourceOverviewMap = ({
       let MapIconImage = firstStatus && firstStatus.mapIcon ? firstStatus.mapIcon : '';
 
       const firstTag = resource.tags && resource.tags[0];
-      MapIconImage = firstTag && firstTag.mapIcon ? firstTag.mapIcon : '';
+      MapIconImage = firstTag && firstTag.mapIcon ? firstTag.mapIcon : MapIconImage;
       const MapIconColor = firstTag && firstTag.documentMapIconColor ? firstTag.documentMapIconColor : '';
 
       // Set the resource name


### PR DESCRIPTION
Deze PR lost deze bugs op:

- Bij Den Haag is het niet mogelijk om meerdere widgets in te laden op 1 pagina door een recente aanpassing die dit probleem lokaal oplost.
- Als er geen tag is gekoppeld aan een resource werd het icoon van de status niet ingeladen, omdat de code voor de tag het icoon resette.