### PR TITLE
Fix/map styling issues

### DIFF
--- a/packages/leaflet-map/src/css/base-map.css
+++ b/packages/leaflet-map/src/css/base-map.css
@@ -43,10 +43,15 @@
 }
 
 .skip-link {
+  clip: rect(1px, 1px, 1px, 1px);
+  -webkit-clip-path: inset(50%);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
   position: absolute;
-  z-index: -1;
-  top: 10px;
-  left: 10px;
 }
 
 .osc .resource-card--link .osc-resource-overview-content-item-footer .icon > p {

--- a/packages/leaflet-map/src/css/base-map.css
+++ b/packages/leaflet-map/src/css/base-map.css
@@ -1,7 +1,7 @@
 :root {
   --basemap-map-width: 100%;
   --basemap-map-height: 100%;
-  --basemap-map-aspect-ratio: 16/9;
+  --basemap-map-aspect-ratio: unset;
 }
 
 .map-container.osc-map {
@@ -16,7 +16,6 @@
   width: 100%;
   height: 100%;
   z-index: 1;
-
 }
 
 .osc-base-map-widget-container .osc-map-marker-faded {
@@ -41,4 +40,15 @@
   display: flex;
   flex-direction: column;
   gap: .5rem;
+}
+
+.skip-link {
+  position: absolute;
+  z-index: -1;
+  top: 10px;
+  left: 10px;
+}
+
+.osc .resource-card--link .osc-resource-overview-content-item-footer .icon > p {
+  margin: 0;
 }


### PR DESCRIPTION
Deze PR fixt de standaard styling voor kaarten. De toegankelijkheidsknop is hiermee standaard verborgen en de basis aspect-ratio van de kaart is aangepast, zodat de kaart niet meer smal wordt getoond.