### PR TITLE
Fix/duplicate site problems

### DIFF
--- a/apps/api-server/src/middleware/project.js
+++ b/apps/api-server/src/middleware/project.js
@@ -13,7 +13,7 @@ const getProjectId = (path) => {
 module.exports = function( req, res, next ) {
 
   // deze paden mogen dit overslaan
-  if (req.path.match('^(/api/repo|/api/template|/api/area|/api/datalayer|/api/widget|/api/image|/api/document|/api/widget-type|/widget|/$)')) return next();
+  if (req.path.match('^(/api/repo|/api/template|/api/area|/api/datalayer|/api/widget|/api/image|/api/document|/api/widget-type|/api/project/delete-duplicated-data|/widget|/$)')) return next();
   if (req.path.match('^(/api/lock(/[^/]*)?)$')) return next();
   if ((req.path.match('^(/api/user)') && ( req.method == 'GET' ))) return next();
 

--- a/apps/api-server/src/models/Project.js
+++ b/apps/api-server/src/models/Project.js
@@ -168,6 +168,8 @@ module.exports = function (db, sequelize, DataTypes) {
       },
 
       afterCreate: async function (instance, options) {
+        if (options.skipDefaultStatuses) return;
+
         // create a default status
         let defaultStatus = await db.Status.create({
           projectId: instance.id,


### PR DESCRIPTION
Problemen die hiermee zijn opgelost:
- Standaard statussen worden niet extra toegevoegd bij het gedupliceerde project
- Bij errors gaat de pagina niet meer stuk

Uitbreidingen:
- Gebruikers die gekoppeld zijn aan een resource worden gekopieerd naar het nieuwe project. Mocht de gebruiker niet meer bestaan, wordt er een anonieme user aangemaakt
- Na fouten bij het dupliceren kun je er nu voor kiezen om de duplicatie terug te draaien