### PR TITLE
feat: Add login choice for choiceguide

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/form.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/form.tsx
@@ -92,7 +92,7 @@ export default function ChoicesSelectorForm(props: ChoiceGuide) {
   return (
     <div className="p-6 bg-white rounded-md">
       <Form {...form}>
-        <Heading size="xl">Instellingen</Heading>
+        <Heading size="xl">Formulier instellingen</Heading>
         <Separator className="my-4" />
         <form
           onSubmit={form.handleSubmit(onSubmit)}

--- a/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/index.tsx
@@ -15,6 +15,7 @@ import { useWidgetPreview } from '@/hooks/useWidgetPreview';
 import WidgetPreview from '@/components/widget-preview';
 import WidgetChoiceGuideItems from "@/pages/projects/[project]/widgets/choiceguide/[id]/items";
 import WidgetChoiceGuideChoiceOptions from "@/pages/projects/[project]/widgets/choiceguide/[id]/choiceOptions";
+import WidgetChoiceGuideGeneralSettings from "@/pages/projects/[project]/widgets/choiceguide/[id]/settings";
 
 export const getServerSideProps = withApiUrl;
 
@@ -50,9 +51,10 @@ export default function WidgetChoiceGuide({
         <div className="container py-6">
           <Tabs defaultValue="form">
             <TabsList className="w-full bg-white border-b-0 mb-4 rounded-md">
-              <TabsTrigger value="form">Instellingen</TabsTrigger>
+              <TabsTrigger value="form">Formulier instellingen</TabsTrigger>
               <TabsTrigger value="items">Velden</TabsTrigger>
               <TabsTrigger value="choiceOptions">Keuze opties</TabsTrigger>
+              <TabsTrigger value="generalSettings">Algemene instellingen</TabsTrigger>
               <TabsTrigger value="publish">Publiceren</TabsTrigger>
             </TabsList>
             <TabsContent value="form" className="p-0">
@@ -80,6 +82,9 @@ export default function WidgetChoiceGuide({
             </TabsContent>
             <TabsContent value="choiceOptions" className="p-0">
               <WidgetChoiceGuideChoiceOptions />
+            </TabsContent>
+            <TabsContent value="generalSettings" className="p-0">
+              <WidgetChoiceGuideGeneralSettings />
             </TabsContent>
             <TabsContent value="publish" className="p-0">
               <WidgetPublish apiUrl={apiUrl} />

--- a/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/settings.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/settings.tsx
@@ -1,0 +1,169 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Button } from '../../../../../../components/ui/button';
+import { Input } from '../../../../../../components/ui/input';
+import {
+  Form,
+  FormControl, FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+} from '../../../../../../components/ui/form';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../../../../../../components/ui/select';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import * as z from 'zod';
+import { Heading } from '@/components/ui/typography';
+import { Separator } from '@/components/ui/separator';
+import { useWidgetConfig } from '@/hooks/use-widget-config';
+import { ChoiceGuide } from '@openstad-headless/choiceguide/src/props';
+import {YesNoSelect} from "@/lib/form-widget-helpers";
+
+const formSchema = z.object({
+  submitButtonText: z.string().optional(),
+  nextButtonText: z.string().optional(),
+  loginText: z.string().optional(),
+  loginTextButton: z.string().optional(),
+  loginRequired: z.boolean().optional(),
+});
+
+export default function WidgetChoiceGuideGeneralSettings(props: ChoiceGuide) {
+  const category = 'generalSettings';
+
+  const {
+    data: widget,
+    isLoading: isLoadingWidget,
+    updateConfig,
+  } = useWidgetConfig<any>();
+
+  const defaults = useCallback(
+    () => ({
+      submitButtonText: widget?.config?.[category]?.submitButtonText || "Versturen",
+      nextButtonText: widget?.config?.[category]?.nextButtonText || "Volgende",
+      loginText: widget?.config?.[category]?.loginText || "Inloggen om deel te nemen.",
+      loginTextButton: widget?.config?.[category]?.loginTextButton || "Inloggen",
+      loginRequired: widget?.config?.[category]?.loginRequired || false,
+    }),
+    [widget?.config]
+  );
+
+  type FormData = z.infer<typeof formSchema>;
+  async function onSubmit(values: FormData) {
+    try {
+      await updateConfig({ [category]: values });
+    } catch (error) {
+      console.error('could not update', error);
+    }
+  }
+
+  const form = useForm<FormData>({
+    resolver: zodResolver<any>(formSchema),
+    defaultValues: defaults(),
+  });
+
+  useEffect(() => {
+    form.reset(defaults());
+  }, [form, defaults]);
+
+  return (
+    <div className="p-6 bg-white rounded-md">
+      <Form {...form}>
+        <Heading size="xl">Instellingen</Heading>
+        <Separator className="my-4" />
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="w-fit lg:w-2/3 grid grid-cols-1 lg:grid-cols-1 gap-4">
+          <FormField
+            control={form.control}
+            name="submitButtonText"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Verstuur knop tekst</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="nextButtonText"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Volgende vraag tekst</FormLabel>
+                <FormDescription>
+                  Tekst die wordt getoond op de knop om naar de volgende vraag te gaan. Alleen van toepassing als er meerdere pagina&apos;s met vragen zijn.
+                </FormDescription>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="loginRequired"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Login vereist</FormLabel>
+                <FormDescription>
+                  Moet de gebruiker ingelogd zijn om de keuzewijzer in te vullen?
+                </FormDescription>
+                {/*@ts-ignore*/}
+                {YesNoSelect(field, props)}
+              </FormItem>
+            )}
+          />
+
+          {!!form.watch('loginRequired') && (
+            <>
+              <FormField
+                control={form.control}
+                name="loginText"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Login tekst
+                    </FormLabel>
+                    <FormDescription>
+                      Tekst die wordt getoond als de gebruiker niet is ingelogd.
+                    </FormDescription>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="loginTextButton"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Login tekst knop
+                    </FormLabel>
+                    <FormDescription>
+                      Tekst die wordt getoond op de knop om in te loggen.
+                    </FormDescription>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+            </>
+          )}
+
+          <Button type="submit" className="w-fit col-span-full">
+            Opslaan
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/packages/choiceguide/src/parts/init-fields.tsx
+++ b/packages/choiceguide/src/parts/init-fields.tsx
@@ -5,7 +5,7 @@ const getMinMaxByField = (key, data) => {
     return !!data && typeof data.resources !== 'undefined' && typeof data.resources[key] !== 'undefined' ? data.resources[key] : '';
 }
 
-export const InitializeFormFields = (items, data) => {
+export const InitializeFormFields = (items, data, showForm = true) => {
     const formFields: FieldProps[] = [];
 
     if (typeof (items) === 'object' && items.length > 0
@@ -39,7 +39,8 @@ export const InitializeFormFields = (items, data) => {
                 labelB: item.explanationB || '',
                 imageA: item.imageA || '',
                 imageB: item.imageB || '',
-                showLabels: false
+                showLabels: false,
+                disabled: !showForm,
             };
 
             switch (item.type) {

--- a/packages/choiceguide/src/props.ts
+++ b/packages/choiceguide/src/props.ts
@@ -1,6 +1,7 @@
 import { ProjectSettingProps, BaseProps } from '@openstad-headless/types';
 
 export type ChoiceGuideProps = ChoiceGuide &
+    ChoiceGuideGeneralSettings &
     BaseProps &
     ProjectSettingProps &
     ExtraProjectSettings;
@@ -27,7 +28,16 @@ type ExtraProjectSettings = {
         choiceOptions: ChoiceOptions[] };
     items?: Array<Item>;
     widgetId?: string;
+    generalSettings?: ChoiceGuideGeneralSettings
 }
+
+export type ChoiceGuideGeneralSettings = {
+    submitButtonText?: string;
+    nextButtonText?: string;
+    loginText?: string;
+    loginTextButton?: string;
+    loginRequired?: boolean;
+};
 
 export type ChoiceGuideSidebarProps = {
     choicesType: 'default' | 'minus-to-plus-100' | 'plane' | 'hidden';


### PR DESCRIPTION
Deze PR zorgt ervoor dat er een optie wordt toegevoegd waarmee je kunt kiezen of gebruikers ingelogd moeten zijn om de keuzewijzer in te vullen