### PR TITLE
fix: Hide image footer when empty

### DIFF
--- a/packages/ui/src/image/index.tsx
+++ b/packages/ui/src/image/index.tsx
@@ -20,7 +20,9 @@ export function Image({
         <div className="osc-image-header">{imageHeader}</div>
       ) : null}
       <img role="presentation" {...props} alt={props.alt ? props.alt : ''} />
-      <figcaption className="osc-image-footer">{imageFooter}</figcaption>
+      {imageFooter && (
+        <figcaption className="osc-image-footer">{imageFooter}</figcaption>
+      )}
     </figure>
   );
 }


### PR DESCRIPTION
Deze PR zorgt ervoor dat er geen lege image footer meer wordt getoond