### PR TITLE
Fix/404 missing design tokens

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/settings/design.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/settings/design.tsx
@@ -37,7 +37,7 @@ export default function ProjectSettingsDesign() {
   const defaults = useCallback(() => {
     let existingCssUrl = data?.config?.project?.cssUrl ?? '';
 
-    let urlsArray = [];
+    let urlsArray: Array<{ url: string }> = [];
     if (Array.isArray(existingCssUrl)) {
       urlsArray = existingCssUrl.map((url) => ({ url }));
     } else if (typeof existingCssUrl === 'string' && existingCssUrl.trim() !== '') {
@@ -66,7 +66,7 @@ export default function ProjectSettingsDesign() {
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     try {
-      const cssUrlsArray = values.cssUrls?.map((item) => item.url.trim()).filter(Boolean) || [];
+      const cssUrlsArray = values.cssUrls?.map((item) => item?.url?.trim() ?? '').filter(Boolean) || [];
 
       const project = await updateProject({
         project: {
@@ -155,7 +155,7 @@ export default function ProjectSettingsDesign() {
               onSubmit={form.handleSubmit(onSubmit)}
               className="w-5/6 grid grid-cols-1 lg:grid-cols-1 gap-x-4 gap-y-8">
 
-              <Heading size="lg">CSS URL's</Heading>
+              <Heading size="lg">CSS URL&apos;s</Heading>
               {fields.map((item, index) => (
                 <div key={item.id} className="flex gap-2 items-center">
                   <Controller

--- a/apps/api-server/src/routes/widget/widget.js
+++ b/apps/api-server/src/routes/widget/widget.js
@@ -274,7 +274,6 @@ function getWidgetJavascriptOutput(
 
   const data = JSON.parse(widgetConfig)
 
-  const extraCssFile = data.project?.cssUrl ? `<link href="${data.project.cssUrl}" rel="stylesheet">` : '';
   const apiUrl = process.env.URL ?? '';
 
 
@@ -366,18 +365,26 @@ function getWidgetJavascriptOutput(
           const redirectUri = encodeURI(window.location.href);
           
           const config = JSON.parse(\`${widgetConfigWithCorrectEscapes}\`.replaceAll("[[REDIRECT_URI]]", redirectUri));
-          let customCss = '';
           
-          if (config.project.cssCustom) {
-            const customCssUrl = '${apiUrl}/api/project/' + config.projectId + '/css/' + randomComponentId;
-            customCss = \`<link href ="\${customCssUrl}" rel ="stylesheet">\`;
+          const head = document.querySelector('head');
+
+          const widgetCssUrl = \`${apiUrl}/api/project/${config.projectId}/widget-css/${widgetType}\`;
+          if (!head.querySelector(\`link[href="${widgetCssUrl}"]\`)) {
+            head.innerHTML += \`<link href="${widgetCssUrl}" rel="stylesheet">\`;
           }
           
-          document.querySelector('head').innerHTML += \`
-            <link href="${apiUrl}/api/project/\${config.projectId}/widget-css/${widgetType}" rel="stylesheet">
-            ${extraCssFile}
-            \${customCss}
-          \`;
+          if (data.project?.cssUrl) {
+            if (!head.querySelector(\`link[href="${data.project.cssUrl}"]\`)) {
+              head.innerHTML += \`<link href="${data.project.cssUrl}" rel="stylesheet">\`;
+            }
+          }
+          
+          if (config.project.cssCustom) {
+            const customCssUrl = \`${apiUrl}/api/project/${config.projectId}/css/${randomComponentId}\`;
+            if (!head.querySelector(\`link[href="${customCssUrl}"]\`)) {
+              head.innerHTML += \`<link href="${customCssUrl}" rel="stylesheet">\`;
+            }
+          }
           
           function renderWidget () {
             

--- a/apps/api-server/src/routes/widget/widget.js
+++ b/apps/api-server/src/routes/widget/widget.js
@@ -276,9 +276,7 @@ function getWidgetJavascriptOutput(
 
   const apiUrl = process.env.URL ?? '';
 
-
-
-
+  const extraCssFile = data.project?.cssUrl ? `<link href="${data.project.cssUrl}" rel="stylesheet">` : '';
 
 
   // TODO: Fix this, it's a hack to get the ChoiceGuide to work
@@ -324,8 +322,6 @@ function getWidgetJavascriptOutput(
 
   } else {
     widgetSettings.js.forEach((file) => {
-      console.log(`${widgetSettings.packageName}/${file}`);
-      console.log(require.resolve(`${widgetSettings.packageName}/${file}`));
       widgetOutput += fs.readFileSync(require.resolve(`${widgetSettings.packageName}/${file}`), 'utf8');
     });
 
@@ -366,23 +362,25 @@ function getWidgetJavascriptOutput(
           
           const config = JSON.parse(\`${widgetConfigWithCorrectEscapes}\`.replaceAll("[[REDIRECT_URI]]", redirectUri));
           
+          let customCss = '';
+  
           const head = document.querySelector('head');
-
-          const widgetCssUrl = \`${apiUrl}/api/project/${config.projectId}/widget-css/${widgetType}\`;
-          if (!head.querySelector(\`link[href="${widgetCssUrl}"]\`)) {
-            head.innerHTML += \`<link href="${widgetCssUrl}" rel="stylesheet">\`;
-          }
+          if (config.project?.cssCustom) {
+            const customCssUrl = '${apiUrl}/api/project/' + config.projectId + '/css/' + randomComponentId;
+            customCss = \`<link href="\${customCssUrl}" rel="stylesheet">\`;
           
-          if (data.project?.cssUrl) {
-            if (!head.querySelector(\`link[href="${data.project.cssUrl}"]\`)) {
-              head.innerHTML += \`<link href="${data.project.cssUrl}" rel="stylesheet">\`;
+            if (customCss && !head.querySelector(\`link[href="\${customCssUrl}"]\`)) {
+              head.innerHTML += customCss;
             }
           }
           
-          if (config.project.cssCustom) {
-            const customCssUrl = \`${apiUrl}/api/project/${config.projectId}/css/${randomComponentId}\`;
-            if (!head.querySelector(\`link[href="${customCssUrl}"]\`)) {
-              head.innerHTML += \`<link href="${customCssUrl}" rel="stylesheet">\`;
+          if (!head.querySelector('link[href="${apiUrl}/api/project/\${config.projectId}/widget-css/${widgetType}"]')) {
+            head.innerHTML += \`<link href="${apiUrl}/api/project/\${config.projectId}/widget-css/${widgetType}" rel="stylesheet">\`;
+          }
+          
+          if (config.project?.cssUrl) {
+            if (!head.querySelector(\`link[href="\${config.project.cssUrl}"]\`)) {
+              head.innerHTML += \`<link href="\${config.project.cssUrl}" rel="stylesheet">\`;
             }
           }
           

--- a/apps/api-server/src/routes/widget/widget.js
+++ b/apps/api-server/src/routes/widget/widget.js
@@ -276,9 +276,6 @@ function getWidgetJavascriptOutput(
 
   const apiUrl = process.env.URL ?? '';
 
-  const extraCssFile = data.project?.cssUrl ? `<link href="${data.project.cssUrl}" rel="stylesheet">` : '';
-
-
   // TODO: Fix this, it's a hack to get the ChoiceGuide to work
   if ( widgetSettings.componentName === 'ChoiceGuide' ) {
 

--- a/apps/cms-server/app.js
+++ b/apps/cms-server/app.js
@@ -386,7 +386,7 @@ app.use((req, res, next) => {
 app.use((req, res, next) => {
 
   if (req.site && req.site.config?.basicAuth?.active && req.site.config?.basicAuth?.username && req.site.config?.basicAuth?.password) {
-    console.log('Basic auth enabled for project: ', req.site.url);
+
     return basicAuth({
       users: { [req.site.config.basicAuth.username]: req.site.config.basicAuth.password },
       challenge: true

--- a/apps/cms-server/modules/@apostrophecms/global/index.js
+++ b/apps/cms-server/modules/@apostrophecms/global/index.js
@@ -2,6 +2,7 @@
 const fs = require('fs');
 const fields = require('./lib/fields');
 const arrangeFields = require('./lib/arrangeFields');
+const projectService = require('../../../services/projects');
 
 module.exports = {
   options: {
@@ -22,6 +23,17 @@ module.exports = {
         req.project = self.apos.options.project;
         req.data.global.projectTitle = req.project.title;
         req.data.prefix = self.apos.options.prefix || '';
+
+        try {
+          if (!!req.project.id){
+            const project = await projectService.fetchOne(req.project.id);
+
+            if (project) {
+              const customCssUrls = project.config?.project?.cssUrl || [];
+              req.data.customCssUrls = Array.isArray(customCssUrls) ? customCssUrls : [customCssUrls];
+            }
+          }
+        } catch (error) {}
 
         // system defaults
         let cmsDefaults = process.env.CMS_DEFAULTS;
@@ -186,23 +198,23 @@ module.exports = {
       //   def: '#logo-image {\n  max-height: 50px;\n}',
       //   label: 'Extra CSS',
       // },
-      customCssLink: {
-        type: 'string',
-        label: 'URL voor CSS imports (optioneel)',
-      },
-      customCssLink: {
-        type: 'array',
-        label: 'URL voor CSS imports (optioneel)',
-        inline: true,
-        fields: {
-          add: {
-            item: {
-              type: 'string',
-              label: 'URL voor CSS imports (optioneel)',
-            },
-          },
-        },
-      },
+      // customCssLink: {
+      //   type: 'string',
+      //   label: 'URL voor CSS imports (optioneel)',
+      // },
+      // customCssLink: {
+      //   type: 'array',
+      //   label: 'URL voor CSS imports (optioneel)',
+      //   inline: true,
+      //   fields: {
+      //     add: {
+      //       item: {
+      //         type: 'string',
+      //         label: 'URL voor CSS imports (optioneel)',
+      //       },
+      //     },
+      //   },
+      // },
       compactMenu: {
         type: 'boolean',
         label: 'Compacte weergave van het hoofdmenu.',
@@ -330,7 +342,7 @@ module.exports = {
       },
       css: {
         label: 'Vormgeving',
-        fields: ['customCssLink', 'favicon', 'compactMenu'],
+        fields: ['favicon', 'compactMenu'],
       },
       login: {
         label: 'Menu instellingen',

--- a/apps/cms-server/views/partials/css.html
+++ b/apps/cms-server/views/partials/css.html
@@ -10,6 +10,12 @@
   {% endfor %}
 {% endif %}
 
+{% if data.customCssUrls %}
+  {% for customCssUrl in data.customCssUrls %}
+    <link rel="stylesheet" href="{{ customCssUrl }}">
+  {% endfor %}
+{% endif %}
+
 {% if data.global.favicon %}
   <link rel="icon" type="image/x-icon" href="{{ data.global.favicon }}">
 {% endif %}


### PR DESCRIPTION
Deze PR zorgt voor een aantal fixes en verbeteringen:

- Console.log in de cms-server die constant in de logs terug kwam is nu weggehaald
- In Apostrophe en in de admin kon je CSS url's opgeven, wat een beetje omslachtig is. In Apostrophe is dit nu weggehaald, maar de code is gebleven zodat die data nog wel ingeladen wordt voor bestaande projecten
- Er is een check gemaakt die ervoor zorgt dat style bestanden niet vaker worden ingeladen. Eerst werd per gebruikte widget op een pagina elke huisstijl bestand ingeladen.
- De 404 pagina kreeg niet de styling vanuit de admin bestanden mee. Doordat het nu standaard wordt ingeladen op apostrophe pagina's is het daar nu ook actief