### PR TITLE
fix: remove double slash and encoded backslash from frontend URIs

### DIFF
--- a/apps/cms-server/app.js
+++ b/apps/cms-server/app.js
@@ -320,6 +320,25 @@ async function serveSite (req, res, siteConfig, forceRestart) {
   }
 }
 
+app.use(function (req, res, next) {
+  // Remove redirects from URL
+  
+  const url = req.url;
+  
+  if (req.url.indexOf('//') > -1 || req.url.indexOf('%5C') > -1) {
+    req.url = req.url.replace('//', '/');
+    req.url = req.url.replace('%5C', '');
+    
+    // Reinitialize route parameters, so the next middleware will see the correct parameters
+    req.app._router.handle(req, res, next);
+  } else {
+    next();
+  }
+  
+  
+  
+});
+
 /**
  * Check if a site is running under the first path
  *

--- a/operations/deployments/openstad-headless/environments/prod/images.yml
+++ b/operations/deployments/openstad-headless/environments/prod/images.yml
@@ -1,15 +1,15 @@
 admin:
   deploymentContainer:
-    image: ghcr.io/openstad/admin-server:main-5797616
+    image: ghcr.io/openstad/admin-server:main-41bb24b
 api:
   deploymentContainer:
-    image: ghcr.io/openstad/api-server:main-5797616
+    image: ghcr.io/openstad/api-server:main-41bb24b
 auth:
   deploymentContainer:
-    image: ghcr.io/openstad/auth-server:main-5797616
+    image: ghcr.io/openstad/auth-server:main-41bb24b
 image:
   deploymentContainer:
-    image: ghcr.io/openstad/image-server:main-5797616
+    image: ghcr.io/openstad/image-server:main-41bb24b
 cms:
   deploymentContainer:
-    image: ghcr.io/openstad/cms-server:main-5797616
+    image: ghcr.io/openstad/cms-server:main-41bb24b

--- a/operations/deployments/openstad-headless/environments/prod/images.yml
+++ b/operations/deployments/openstad-headless/environments/prod/images.yml
@@ -1,15 +1,15 @@
 admin:
   deploymentContainer:
-    image: ghcr.io/openstad/admin-server:main-41bb24b
+    image: ghcr.io/openstad/admin-server:main-99937b7
 api:
   deploymentContainer:
-    image: ghcr.io/openstad/api-server:main-41bb24b
+    image: ghcr.io/openstad/api-server:main-99937b7
 auth:
   deploymentContainer:
-    image: ghcr.io/openstad/auth-server:main-41bb24b
+    image: ghcr.io/openstad/auth-server:main-99937b7
 image:
   deploymentContainer:
-    image: ghcr.io/openstad/image-server:main-41bb24b
+    image: ghcr.io/openstad/image-server:main-99937b7
 cms:
   deploymentContainer:
-    image: ghcr.io/openstad/cms-server:main-41bb24b
+    image: ghcr.io/openstad/cms-server:main-99937b7

--- a/operations/deployments/openstad-headless/environments/prod/images.yml
+++ b/operations/deployments/openstad-headless/environments/prod/images.yml
@@ -1,15 +1,15 @@
 admin:
   deploymentContainer:
-    image: ghcr.io/openstad/admin-server:main-99937b7
+    image: ghcr.io/openstad/admin-server:main-e9fa8f6
 api:
   deploymentContainer:
-    image: ghcr.io/openstad/api-server:main-99937b7
+    image: ghcr.io/openstad/api-server:main-e9fa8f6
 auth:
   deploymentContainer:
-    image: ghcr.io/openstad/auth-server:main-99937b7
+    image: ghcr.io/openstad/auth-server:main-e9fa8f6
 image:
   deploymentContainer:
-    image: ghcr.io/openstad/image-server:main-99937b7
+    image: ghcr.io/openstad/image-server:main-e9fa8f6
 cms:
   deploymentContainer:
-    image: ghcr.io/openstad/cms-server:main-99937b7
+    image: ghcr.io/openstad/cms-server:main-e9fa8f6

--- a/operations/deployments/openstad-headless/environments/prod/images.yml
+++ b/operations/deployments/openstad-headless/environments/prod/images.yml
@@ -1,15 +1,15 @@
 admin:
   deploymentContainer:
-    image: ghcr.io/openstad/admin-server:main-e9fa8f6
+    image: ghcr.io/openstad/admin-server:main-339fb47
 api:
   deploymentContainer:
-    image: ghcr.io/openstad/api-server:main-e9fa8f6
+    image: ghcr.io/openstad/api-server:main-339fb47
 auth:
   deploymentContainer:
-    image: ghcr.io/openstad/auth-server:main-e9fa8f6
+    image: ghcr.io/openstad/auth-server:main-339fb47
 image:
   deploymentContainer:
-    image: ghcr.io/openstad/image-server:main-e9fa8f6
+    image: ghcr.io/openstad/image-server:main-339fb47
 cms:
   deploymentContainer:
-    image: ghcr.io/openstad/cms-server:main-e9fa8f6
+    image: ghcr.io/openstad/cms-server:main-339fb47


### PR DESCRIPTION
This prevents a redirect from Apostrophe to the given URI (Open redirect)