### PR TITLE
feat: Create fields to choose if budget and tags are visible in the dialog

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourceoverview/[id]/display.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourceoverview/[id]/display.tsx
@@ -46,6 +46,8 @@ const formSchema = z.object({
   resetText: z.string().optional(),
   displayLikeButton: z.boolean(),
   clickableImage: z.boolean(),
+  displayBudget: z.boolean(),
+  displayTags: z.boolean(),
   // displayRanking: z.boolean(),
   // displayLabel: z.boolean(),
   // displayShareButtons: z.boolean(),
@@ -87,6 +89,8 @@ export default function WidgetResourceOverviewDisplay(
       resetText: props?.resetText || 'Reset',
       displayLikeButton: props?.displayLikeButton || false,
       clickableImage: props?.clickableImage || false,
+      displayBudget: props?.displayBudget !== false,
+      displayTags: props?.displayTags !== false,
       // displayRanking: props?.displayRanking || false,
       // displayLabel: props?.displayLabel || false,
       // displayShareButtons: props?.displayShareButtons || false,
@@ -332,6 +336,34 @@ export default function WidgetResourceOverviewDisplay(
               <FormItem>
                 <FormLabel>
                   Status label weergeven
+                </FormLabel>
+                {YesNoSelect(field, props)}
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="displayBudget"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Budget in dialog weergeven
+                </FormLabel>
+                {YesNoSelect(field, props)}
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="displayTags"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Tags in dialog weergeven
                 </FormLabel>
                 {YesNoSelect(field, props)}
                 <FormMessage />

--- a/packages/resource-overview/src/gridder-resource-detail.tsx
+++ b/packages/resource-overview/src/gridder-resource-detail.tsx
@@ -37,6 +37,8 @@ export type GridderResourceDetailProps =
   clickableImage?: boolean;
   documentsTitle?: string;
   documentsDesc?: string;
+  displayTags?: boolean;
+  displayBudget?: boolean;
   likeWidget?: Omit<
     LikeWidgetProps,
     keyof BaseProps | keyof ProjectSettingProps | 'resourceId'
@@ -51,6 +53,8 @@ export const GridderResourceDetail = ({
   documentsTitle = '',
   documentsDesc = '',
   clickableImage = false,
+  displayTags = true,
+  displayBudget = true,
   currentUser,
   ...props
 }: GridderResourceDetailProps) => {
@@ -107,16 +111,27 @@ export const GridderResourceDetail = ({
           {renderImage(resource.images?.at(0)?.url || defaultImage, clickableImage)}
 
           <div className="osc-gridder-resource-detail-budget-theme-bar">
-            <Heading4>Budget</Heading4>
-            <Paragraph>&euro; {resource.budget > 0 ? resource.budget.toLocaleString('nl-NL') : 0}</Paragraph>
-            <Spacer size={1} />
-            <Heading4>Tags</Heading4>
-            <Spacer size={.5} />
-            <div className="pill-grid">
-                  {(resource.tags as Array<{ type: string; name: string }>)
-                    ?.filter((t) => t.type !== 'status')
-                    ?.map((t) => <Pill text={t.name} />)}
+
+            {displayBudget && (
+              <>
+                <Heading4>Budget</Heading4>
+                <Paragraph>&euro; {resource.budget > 0 ? resource.budget.toLocaleString('nl-NL') : 0}</Paragraph>
+                <Spacer size={1} />
+              </>
+            )}
+
+            {displayTags && (
+              <>
+                <Heading4>Tags</Heading4>
+                <Spacer size={.5} />
+                <div className="pill-grid">
+                      {(resource.tags as Array<{ type: string; name: string }>)
+                        ?.filter((t) => t.type !== 'status')
+                        ?.map((t) => <Pill text={t.name} />)}
                 </div>
+              </>
+            )}
+
           </div>
         </section>
 

--- a/packages/resource-overview/src/resource-overview.tsx
+++ b/packages/resource-overview/src/resource-overview.tsx
@@ -92,6 +92,8 @@ export type ResourceOverviewWidgetProps = BaseProps &
     onFilteredResourcesChange?: (filteredResources: any[]) => void;
     displayLikeButton?: boolean;
     clickableImage?: boolean;
+    displayBudget?: boolean;
+    displayTags?: boolean;
   };
 
 //Temp: Header can only be made when the map works so for now a banner
@@ -355,6 +357,8 @@ function ResourceOverview({
   showActiveTags = false,
   displayLikeButton = false,
   clickableImage = false,
+  displayTags = true,
+  displayBudget= true,
   documentsTitle = '',
   documentsDesc = '',
   displayVariant = '',
@@ -535,6 +539,8 @@ function ResourceOverview({
                 displayDocuments={displayDocuments}
                 documentsTitle={documentsTitle}
                 documentsDesc={documentsDesc}
+                displayTags={displayTags}
+                displayBudget={displayBudget}
                 displayLikeButton={displayLikeButton}
                 clickableImage={clickableImage}
                 onRemoveClick={(resource) => {


### PR DESCRIPTION
Deze PR zorgt ervoor dat je nu kan kiezen of je de tags en het budget wil tonen in de dialoog bij het inzendingen overzicht