### PR TITLE
fix: Use relative path for the back button to the document

### DIFF
--- a/packages/resource-detail/src/resource-detail.tsx
+++ b/packages/resource-detail/src/resource-detail.tsx
@@ -183,7 +183,7 @@ function ResourceDetail({
         const backUrlId = getIdFromHash();
 
         if (backUrlId) {
-          url = url.replace('[id]', backUrlId);
+          url = backUrlIdRelativePath.replace('[id]', backUrlId);
         }
       }
 


### PR DESCRIPTION
Deze PR zorgt ervoor dat de knop voor 'Terug naar het document' het goede pad gebruikt die is ingesteld.