### PR TITLE
fix: prevent sending emails to info@openstad.org

### DIFF
--- a/apps/api-server/src/models/Notification.js
+++ b/apps/api-server/src/models/Notification.js
@@ -83,6 +83,10 @@ module.exports = ( db, sequelize, DataTypes ) => {
 
           if (managerTypes.find(type => type == instance.type)) {
             let defaultRecipient = project.emailConfig?.notifications?.projectmanagerAddress;
+            
+            if (defaultRecipient === 'info@openstad.org') {
+              defaultRecipient = '';
+            }
 
             let overwriteEmail =  (
               instance.data.hasOwnProperty('emailReceivers')


### PR DESCRIPTION
This is the default e-mail for now, but we don't want to ever send to this e-mail address.