### PR TITLE
fix: Don't show status bar when display status is set to false

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/display.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/display.tsx
@@ -30,6 +30,7 @@ const formSchema = z.object({
   displayTags: z.boolean(),
   displaySocials: z.boolean(),
   displayStatus: z.boolean(),
+  displayStatusBar: z.boolean(),
   displayLikes: z.boolean(),
   displayDocuments: z.boolean(),
   documentsTitle: z.string().optional(),
@@ -65,6 +66,7 @@ export default function WidgetResourceDetailDisplay(
       displayTags: undefinedToTrueOrProp(props?.displayTags),
       displaySocials: undefinedToTrueOrProp(props?.displaySocials),
       displayStatus: undefinedToTrueOrProp(props?.displayStatus),
+      displayStatusBar: undefinedToTrueOrProp(props?.displayStatusBar),
       displayLikes: undefinedToTrueOrProp(props?.displayLikes),
       displayDocuments: undefinedToTrueOrProp(props?.displayDocuments),
       clickableImage: props?.clickableImage || false,
@@ -208,6 +210,18 @@ export default function WidgetResourceDetailDisplay(
 
           <FormField
             control={form.control}
+            name="displayStatusBar"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>De balk met statussen weergeven bij de afbeelding?</FormLabel>
+                {YesNoSelect(field, props)}
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
             name="displaySocials"
             render={({ field }) => (
               <FormItem>
@@ -232,6 +246,20 @@ export default function WidgetResourceDetailDisplay(
 
           <FormField
             control={form.control}
+            name="displayDocuments"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Geüploade documenten weergeven
+                </FormLabel>
+                {YesNoSelect(field, props)}
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
             name="clickableImage"
             render={({ field }) => (
               <FormItem>
@@ -241,20 +269,6 @@ export default function WidgetResourceDetailDisplay(
                 <FormDescription>
                   Als je dit aanvinkt, wordt de afbeelding in de dialog klikbaar en wordt de afbeelding geopend in een nieuw tabblad.
                 </FormDescription>
-                {YesNoSelect(field, props)}
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name="displayDocuments"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>
-                  Geüploade documenten weergeven
-                </FormLabel>
                 {YesNoSelect(field, props)}
                 <FormMessage />
               </FormItem>

--- a/packages/resource-detail/src/resource-detail.tsx
+++ b/packages/resource-detail/src/resource-detail.tsx
@@ -46,6 +46,7 @@ type booleanProps = {
   | 'displayStatus'
   | 'displayDocuments'
   | 'clickableImage'
+  | 'displayStatusBar'
   | 'displaySocials']: boolean | undefined;
 };
 
@@ -99,6 +100,7 @@ function ResourceDetail({
   displayLikes = true,
   displayTags = true,
   displayStatus = true,
+  displayStatusBar = true,
   displaySocials = true,
   displayDocuments = true,
   clickableImage = false,
@@ -216,7 +218,7 @@ function ResourceDetail({
       <Image
         src={src}
         imageFooter={
-          (displayStatus && resource.statuses && resource.statuses.length > 0) && (
+          (displayStatusBar && resource.statuses && resource.statuses.length > 0) && (
             <div>
               <Paragraph className={`osc-resource-detail-content-item-status ${statusClasses}`}>
                 {resource.statuses

--- a/packages/resource-detail/src/resource-detail.tsx
+++ b/packages/resource-detail/src/resource-detail.tsx
@@ -216,13 +216,15 @@ function ResourceDetail({
       <Image
         src={src}
         imageFooter={
-          <div>
-            <Paragraph className={`osc-resource-detail-content-item-status ${statusClasses}`}>
-              {resource.statuses
-                ?.map((s: { name: string }) => s.name)
-                ?.join(', ')}
-            </Paragraph>
-          </div>
+          (displayStatus && resource.statuses && resource.statuses.length > 0) && (
+            <div>
+              <Paragraph className={`osc-resource-detail-content-item-status ${statusClasses}`}>
+                {resource.statuses
+                  ?.map((s: { name: string }) => s.name)
+                  ?.join(', ')}
+              </Paragraph>
+            </div>
+          )
         }
       />
     );


### PR DESCRIPTION
Deze PR zorgt ervoor dat de status balk niet meer wordt getoond als de instelling voor het tonen van de status balk op false staat.