### PR TITLE
fix: Validation problem

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/items.tsx
@@ -31,9 +31,9 @@ import {useWidgetConfig} from "@/hooks/use-widget-config";
 import {Item, Option, ChoiceGuideProps, ChoiceOptions} from '@openstad-headless/choiceguide/src/props';
 
 const weightSchema: z.ZodSchema = z.object({
-  weightX: z.string().optional(),
-  weightY: z.string().optional(),
-  weightAB: z.string().optional(),
+  weightX: z.any().optional(),
+  weightY: z.any().optional(),
+  weightAB: z.any().optional(),
   choice: z.record(z.lazy(() => weightSchema)).optional(),
 });
 


### PR DESCRIPTION
Bepaalde velden in de keuzewijzer hebben geen weging, maar kregen wel de error dat de weging een nummer was in plaats van een string. De standaard waarde is een nummer (ook al pas je dat aan naar een string), maar als je iets invoert wordt het een string. De validatie kan dus niet gedaan worden op basis van string of nummer.