### PR TITLE
fix: Update markers only when necessary

### DIFF
--- a/packages/leaflet-map/src/base-map.tsx
+++ b/packages/leaflet-map/src/base-map.tsx
@@ -370,7 +370,19 @@ const BaseMap = ({
       result[i] = markerData;
     });
 
-    setCurrentMarkers(result);
+    if (result.length !== currentMarkers.length) {
+      setCurrentMarkers(result);
+    } else {
+      const isDifferent = result.some(
+        (marker, index) =>
+          marker.lat !== currentMarkers[index]?.lat ||
+          marker.lng !== currentMarkers[index]?.lng
+      );
+
+      if (isDifferent) {
+        setCurrentMarkers(result);
+      }
+    }
   }, [markers, mapDataLayers]);
 
   let clusterMarkers: MarkerProps[] = [];


### PR DESCRIPTION
Deze PR zorgt ervoor dat de detail pagina niet meer in een infinite loop komt, wat die soms kwam.