### PR TITLE
fix: remove www. from redirect uri before check

### DIFF
--- a/apps/api-server/src/services/isRedirectAllowed.js
+++ b/apps/api-server/src/services/isRedirectAllowed.js
@@ -36,8 +36,14 @@ const isRedirectAllowed = async (projectId, redirectUri) => {
             return false;
         }
     });
+    
+    let redirectHost = new URL(redirectUri).host;
+    
+    if (redirectHost.startsWith('www.')) {
+        redirectHost = redirectHost.slice(4);
+    }
 
-    if(allowedDomains.includes(new URL(redirectUri).host)){
+    if(allowedDomains.includes(redirectHost)){
         return true;
     }
     return false;


### PR DESCRIPTION
The allowedDomains all have their www. removed, so we must do the same for the redirectUri to ensure that we can still match www.-prefixed domains.