### PR TITLE
fix: Remove emoji filter as it filters out numbers

### DIFF
--- a/apps/api-server/src/util/sanitize.js
+++ b/apps/api-server/src/util/sanitize.js
@@ -1,12 +1,6 @@
 var sanitize = require('sanitize-html');
 const _ = require('lodash');
 
-
-
-const removeEmojis = (text) => {
-	return !!text ? text.replace(/\p{Emoji}/gu, '') : text;
-};
-
 // Normalize unicode text by Compatibility Decomposition
 // this will remove the unicode characters that are not in the ASCII range
 // We also use the deburr method from lodash to remove diacritics
@@ -24,7 +18,6 @@ const sanitizeIfNotNull = (text, tags) => {
 	if (text === null) {
 		return null;
 	}
-	text = removeEmojis(text);
 	text = normalizeUnicodeText(text);
 	return sanitize(text, tags);
 }


### PR DESCRIPTION
Dit filter zorgde ervoor dat de nummers ook verdwenen. Niet heel handig. Voor nu maar even volledig weghalen