### PR TITLE
fix: Use the filename from the updated file instead of creating one

### DIFF
--- a/apps/image-server/server.js
+++ b/apps/image-server/server.js
@@ -228,7 +228,12 @@ app.get('/document/*',
  */
 app.post('/document',
   documentUpload.single('document'), (req, res, next) => {
-    const fileName = createFilename(req.file.originalname);
+    const fileName = req?.file?.filename || '';
+
+    // Check if the filename is not empty
+    if (!fileName) {
+      return res.status(400).send(JSON.stringify({ error: 'No file uploaded' }));
+    }
 
     let url = `${process.env.APP_URL}/document/${encodeURIComponent(fileName)}`;
 


### PR DESCRIPTION
Deze PR zorgt ervoor dat een single document upload de goede URL terugstuurt na het uploaden van een bestand.