### PR TITLE
fix: Use different call for retrieving the areas

### DIFF
--- a/packages/leaflet-map/src/area.tsx
+++ b/packages/leaflet-map/src/area.tsx
@@ -6,6 +6,7 @@ import { Polygon, Popup } from 'react-leaflet';
 import type { AreaProps } from './types/area-props';
 
 import { difference, polygon as tPolygon } from 'turf';
+import { BaseProps } from '@openstad-headless/types/base-props';
 
 function createCutoutPolygonMulti(areas: any) {
   const outerBoxCoordinates = [
@@ -75,9 +76,11 @@ export function Area({
     fillOpacity: 0.15,
   },
   ...props
-}: AreaProps) {
+}: BaseProps & AreaProps) {
   const datastore = new DataStore({});
-  const { data: allAreas } = datastore.useAreas();
+  const { data: allAreas } = datastore.useArea({
+    projectId: props.projectId
+  });
 
   interface Area {
     id: number;

--- a/packages/leaflet-map/src/base-map.tsx
+++ b/packages/leaflet-map/src/base-map.tsx
@@ -407,7 +407,7 @@ const BaseMap = ({
           <TileLayer {...tileLayerProps} />
 
           {area && area.length ? (
-            <Area area={area} areas={customPolygon} areaPolygonStyle={areaPolygonStyle} />
+            <Area area={area} areas={customPolygon} areaPolygonStyle={areaPolygonStyle} {...props} />
           ) : null}
 
           {!!currentMarkers && currentMarkers.length > 0 && currentMarkers.map((data) => {


### PR DESCRIPTION
Deze PR zorgt ervoor dat de useAreas niet meer gebruikt wordt in het bestand van de polygonen. De useAreas gebruikt een api call die nu alleen lokaal werkt, terwijl de useArea altijd de gebieden goed ophaalt. Hierdoor krijg je dus niet meer standaard meerdere foutmeldingen tijdens het inladen van de kaart met polygonen. Mogelijk lost dit het probleem op voor de wijkenkaart van Enschede, los van dat het al een onjuiste api call oplost.