### PR TITLE
fix: Show budget field and add default values

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourceform/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourceform/[id]/items.tsx
@@ -971,12 +971,7 @@ export default function WidgetResourceFormItems(
                                                         <FormLabel>Is dit veld zichtbaar voor iedereen of alleen admin gebruikers?</FormLabel>
                                                         <Select
                                                             onValueChange={(e: string) => field.onChange(e === 'true')}
-                                                            value={
-                                                                type === 'budget'
-                                                                    ? 'true'
-                                                                    : (field.value ? 'true' : 'false')
-                                                            }
-                                                            disabled={type === 'budget'}
+                                                            value={field.value ? 'true' : 'false'}
                                                         >
                                                             <FormControl>
                                                                 <SelectTrigger>

--- a/packages/resource-form/src/parts/default-values.tsx
+++ b/packages/resource-form/src/parts/default-values.tsx
@@ -149,5 +149,20 @@ export const defaultFormValues = [
         "multiple": true,
         "options": [],
         "fieldType": "text"
+    },
+    {
+        "trigger": "13",
+        "title": "Budget",
+        "description": "Welk budget heb je nodig van de gemeente voor de uitvoering?",
+        "type": "budget",
+        "fieldKey": "budget",
+        "fieldRequired": false,
+        "onlyForModerator": false,
+        "minCharacters": "",
+        "maxCharacters": "",
+        "variant": "text input",
+        "multiple": true,
+        "options": [],
+        "fieldType": "number"
     }
 ]

--- a/packages/resource-form/src/parts/init-fields.tsx
+++ b/packages/resource-form/src/parts/init-fields.tsx
@@ -94,6 +94,9 @@ export const InitializeFormFields = (items, data) => {
                         });
                     }
                     break;
+                case 'budget':
+                    fieldData['format'] = true;
+                    break;
                 
             }
 


### PR DESCRIPTION
Het budget veld werd niet getoond, doordat het standaard alleen zichtbaar was voor admin's. Dit is nog logica uit oud openstad, maar is hier niet meer nodig. 