### PR TITLE
Feat/stop showing help popup closed resources

### DIFF
--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -662,6 +662,10 @@ function DocumentMap({
       }
     };
 
+    const configVotingEnabled = props?.votes?.isActive || false;
+    const votingEnabled = configVotingEnabled && args.canComment;
+
+
     return !bounds ? null : (
       <div className={`documentMap--container ${largeDoc ? '--largeDoc' : ''}`}>
         <div className={`map-container ${!toggleMarker ? '--hideMarkers' : ''} ${displayMapSide}`}>
@@ -731,14 +735,14 @@ function DocumentMap({
                 bounds={bounds as LatLngBoundsLiteral}
                 aria-describedby={randomId}
               />
-              {popupPosition && !isDefinitive && (
+              {(popupPosition && !isDefinitive && args.canComment) && (
                 <Popup
                   position={popupPosition}
                   eventHandlers={{
                     popupclose: () => setPopupPosition(null),
                   }}
                 >
-                  {args.canComment && !hasRole(currentUser, args.requiredUserRole) ? (
+                  { !hasRole(currentUser, args.requiredUserRole) ? (
                     <>
                       <Paragraph>Om een reactie te plaatsen, moet je ingelogd zijn.</Paragraph>
                       <Spacer size={1} />
@@ -814,42 +818,45 @@ function DocumentMap({
               )}
             </MapContainer>
 
-            <Button className={`info-trigger ${infoPopupButtonText ? 'button-has-text' : ''}`}
-                    appearance='primary-action-button' onClick={() => setModalOpen(true)}>
-              <i className="ri-information-line"></i>
-              {infoPopupButtonText && (
-                  <span className="trigger-text">{infoPopupButtonText}</span>
-              )}
-              <span className="sr-only">{infoPopupButtonText || 'Hoe werkt het?'}</span>
-            </Button>
-
-
-            <div className="modal-overlay" aria-hidden={isModalOpen ? "false" : "true"}>
-              <div
-                  ref={modalRef}
-                  className="modal"
-                  role="dialog"
-                  aria-labelledby="modal-title"
-                  aria-modal="true"
-                  tabIndex={-1}
-              >
-                <Heading level={2}>Hoe werkt het?</Heading>
-                <Paragraph>{infoPopupContent}</Paragraph>
-                <Spacer size={1}/>
-                <Button appearance='secondary-action-button' aria-label="Close Modal" onClick={() => setModalOpen(false)}>
-                  <i className="ri-close-fill"></i>
-                  <span>Info venster sluiten</span>
+            { !!args.canComment && (
+              <>
+                <Button className={`info-trigger ${infoPopupButtonText ? 'button-has-text' : ''}`}
+                        appearance='primary-action-button' onClick={() => setModalOpen(true)}>
+                  <i className="ri-information-line"></i>
+                  {infoPopupButtonText && (
+                      <span className="trigger-text">{infoPopupButtonText}</span>
+                  )}
+                  <span className="sr-only">{infoPopupButtonText || 'Hoe werkt het?'}</span>
                 </Button>
-              </div>
-            </div>
 
+
+                <div className="modal-overlay" aria-hidden={isModalOpen ? "false" : "true"}>
+                  <div
+                      ref={modalRef}
+                      className="modal"
+                      role="dialog"
+                      aria-labelledby="modal-title"
+                      aria-modal="true"
+                      tabIndex={-1}
+                  >
+                    <Heading level={2}>Hoe werkt het?</Heading>
+                    <Paragraph>{infoPopupContent}</Paragraph>
+                    <Spacer size={1}/>
+                    <Button appearance='secondary-action-button' aria-label="Close Modal" onClick={() => setModalOpen(false)}>
+                      <i className="ri-close-fill"></i>
+                      <span>Info venster sluiten</span>
+                    </Button>
+                  </div>
+                </div>
+              </>
+            )}
 
           </div>
         </div>
         <div className="content document-map-info-container" ref={contentRef}>
           {!isDefinitive && (
             <>
-              {displayLikes && canComment && (
+              {displayLikes && (
                 <>
                   <Likes
                     {...props}
@@ -864,6 +871,7 @@ function DocumentMap({
                       props.likeWidget?.progressBarDescription
                     }
                     displayDislike={props.likeWidget?.displayDislike}
+                    disabled={!votingEnabled}
                   />
                   <Spacer size={1} />
                 </>

--- a/packages/likes/src/likes.tsx
+++ b/packages/likes/src/likes.tsx
@@ -34,6 +34,7 @@ export type LikeProps = {
   hideCounters?: boolean;
   showProgressBar?: boolean;
   progressBarDescription?: string;
+  disabled?: boolean;
 };
 
 function Likes({
@@ -44,6 +45,7 @@ function Likes({
   noLabel = 'Tegen',
   displayDislike = false,
   showProgressBar = true,
+  disabled = false,
   ...props
 }: LikeWidgetProps) {
 
@@ -149,7 +151,10 @@ function Likes({
                 resource?.userVote?.opinion === likeVariant.type
                   ? 'selected'
                   : ''
-              } ${hideCounters ? 'osc-no-counter' : ''}`}>
+                } ${hideCounters ? 'osc-no-counter' : ''}`
+              }
+              disabled={disabled}
+            >
               <section className="like-kind">
                 <i className={likeVariant.icon}></i>
                 {variant === 'small' ? null : likeVariant.label}


### PR DESCRIPTION
Deze PR lost de volgende punten op:

> Er moet naar de status van een resource worden gekeken om te checken of de hulp popup automatisch opent zodra je de pagina opent. Reageren inactief = geen auto popup

> Op de originele versie met reacties moet je nog wel de likes kunnen zien, echter alleen disabled. Dus als de status disabled is, dan wel likes tonen, maar in disabled state

> Als de reacties zijn gesloten, kun je nog steeds op de afbeelding klikken om een reactie toe te voegen.