### PR TITLE
Fix/save auth settings

### DIFF
--- a/apps/api-server/src/adapter/openstad/service.js
+++ b/apps/api-server/src/adapter/openstad/service.js
@@ -320,8 +320,8 @@ service.updateClient = async function({ authConfig, project }) {
         canCreateNewUsers: project.config.users?.canCreateNewUsers
       },
       styling: {
-        logo: authConfig?.config?.styling?.logo || project.config.styling?.logo,
-        favicon: authConfig?.config?.styling?.favicon || project.config.styling?.favicon,
+        logo: authConfig?.config?.styling?.logo || client?.config?.styling?.logo || project.config.styling?.logo,
+        favicon: authConfig?.config?.styling?.favicon || client?.config?.styling?.favicon || project.config.styling?.favicon,
         inlineCSS: project.config.styling?.inlineCSS,
         displayClientName: project.config.styling?.displayClientName,
       },

--- a/apps/api-server/src/routes/api/project.js
+++ b/apps/api-server/src/routes/api/project.js
@@ -585,13 +585,15 @@ router.route('/:projectId') //(\\d+)
     if (!hasRole( req.user, 'admin')) return next();
     try {
       let providers = await authSettings.providers({ project });
+      const configData = req.body.config?.auth?.provider?.openstad?.config || {};
+
       for (let provider of providers) {
-        let authData = req.body.config?.auth?.provider?.[provider];
-        if (!authData) continue;
+        if ( Object.keys(configData).length === 0 ) continue;
+
         let authConfig = await authSettings.config({ project, useAuth: provider });
         let adapter = await authSettings.adapter({ authConfig });
         if (adapter.service.updateClient) {
-          let merged = merge.recursive({}, authConfig, req.body.config?.auth?.provider?.[authConfig.provider])
+          let merged = merge.recursive({}, authConfig, {config: configData});
           await adapter.service.updateClient({ authConfig: merged, project });
           delete req.body.config?.auth?.provider?.[authConfig.provider]?.authTypes;
           delete req.body.config?.auth?.provider?.[authConfig.provider]?.twoFactorRoles;


### PR DESCRIPTION
Deze PR lost de volgende 2 punten op:

- Logo en favicon van de auth werden gereset als er andere instellingen aangepast werden
- De anonieme configuratie werd niet aangepast als je in de admin instellingen aanpaste