### PR TITLE
optionally use base64 encoded certificates in env vars

### DIFF
--- a/apps/auth-server/utils.js
+++ b/apps/auth-server/utils.js
@@ -8,10 +8,10 @@ const jwt  = require('jsonwebtoken');
 const certPath = process.env.TEST_CERTS ? 'test/test-certs/' : 'certs/';
 
 /** Private certificate used for signing JSON WebTokens */
-const privateKey =  fs.readFileSync(path.join(__dirname, certPath + '/privatekey.pem'));
+const privateKey = process.env.PRIVATE_KEY_BASE64 ? Buffer.from(process.env.PRIVATE_KEY_BASE64, 'base64').toString('utf8') : fs.readFileSync(path.join(__dirname, certPath + '/privatekey.pem'));
 
 /** Public certificate used for verification.  Note: you could also use the private key */
-const publicKey =  fs.readFileSync(path.join(__dirname, certPath + '/certificate.pem'));
+const publicKey = process.env.PUBLIC_KEY_BASE64 ? Buffer.from(process.env.PUBLIC_KEY_BASE64, 'base64').toString('utf8') : fs.readFileSync(path.join(__dirname, certPath + '/certificate.pem'));
 
 /**
  * Creates a signed JSON WebToken and returns it.  Utilizes the private certificate to create


### PR DESCRIPTION
 ... instead of reading certificates from the filesystem