### PR TITLE
feat: Add option to choose which view on init is set for the document image

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/general.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/general.tsx
@@ -21,9 +21,11 @@ import { useEffect, useState } from "react";
 import * as React from "react";
 import * as Switch from '@radix-ui/react-switch';
 import { YesNoSelect } from '@/lib/form-widget-helpers';
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from "@/components/ui/select";
 
 const formSchema = z.object({
   resourceId: z.string().optional(),
+  entireDocumentVisible: z.enum(['entirely', 'onlyTop']).optional(),
   zoom: z.number().optional(),
   minZoom: z.number().optional(),
   maxZoom: z.number().optional(),
@@ -54,6 +56,7 @@ export default function DocumentGeneral(
       zoom: props.zoom || 1,
       minZoom: props.minZoom || -6,
       maxZoom: props.maxZoom || 10,
+      entireDocumentVisible: props.entireDocumentVisible || 'entirely',
     },
   });
 
@@ -208,6 +211,32 @@ export default function DocumentGeneral(
               <FormLabel>Grotere weergave voor het document</FormLabel>
               {YesNoSelect(field, props)}
               <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="entireDocumentVisible"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Welk gedeelte van de afbeelding moet zichtbaar zijn als de widget is ingeladen?</FormLabel>
+              <Select
+                onValueChange={(value) => {
+                  field.onChange(value);
+                  props.onFieldChanged(field.name, value);
+                }}
+                value={field.value}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Standaard" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="entirely">Hele afbeelding zichtbaar</SelectItem>
+                  <SelectItem value="onlyTop">Focus op de bovenkant</SelectItem>
+                </SelectContent>
+              </Select>
             </FormItem>
           )}
         />

--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -82,6 +82,7 @@ export type DocumentMapProps = BaseProps &
     openInfoPopupOnInit?: string;
     closedText?: string;
     relativePathPrepend?: string;
+    entireDocumentVisible?: 'entirely' | 'onlyTop';
   };
 
 
@@ -115,6 +116,7 @@ function DocumentMap({
   openInfoPopupOnInit = 'no',
   closedText = 'Het insturen van reacties is gesloten, u kunt niet meer reageren',
   relativePathPrepend = '',
+  entireDocumentVisible = 'onlyTop',
   ...props
 }: DocumentMapProps) {
 
@@ -326,7 +328,20 @@ function DocumentMap({
 
     useEffect(() => {
       if (map && bounds && !!docHeight && !!docWidth && !isBoundsSet) {
-        map.fitBounds(bounds as LatLngBoundsLiteral);
+        if (entireDocumentVisible === 'entirely') {
+          map.fitBounds(bounds as LatLngBoundsLiteral);
+        } else {
+          map.setMaxBounds(bounds as LatLngBoundsLiteral);
+          const topLeft = bounds[0];
+          const topRight = [bounds[0][0], bounds[1][1]];
+
+          const topBounds: LatLngBoundsLiteral = [
+            [topLeft[0], topLeft[1]],
+            [topRight[0], topRight[1]]
+          ];
+
+          map.flyToBounds(topBounds, { animate: true, duration: 0.2 });
+        }
         map.scrollWheelZoom.disable();
         setIsBoundsSet(true);
       }


### PR DESCRIPTION
Deze PR zorgt ervoor dat je kunt kiezen voor de interactieve afbeelding of je wil dat de gehele afbeelding zichtbaar is bij het inladen of alleen de bovenkant