### PR TITLE
feat: Allow multiple image options instead of 2

### DIFF
--- a/packages/enquete/src/enquete.css
+++ b/packages/enquete/src/enquete.css
@@ -100,12 +100,9 @@
 }
 
 .question-type-imageChoice .image-choice-container {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 1rem;
-}
-
-.question-type-imageChoice .image-choice-container > * {
-  flex: 1;
 }
 
 label.utrecht-form-label{

--- a/packages/enquete/src/enquete.tsx
+++ b/packages/enquete/src/enquete.tsx
@@ -126,18 +126,31 @@ function Enquete(props: EnqueteWidgetProps) {
                     break;
                 case 'images':
                     fieldData['type'] = 'imageChoice';
-                    fieldData['choices'] = [
-                        {
-                            label: item?.text1 || '',
-                            value: item?.key1 || '',
-                            imageSrc: item?.image1 || ''
-                        },
-                        {
-                            label: item?.text2 || '',
-                            value: item?.key2 || '',
-                            imageSrc: item?.image2 || ''
-                        }
-                    ];
+
+                    if ( item.options && item.options.length > 0 ) {
+                        fieldData['choices'] = item.options.map((option) => {
+                            return {
+                                value: option.titles[0].key,
+                                label: option.titles[0].key,
+                                imageSrc: option.titles[0].image,
+                                imageAlt: option.titles[0].key,
+                                showLabel: option.titles[0].showLabel
+                            };
+                        });
+                    } else {
+                        fieldData['choices'] = [
+                            {
+                                label: item?.text1 || '',
+                                value: item?.key1 || '',
+                                imageSrc: item?.image1 || ''
+                            },
+                            {
+                                label: item?.text2 || '',
+                                value: item?.key2 || '',
+                                imageSrc: item?.image2 || ''
+                            }
+                        ];
+                    }
 
                     break;
                 case 'imageUpload':

--- a/packages/enquete/src/types/enquete-props.ts
+++ b/packages/enquete/src/types/enquete-props.ts
@@ -22,12 +22,6 @@ export type Item = {
   minCharacters?: string;
   maxCharacters?: string;
   variant?: string;
-  image1?: string;
-  text1?: string;
-  key1?: string;
-  image2?: string;
-  text2?: string;
-  key2?: string;
   options?: Array<Option>;
   imageUpload?: string;
   multiple?: boolean;
@@ -38,6 +32,15 @@ export type Item = {
   showSmileys?: boolean;
   placeholder?: string;
   defaultValue?: string;
+  imageOptionUpload?: string;
+
+  // Keeping this for backwards compatibility
+  image1?: string;
+  text1?: string;
+  key1?: string;
+  image2?: string;
+  text2?: string;
+  key2?: string;
 };
 
 export type Option = {
@@ -50,6 +53,8 @@ export type Title = {
   key: string;
   isOtherOption?: boolean;
   defaultValue?: boolean;
+  image?: string;
+  showLabel?: boolean;
 };
 
 export type Confirmation = {

--- a/packages/ui/src/form-elements/image-choice/index.tsx
+++ b/packages/ui/src/form-elements/image-choice/index.tsx
@@ -31,6 +31,7 @@ export type ChoiceItem = {
     imageSrc: string;
     imageDescription: string;
     imageAlt: string;
+    showLabel?: boolean;
 }
 
 const ImageChoiceField: FC<ImageChoiceFieldProps> = ({
@@ -106,7 +107,7 @@ const ImageChoiceField: FC<ImageChoiceFieldProps> = ({
                                     />
                                     <figure>
                                         <img src={choice.imageSrc} alt={choice.imageAlt} />
-                                        {choice.label && (
+                                        { (choice.label && choice.showLabel) && (
                                             <figcaption>{choice.label}</figcaption>
                                         )}
                                     </figure>


### PR DESCRIPTION
Er was een veld in de enquete waarmee je een keuze kon voorleggen tussen 2 afbeeldingen. Dat is nu uitgebreid zodat je zelf kan kiezen hoeveel keuzes je voorlegt. Mogelijk wordt dit veld al ergens gebruikt, dus vandaar dat de oude logica behouden is.