### PR TITLE
Fix: document map image bounds

### DIFF
--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -261,10 +261,19 @@ function DocumentMap({
   };
 
 
-  const imageBounds: LatLngBoundsLiteral = [
-    [0, docWidth / 2],
-    [-docHeight, -docWidth / 2]
-  ];
+  const [imageBounds, setImageBounds] = useState<LatLngBoundsLiteral>([
+    [0, 1920 / 2],
+    [-1080, -1920 / 2]
+  ]);
+
+  useEffect(() => {
+    if (docWidth && !Number.isNaN(docWidth) && docHeight && !Number.isNaN(docHeight)) {
+      setImageBounds([
+        [0, docWidth / 2],
+        [-docHeight, -docWidth / 2]
+      ]);
+    }
+  }, [docWidth, docHeight]);
 
 
   const contentRef = useRef<HTMLDivElement>(null);

--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -315,9 +315,13 @@ function DocumentMap({
 
     useEffect(() => {
       if (map && imageBounds && !isBoundsSet) {
-        map.fitBounds(imageBounds);
-        map.scrollWheelZoom.disable();
-        setIsBoundsSet(true);
+        try {
+          map.fitBounds(imageBounds);
+          map.scrollWheelZoom.disable();
+          setIsBoundsSet(true);
+        } catch (e) {
+          console.error (e);
+        }
       }
     }, [map, imageBounds, isBoundsSet]);
 
@@ -480,7 +484,7 @@ function DocumentMap({
     const MarkerWithId: React.FC<ExtendedMarkerProps> = ({ id, index, color, ...props }) => {
       const markerRef = useRef<any>(null);
       const isDefaultColor = color === '#555588';
-  
+
       return (
           <Marker
               {...props}
@@ -602,7 +606,7 @@ function DocumentMap({
         setManualFocus(false);
       }
     }, []);
-  
+
     const [showButton, setShowButton] = useState(false);
     const containerRef = useRef<HTMLDivElement | null>(null);
 


### PR DESCRIPTION
This pull request includes changes to the `DocumentMap` component in `packages/document-map/src/document-map.tsx` to improve the handling of image bounds and error handling.

Improvements to image bounds handling:

* [`packages/document-map/src/document-map.tsx`](diffhunk://#diff-dadcc5092ccfe7c0fe2f2ba361365134eaa33ab9e02674c9941a2e8d728a3d3dL264-R276): Changed the `imageBounds` constant to a state variable and added an effect to update `imageBounds` based on `docWidth` and `docHeight` values.

Error handling enhancements:

* [`packages/document-map/src/document-map.tsx`](diffhunk://#diff-dadcc5092ccfe7c0fe2f2ba361365134eaa33ab9e02674c9941a2e8d728a3d3dR318-R324): Added a try-catch block around the `map.fitBounds` method to log errors to the console, ensuring that any issues during map fitting are captured and do not disrupt the application.