### PR TITLE
Fix/dont reset bounds after closing popup

### DIFF
--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -584,7 +584,6 @@ function DocumentMap({
         if (popupPosition) {
           map.setMaxBounds( [] );
         } else {
-          map.fitBounds(bounds);
           map.setMaxBounds(bounds);
         }
       }

--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -662,6 +662,10 @@ function DocumentMap({
       }
     };
 
+    const configVotingEnabled = props?.votes?.isActive || false;
+    const votingEnabled = configVotingEnabled && args.canComment;
+
+
     return !bounds ? null : (
       <div className={`documentMap--container ${largeDoc ? '--largeDoc' : ''}`}>
         <div className={`map-container ${!toggleMarker ? '--hideMarkers' : ''} ${displayMapSide}`}>
@@ -731,14 +735,14 @@ function DocumentMap({
                 bounds={bounds as LatLngBoundsLiteral}
                 aria-describedby={randomId}
               />
-              {popupPosition && !isDefinitive && (
+              {(popupPosition && !isDefinitive && args.canComment) && (
                 <Popup
                   position={popupPosition}
                   eventHandlers={{
                     popupclose: () => setPopupPosition(null),
                   }}
                 >
-                  {args.canComment && !hasRole(currentUser, args.requiredUserRole) ? (
+                  { !hasRole(currentUser, args.requiredUserRole) ? (
                     <>
                       <Paragraph>Om een reactie te plaatsen, moet je ingelogd zijn.</Paragraph>
                       <Spacer size={1} />
@@ -814,42 +818,45 @@ function DocumentMap({
               )}
             </MapContainer>
 
-            <Button className={`info-trigger ${infoPopupButtonText ? 'button-has-text' : ''}`}
-                    appearance='primary-action-button' onClick={() => setModalOpen(true)}>
-              <i className="ri-information-line"></i>
-              {infoPopupButtonText && (
-                  <span className="trigger-text">{infoPopupButtonText}</span>
-              )}
-              <span className="sr-only">{infoPopupButtonText || 'Hoe werkt het?'}</span>
-            </Button>
-
-
-            <div className="modal-overlay" aria-hidden={isModalOpen ? "false" : "true"}>
-              <div
-                  ref={modalRef}
-                  className="modal"
-                  role="dialog"
-                  aria-labelledby="modal-title"
-                  aria-modal="true"
-                  tabIndex={-1}
-              >
-                <Heading level={2}>Hoe werkt het?</Heading>
-                <Paragraph>{infoPopupContent}</Paragraph>
-                <Spacer size={1}/>
-                <Button appearance='secondary-action-button' aria-label="Close Modal" onClick={() => setModalOpen(false)}>
-                  <i className="ri-close-fill"></i>
-                  <span>Info venster sluiten</span>
+            { !!args.canComment && (
+              <>
+                <Button className={`info-trigger ${infoPopupButtonText ? 'button-has-text' : ''}`}
+                        appearance='primary-action-button' onClick={() => setModalOpen(true)}>
+                  <i className="ri-information-line"></i>
+                  {infoPopupButtonText && (
+                      <span className="trigger-text">{infoPopupButtonText}</span>
+                  )}
+                  <span className="sr-only">{infoPopupButtonText || 'Hoe werkt het?'}</span>
                 </Button>
-              </div>
-            </div>
 
+
+                <div className="modal-overlay" aria-hidden={isModalOpen ? "false" : "true"}>
+                  <div
+                      ref={modalRef}
+                      className="modal"
+                      role="dialog"
+                      aria-labelledby="modal-title"
+                      aria-modal="true"
+                      tabIndex={-1}
+                  >
+                    <Heading level={2}>Hoe werkt het?</Heading>
+                    <Paragraph>{infoPopupContent}</Paragraph>
+                    <Spacer size={1}/>
+                    <Button appearance='secondary-action-button' aria-label="Close Modal" onClick={() => setModalOpen(false)}>
+                      <i className="ri-close-fill"></i>
+                      <span>Info venster sluiten</span>
+                    </Button>
+                  </div>
+                </div>
+              </>
+            )}
 
           </div>
         </div>
         <div className="content document-map-info-container" ref={contentRef}>
           {!isDefinitive && (
             <>
-              {displayLikes && canComment && (
+              {displayLikes && (
                 <>
                   <Likes
                     {...props}
@@ -864,6 +871,7 @@ function DocumentMap({
                       props.likeWidget?.progressBarDescription
                     }
                     displayDislike={props.likeWidget?.displayDislike}
+                    disabled={!votingEnabled}
                   />
                   <Spacer size={1} />
                 </>

--- a/packages/likes/src/likes.tsx
+++ b/packages/likes/src/likes.tsx
@@ -34,6 +34,7 @@ export type LikeProps = {
   hideCounters?: boolean;
   showProgressBar?: boolean;
   progressBarDescription?: string;
+  disabled?: boolean;
 };
 
 function Likes({
@@ -44,6 +45,7 @@ function Likes({
   noLabel = 'Tegen',
   displayDislike = false,
   showProgressBar = true,
+  disabled = false,
   ...props
 }: LikeWidgetProps) {
 
@@ -149,7 +151,10 @@ function Likes({
                 resource?.userVote?.opinion === likeVariant.type
                   ? 'selected'
                   : ''
-              } ${hideCounters ? 'osc-no-counter' : ''}`}>
+                } ${hideCounters ? 'osc-no-counter' : ''}`
+              }
+              disabled={disabled}
+            >
               <section className="like-kind">
                 <i className={likeVariant.icon}></i>
                 {variant === 'small' ? null : likeVariant.label}


### PR DESCRIPTION
Deze PR lost het volgende punt op:

> Als ik een marker plaats en bedenk dat ik verkeerd sta, kan ik op het kruisje rechtsbooven klikken om de marker weer te verwijderen. Dan raak ik echter mijn positie en zoomniveau kwijt. De brief staat weer in de standaard positie. Terrwijl ik wil dat hij vasthoudt waar ik stond en hoever ik was ingezoomd.