### PR TITLE
Feat/state document map settings

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/content.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/content.tsx
@@ -1,10 +1,10 @@
 import { Button } from '@/components/ui/button';
 import {
-    Form,
-    FormControl,
-    FormField,
-    FormItem,
-    FormLabel, FormMessage,
+  Form,
+  FormControl, FormDescription,
+  FormField,
+  FormItem,
+  FormLabel, FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 
@@ -32,6 +32,7 @@ const formSchema = z.object({
     largeDoc: z.boolean().optional(),
     infoPopupButtonText: z.string().optional(),
     openInfoPopupOnInit: z.string().optional(),
+    relativePathPrepend: z.string().optional(),
 });
 
 export default function DocumentContent(
@@ -60,6 +61,7 @@ export default function DocumentContent(
             closedText: props?.closedText || 'Het insturen van reacties is gesloten, u kunt niet meer reageren',
             largeDoc: props?.largeDoc || false,
             infoPopupButtonText: props?.infoPopupButtonText || '',
+            relativePathPrepend: props?.relativePathPrepend || '',
         },
     });
 
@@ -330,6 +332,29 @@ export default function DocumentContent(
                                 <FormLabel>
                                     Wat is de tekst voor de knop die de info pop-up opent?
                                 </FormLabel>
+                                <FormControl>
+                                    <Input {...field} />
+                                </FormControl>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+
+                    <Heading size="lg" className="mt-8 mb-2">Doorverwijzing</Heading>
+
+                    <FormField
+                        control={form.control}
+                        name="relativePathPrepend"
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormLabel>
+                                    Relatief pad naar document
+                                </FormLabel>
+                              <FormDescription>
+                                Mist er een gedeelte van de URL? Voeg het hier toe (Bijvoorbeeld: /projecten).
+                                Dit wordt gebruikt bij het doorverwijzen naar de inzending.
+                                Dit is vooral belangrijk als de homepagina een &quot;/&quot; bevat, zoals bijvoorbeeld https://openstad.nl/projecten
+                              </FormDescription>
                                 <FormControl>
                                     <Input {...field} />
                                 </FormControl>

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/document-map.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/document-map.tsx
@@ -1,0 +1,118 @@
+import { Button } from '@/components/ui/button';
+import {
+  Form,
+  FormControl, FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Separator } from '@/components/ui/separator';
+import { Heading } from '@/components/ui/typography';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import * as z from 'zod';
+import { ResourceDetailWidgetProps } from '@openstad-headless/resource-detail/src/resource-detail';
+import { EditFieldProps } from '@/lib/form-widget-helpers/EditFieldProps';
+import { useCallback, useEffect, useState } from 'react';
+import { useFieldDebounce } from '@/hooks/useFieldDebounce';
+import * as React from "react";
+
+const formSchema = z.object({
+  backUrlText: z.string().optional(),
+  backUrlIdRelativePath: z
+    .string()
+    .optional()
+    .refine(
+      (value) => !value || value.includes('[id]'),
+      'Specificeer een [id] veld'
+    ),
+});
+
+export default function WidgetResourceDetailDocumentMap(
+  props: ResourceDetailWidgetProps & EditFieldProps<ResourceDetailWidgetProps>
+) {
+
+  type FormData = z.infer<typeof formSchema>;
+  async function onSubmit(values: FormData) {
+    props.updateConfig({ ...props, ...values });
+  }
+
+  const { onFieldChange } = useFieldDebounce(props.onFieldChanged);
+
+  const defaults = useCallback(
+    () => ({
+      backUrlText: props?.backUrlText || undefined,
+      backUrlIdRelativePath: props?.backUrlIdRelativePath || undefined
+    }),
+    [props?.backUrlText, props?.backUrlIdRelativePath]
+  );
+
+  const form = useForm<FormData>({
+    resolver: zodResolver<any>(formSchema),
+    defaultValues: defaults(),
+  });
+
+  useEffect(() => {
+    form.reset(defaults());
+  }, [form, defaults]);
+
+  return (
+    <div className="p-6 bg-white rounded-md">
+      <Form {...form}>
+        <Heading size="xl">Instellingen interactieve afbeelding.</Heading>
+        <FormDescription>Pas de instellingen van de interactieve afbeelding aan.</FormDescription>
+        <Separator className="my-4" />
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="space-y-4 lg:w-1/2">
+
+          <FormField
+            control={form.control}
+            name="backUrlText"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Tekst van de terug knop</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="Terug naar het document"
+                    defaultValue={field.value}
+                    onChange={(e) => {
+                      field.onChange(e);
+                      onFieldChange(field.name, e.target.value);
+                    }}
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="backUrlIdRelativePath"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Relatief pad naar document
+                </FormLabel>
+                <em className="text-xs">Beschrijf hoe de inzending gehaald wordt uit de url: (/pad/naar/[id]) of laat leeg om terug te vallen op ?openstadResourceId</em>
+                <FormControl>
+                  <Input {...field} onChange={(e) => {
+                    onFieldChange(field.name, e.target.value);
+                    field.onChange(e);
+                  }} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button className="w-fit col-span-full" type="submit">
+            Opslaan
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/document-map.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/document-map.tsx
@@ -43,7 +43,7 @@ export default function WidgetResourceDetailDocumentMap(
 
   const defaults = useCallback(
     () => ({
-      backUrlText: props?.backUrlText || undefined,
+      backUrlText: props?.backUrlText || 'Terug naar het document',
       backUrlIdRelativePath: props?.backUrlIdRelativePath || undefined
     }),
     [props?.backUrlText, props?.backUrlIdRelativePath]

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/index.tsx
@@ -25,6 +25,7 @@ import { ArgumentWidgetTabProps } from '../../comments/[id]';
 import ArgumentsForm from '../../comments/[id]/form';
 import { LikeWidgetTabProps } from '../../likes/[id]';
 import { extractConfig } from '@/lib/sub-widget-helper';
+import WidgetResourceDetailDocumentMap from "@/pages/projects/[project]/widgets/resourcedetail/[id]/document-map";
 export const getServerSideProps = withApiUrl;
 
 export default function WidgetResourceDetail({ apiUrl }: WithApiUrlProps) {
@@ -64,6 +65,7 @@ export default function WidgetResourceDetail({ apiUrl }: WithApiUrlProps) {
               <TabsTrigger value="display">Weergave</TabsTrigger>
               <TabsTrigger value="comments">Reacties widget</TabsTrigger>
               <TabsTrigger value="likes">Likes widget</TabsTrigger>
+              <TabsTrigger value="document-map">Interactieve afbeelding</TabsTrigger>
               <TabsTrigger value="publish">Publiceren</TabsTrigger>
             </TabsList>
             <TabsContent value="general" className="p-0">
@@ -209,6 +211,25 @@ export default function WidgetResourceDetail({ apiUrl }: WithApiUrlProps) {
                     updateConfig,
                     updatePreview,
                   })}
+                />
+              )}
+            </TabsContent>
+
+            <TabsContent value="document-map" className="p-0">
+              {previewConfig && (
+                <WidgetResourceDetailDocumentMap
+                  {...previewConfig}
+                  updateConfig={(config) =>
+                    updateConfig({ ...widget.config, ...config })
+                  }
+                  onFieldChanged={(key, value) => {
+                    if (previewConfig) {
+                      updatePreview({
+                        ...previewConfig,
+                        [key]: value,
+                      });
+                    }
+                  }}
                 />
               )}
             </TabsContent>

--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -81,6 +81,7 @@ export type DocumentMapProps = BaseProps &
     infoPopupButtonText?: string;
     openInfoPopupOnInit?: string;
     closedText?: string;
+    relativePathPrepend?: string;
   };
 
 
@@ -113,6 +114,7 @@ function DocumentMap({
   infoPopupButtonText = '',
   openInfoPopupOnInit = 'no',
   closedText = 'Het insturen van reacties is gesloten, u kunt niet meer reageren',
+  relativePathPrepend = '',
   ...props
 }: DocumentMapProps) {
 
@@ -395,7 +397,7 @@ function DocumentMap({
   useEffect(() => {
     setRandomId(generateRandomId());
     if (window.location.hash.includes('#doc')) {
-      setBackUrl('/' + window.location.hash.split('=')[1] + (window.location.hash.split('=')[2] !== undefined ? '=' + window.location.hash.split('=')[2] : ''));
+      setBackUrl(relativePathPrepend + '/' + window.location.hash.split('=')[1] + (window.location.hash.split('=')[2] !== undefined ? '=' + window.location.hash.split('=')[2] : ''));
     }
   }, []);
 
@@ -871,13 +873,20 @@ function DocumentMap({
               {backUrl !== undefined && (
                 <div className="osc back-url-container">
                   <div className="banner">
-                    <Spacer size={2} />
+                    <Spacer size={2}/>
                     <Heading6>{props.backUrlContent}</Heading6>
-                    <Spacer size={1} />
-                    <ButtonLink appearance="primary-action-button" href={backUrl} title="Terug naar overzicht" id={randomId}>{props.backUrlText}</ButtonLink>
-                    <Spacer size={2} />
+                    <Spacer size={1}/>
+                    <a
+                      href={backUrl}
+                      className="utrecht-button-link utrecht-button-link--html-a utrecht-button-link--primary-action"
+                      title="Terug naar overzicht"
+                      id={randomId}
+                    >
+                      {props.backUrlText}
+                    </a>
+                    <Spacer size={2}/>
                   </div>
-                  <Spacer size={2} />
+                  <Spacer size={2}/>
                 </div>
               )}
               <div className='toggleMarkers'>

--- a/packages/resource-detail/src/resource-detail.tsx
+++ b/packages/resource-detail/src/resource-detail.tsx
@@ -54,6 +54,8 @@ export type ResourceDetailWidgetProps = {
     projectId?: string;
     resourceId?: string;
     resourceIdRelativePath?: string;
+    backUrlIdRelativePath?: string;
+    backUrlText?: string;
   } & booleanProps & {
     likeWidget?: Omit<
       LikeWidgetProps,

--- a/packages/resource-detail/src/resource-detail.tsx
+++ b/packages/resource-detail/src/resource-detail.tsx
@@ -98,6 +98,8 @@ function ResourceDetail({
   displayDocuments = true,
   documentsTitle = '',
   documentsDesc = '',
+  backUrlText = 'Terug naar het document',
+  backUrlIdRelativePath = '',
   ...props
 }: ResourceDetailWidgetProps) {
   const [refreshComments, setRefreshComments] = useState(false);
@@ -143,11 +145,49 @@ function ResourceDetail({
   const resourceImages = (Array.isArray(resource.images) && resource.images.length > 0) ? resource.images : [{ url: defaultImage }];
   const hasImages = (Array.isArray(resourceImages) && resourceImages.length > 0 && resourceImages[0].url !== '') ? '' : 'resource-has-no-images';
 
+  const getIdFromHash = () => {
+    try {
+      const hash = window.location.hash;
+
+      if (hash && hash.includes('#doc=')) {
+        const docParams = hash.split('#doc=')[1];
+
+        if (docParams && docParams.includes('?')) {
+          const queryParams = docParams.split('?')[1];
+
+          if (queryParams) {
+            const params = queryParams.split('&');
+
+            for (const param of params) {
+              const [key, value] = param.split('=');
+
+              if (key && value && !isNaN(Number(value))) {
+                return value;
+              }
+            }
+          }
+        }
+      }
+    } catch (error) {
+      console.error('Error while parsing the hash:', error);
+    }
+
+    return null;
+  };
+
   const getPageHash = () => {
     if (window.location.hash.includes('#doc')) {
-      const url = '/' + window.location.hash.split('=')[1] + (window.location.hash.split('=')[2] !== undefined ? '=' + window.location.hash.split('=')[2] : '');
+      let url = '/' + window.location.hash.split('=')[1] + (window.location.hash.split('=')[2] !== undefined ? '=' + window.location.hash.split('=')[2] : '');
 
-      return <div className="back-url"><Link href={url}>Terug naar het document</Link></div>
+      if ( backUrlIdRelativePath ) {
+        const backUrlId = getIdFromHash();
+
+        if (backUrlId) {
+          url = url.replace('[id]', backUrlId);
+        }
+      }
+
+      return <div className="back-url"><Link href={url}>{backUrlText}</Link></div>
     }
   };
 


### PR DESCRIPTION
Deze PR lost deze punten op:

> Er zijn twee speciale knoppen, waarmee je kunt wisselen tussen verschillende 'standen' van de document widget. Maar je kunt de link niet aanpassen die deze knoppen gebruiken. Nu geven ze 404's. Op deze pagina's vind je die:
> 
> https://jijmaaktenschede.nl/directduidelijk/tekstuele-versie?openstadResourceId=24#doc=tekst?openstadResourceId=24#doc=tekst?openstadResourceId=453 (aan de rechterkant). Hier kun je in de rechter kolom op 'bekijk de verbeterde versie' klikken. De link klopt niet.
> 
> https://jijmaaktenschede.nl/directduidelijk/tekst?openstadResourceId=24#doc=tekst?openstadResourceId=453 (linksbovenin). Hier staat 'Terug naar het document', maar je kunt de tekst én de link niet aanpassen.
> 
> Dit probleem is veroorzaakt door verhuizen naar een subdirectory domein.