### PR TITLE
Fix/participatory budgeting proces

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/begrootmodule/[id]/display.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/begrootmodule/[id]/display.tsx
@@ -312,6 +312,8 @@ export default function BegrootmoduleDisplay(
                                             values = values.filter(value => value !== item);
                                           }
 
+                                          values = values.filter(value => tagGroupNames.includes(value));
+
                                           form.setValue('tagTypeTagGroup', values);
                                           props.onFieldChanged('tagTypeTagGroup', values);
                                         }}

--- a/packages/stem-begroot/src/stem-begroot.tsx
+++ b/packages/stem-begroot/src/stem-begroot.tsx
@@ -654,9 +654,7 @@ function StemBegroot({
 
           {currentStep === 3 ? (
             <Step3Success
-              loginUrl={`${props?.login?.url}`}
               step3success={props.step3success || ''}
-              stemCodeTitleSuccess={props.stemCodeTitleSuccess}
             />
           ) : null}
 
@@ -685,6 +683,17 @@ function StemBegroot({
                   }
                 }}>
                 Vorige
+              </Button>
+            ) : null}
+
+            {currentStep === 3 ? (
+              <Button
+                appearance='secondary-action-button'
+                onClick={() => {
+                  const loginUrl = new URL(`${props?.login?.url}`);
+                  document.location.href = loginUrl.toString();
+                }}>
+                {props.stemCodeTitleSuccess}
               </Button>
             ) : null}
 

--- a/packages/stem-begroot/src/stem-begroot.tsx
+++ b/packages/stem-begroot/src/stem-begroot.tsx
@@ -212,7 +212,7 @@ function StemBegroot({
   // Check the pending state and if there are any resources, hint to  update the selected items
   useEffect(() => {
     if (props.votes.voteType === "countPerTag" || props.votes.voteType === "budgetingPerTag") {
-      const pendingPerTag = session.get('osc-resource-vote-pending-per-tag');
+      const pendingPerTag = JSON.parse(localStorage.getItem('oscResourceVotePendingPerTag') || 'null');
 
       if (pendingPerTag) {
         setTagCounter((prevTagCounter) =>
@@ -241,7 +241,7 @@ function StemBegroot({
         );
       }
     } else {
-      let pending = session.get('osc-resource-vote-pending');
+      let pending = JSON.parse(localStorage.getItem('oscResourceVotePending') || 'null');
       if (
         pending &&
         resources?.records?.length > 0 &&
@@ -257,9 +257,9 @@ function StemBegroot({
     let pending;
 
     if (props.votes.voteType === "countPerTag" || props.votes.voteType === "budgetingPerTag") {
-      pending = session.get('osc-resource-vote-pending-per-tag');
+      pending = JSON.parse(localStorage.getItem('oscResourceVotePendingPerTag') || 'null');
     } else {
-      pending = session.get('osc-resource-vote-pending');
+      pending = JSON.parse(localStorage.getItem('oscResourceVotePending') || 'null');
     }
 
     if (
@@ -282,7 +282,8 @@ function StemBegroot({
           resourcesToVoteFor[resource.id] = 'yes';
         }
       );
-      session.set('osc-resource-vote-pending', resourcesToVoteFor);
+
+      localStorage.setItem('oscResourceVotePending', JSON.stringify(resourcesToVoteFor));
     } else {
       const resourcesToVoteForPerTag: { [tag: string]: { [key: string]: any } } = {};
 
@@ -296,7 +297,7 @@ function StemBegroot({
         });
       });
 
-      session.set('osc-resource-vote-pending-per-tag', resourcesToVoteForPerTag);
+      localStorage.setItem('oscResourceVotePendingPerTag', JSON.stringify(resourcesToVoteForPerTag));
     }
   }
 
@@ -455,7 +456,7 @@ function StemBegroot({
         isSimpleView={Boolean(props.isSimpleView)}
         onPrimaryButtonClick={(resource) => {
           if (props.votes.voteType === "countPerTag" || props.votes.voteType === "budgetingPerTag") {
-            session.remove('osc-resource-vote-pending-per-tag');
+            localStorage.removeItem('oscResourceVotePendingPerTag');
 
             if (activeTagTab) {
               const activeTag = tagCounter.find(tagObj => tagObj[activeTagTab]);
@@ -475,7 +476,7 @@ function StemBegroot({
               }
             }
           } else {
-            session.remove('osc-resource-vote-pending');
+            localStorage.removeItem('oscResourceVotePending');
 
             const resourceInBudgetList = selectedResources.find(
               (r) => r.id === resource.id
@@ -550,8 +551,8 @@ function StemBegroot({
                 setActiveTagTab={setActiveTagTab}
                 typeIsPerTag={props?.votes?.voteType === "countPerTag" || props?.votes?.voteType === "budgetingPerTag"}
                 onSelectedResourceRemove={(resource: {id: number, budget: number}) => {
-                  session.remove('osc-resource-vote-pending');
-                  session.remove('osc-resource-vote-pending-per-tag');
+                  localStorage.removeItem('oscResourceVotePending');
+                  localStorage.removeItem('oscResourceVotePendingPerTag');
 
                   if (props?.votes?.voteType === "countPerTag" || props?.votes?.voteType === "budgetingPerTag") {
                     setTagCounter(prevTagCounter => {
@@ -732,12 +733,11 @@ function StemBegroot({
 
                         if (uniqueResourcesToVote.length > 0) {
                           await doVote(uniqueResourcesToVote);
+                          localStorage.removeItem('oscResourceVotePendingPerTag');
                         }
-
-                        session.remove('osc-resource-vote-pending-per-tag');
                       } else {
                         await doVote(selectedResources);
-                        session.remove('osc-resource-vote-pending');
+                        localStorage.removeItem('oscResourceVotePending');
                       }
                       setCurrentStep(currentStep + 1);
                     } catch (err: any) {
@@ -849,8 +849,8 @@ function StemBegroot({
               originalResourceUrl={props.originalResourceUrl}
               resourceListColumns={resourceListColumns || 3}
               onResourcePrimaryClicked={(resource) => {
-                session.remove('osc-resource-vote-pending');
-                session.remove('osc-resource-vote-pending-per-tag');
+                localStorage.removeItem('oscResourceVotePending');
+                localStorage.removeItem('oscResourceVotePendingPerTag');
 
                 let newTagCounter = [...tagCounter];
 

--- a/packages/stem-begroot/src/step-3-success/index.tsx
+++ b/packages/stem-begroot/src/step-3-success/index.tsx
@@ -1,27 +1,16 @@
-import { SecondaryButton, Spacer } from '@openstad-headless/ui/src';
-import React, { ReactNode } from 'react';
-import { Heading5, Button } from "@utrecht/component-library-react";
+import { Spacer } from '@openstad-headless/ui/src';
+import React from 'react';
+import { Heading5 } from "@utrecht/component-library-react";
 
 type Props = {
-  loginUrl: string;
   step3success: string;
-  stemCodeTitleSuccess: string;
 };
-export const Step3Success = ({ step3success, stemCodeTitleSuccess, ...props }: Props) => {
+export const Step3Success = ({ step3success, ...props }: Props) => {
   return (
     <>
       <Spacer size={1.5} />
       <Heading5>{step3success}</Heading5>
-      <Spacer size={2} />
-
-      <Button
-        appearance='primary-action-button'
-        onClick={() => {
-          const loginUrl = new URL(`${props.loginUrl}`);
-          document.location.href = loginUrl.toString();
-        }}>
-        {stemCodeTitleSuccess}
-      </Button>
+      <Spacer size={4} />
     </>
   );
 };


### PR DESCRIPTION
Deze PR lost de volgende punten op:

- Als je inlogt bij stap 3 kom je weer bij het overzicht uit maar is je “winkelmandje” leeg en moet je opnieuw je ideeën selecteren.
- Als je bent ingelogd blijft op de derde stap altijd een “inloggen” knop staan die je weer opnieuw door deze flow leidt. Je kunt nu echter wel je stem indienen met de knop rechtsonder maar dit is wel onduidelijk.