### PR TITLE
Add flag for project issue warnings

### DIFF
--- a/apps/api-server/src/cron/send_enddate_notifications.js
+++ b/apps/api-server/src/cron/send_enddate_notifications.js
@@ -7,7 +7,7 @@ const UseLock = require('../lib/use-lock');
 // Purpose
 // -------
 // Send emails to projectmanagers just before the enddate of their project is reached
-// 
+//
 // Runs every day
 module.exports = {
   // cronTime: '*/10 * * * * *',
@@ -16,6 +16,8 @@ module.exports = {
   onTick: UseLock.createLockedExecutable({
     name: 'send-enddate-notifications',
     task: async (next) => {
+      
+      if (!!process.env.DISABLE_PROJECT_ISSUE_WARNINGS) return;
 
       let endDateConfig = config.notifications.sendEndDateNotifications;
 
@@ -98,4 +100,3 @@ module.exports = {
   })
 
 };
-

--- a/apps/api-server/src/cron/send_project_issues_notifications.js
+++ b/apps/api-server/src/cron/send_project_issues_notifications.js
@@ -8,7 +8,7 @@ const projectsWithIssues = require('../services/projects-with-issues');
 // Purpose
 // -------
 // Send emails to projectmanagers just before the enddate of their project is reached
-// 
+//
 // Runs every day
 module.exports = {
   // cronTime: '*/10 * * * * *',
@@ -19,6 +19,8 @@ module.exports = {
     name: 'send-project-issues-notifications',
     task: async (next) => {
 
+      if (!!process.env.DISABLE_PROJECT_ISSUE_WARNINGS) return;
+      
       try {
 
         let notificationsToBeSent = {};

--- a/charts/openstad-headless/Chart.yaml
+++ b/charts/openstad-headless/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.18
+version: 0.0.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openstad-headless/Chart.yaml
+++ b/charts/openstad-headless/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: openstad-headless
 description: Openstad Headless Helm chart for Kubernetes
+icon: https://avatars.githubusercontent.com/u/99011277?s=200&v=4
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/charts/openstad-headless/templates/api/deployment.yaml
+++ b/charts/openstad-headless/templates/api/deployment.yaml
@@ -106,6 +106,9 @@ spec:
           - name: NOTIFICATIONS_ADMIN_EMAILADDRESS
             value: {{ .Values.api.emailAddress }}
 
+          - name: DISABLE_PROJECT_ISSUE_WARNINGS
+            value: {{ .Values.api.disableProjectIssueWarnings }}
+
           - name: AUTH_JWTSECRET
             valueFrom:
               secretKeyRef:

--- a/charts/openstad-headless/values.yaml
+++ b/charts/openstad-headless/values.yaml
@@ -290,6 +290,8 @@ api:
   # Inject extra environment variables
   extraEnvVars: []
 
+  disableProjectIssueWarnings: false
+
   # Resources:
   resources:
     # Max resources


### PR DESCRIPTION
This new env var (`DISABLE_PROJECT_ISSUE_WARNINGS`) allows us to prevent sending project issue warnings from the installation entirely.