### PR TITLE
fix: Use trigger for retrieving data instead of index

### DIFF
--- a/apps/admin-server/src/lib/export-helpers/choiceguide-export.tsx
+++ b/apps/admin-server/src/lib/export-helpers/choiceguide-export.tsx
@@ -28,7 +28,7 @@ export const exportChoiceGuideToCSV = (data: any, widgetName: string, selectedWi
         title = `${title}   ${explanationA} - ${explanationB}`;
       }
 
-      const newKey = item.type + '-' + (index + 1);
+      const newKey = item.type + '-' + item.trigger;
 
       acc[newKey] = title;
       return acc;


### PR DESCRIPTION
Index werd eerst gebruikt voor het koppelen van keuzewijzer inzendingen aan vragen, maar als er vragen werden verwijderd en toegevoegd klopte dat niet meer. Trigger is dan beter voor het ophalen, aangezien die waarde vast is.