### PR TITLE
fix: optimize npm cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,8 @@ else \
     npm run build-packages --if-present --prefix=$WORKSPACE; \
 fi
 
+RUN npm cache clean --force
+
 # Generate and store release ID dynamically
 # Alleen uitvoeren voor de cms-server
 RUN if [ "$APP" = "cms-server" ]; then \


### PR DESCRIPTION
The `npm cache clean` command clears the `.npm`-folder, which is a caching folder used by `npm`. When not cleared, files in this folder might be seen and flagged as secrets, by a container image scanner like Trivy. 