### PR TITLE
Feat/comments pagination

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/comments/[id]/general.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/comments/[id]/general.tsx
@@ -24,11 +24,16 @@ import { FormObjectSelectField } from '@/components/ui/form-object-select-field'
 import useResources from '@/hooks/use-resources';
 import { ReactNode } from 'react';
 import { ArgumentWidgetTabProps } from '.';
+import * as Switch from "@radix-ui/react-switch";
+import {Input} from "@/components/ui/input";
+import {useFieldDebounce} from "@/hooks/useFieldDebounce";
 
 const formSchema = z.object({
   resourceId: z.string().optional(),
   sentiment: z.string(),
   useSentiments: z.string().optional(),
+  itemsPerPage: z.coerce.number(),
+  displayPagination: z.boolean().optional()
 });
 
 type SchemaKey = keyof typeof formSchema.shape;
@@ -53,12 +58,16 @@ export default function ArgumentsGeneral({
     return key in finalSchema.shape ? field : null;
   };
 
+  const { onFieldChange } = useFieldDebounce(props.onFieldChanged);
+
   const form = useForm<finalSchemaInfer>({
     resolver: zodResolver<any>(finalSchema),
     defaultValues: {
       resourceId: props.resourceId,
       sentiment: props.sentiment || 'for',
       useSentiments: JSON.stringify(props.useSentiments || ["for","against"]),
+      itemsPerPage: props?.itemsPerPage || 9999,
+      displayPagination: props?.displayPagination || false,
     },
   });
 
@@ -152,6 +161,49 @@ export default function ArgumentsGeneral({
                       <SelectItem value='["no sentiment"]'>Eén lijst, geen sentiment</SelectItem>
                     </SelectContent>
                   </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          )}
+
+          <FormField
+            control={form.control}
+            name="displayPagination"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Paginering tonen</FormLabel>
+                <FormControl>
+                  <Switch.Root
+                    className="block w-[50px] h-[25px] bg-stone-300 rounded-full relative focus:shadow-[0_0_0_2px] focus:shadow-black data-[state=checked]:bg-primary outline-none cursor-default"
+                    onCheckedChange={(e: boolean) => {
+                      props.onFieldChanged(field.name, e);
+                      field.onChange(e);
+                    }}
+                    checked={field.value}>
+                    <Switch.Thumb className="block w-[21px] h-[21px] bg-white rounded-full transition-transform duration-100 translate-x-0.5 will-change-transform data-[state=checked]:translate-x-[27px]" />
+                  </Switch.Root>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          { !!form.watch('displayPagination') && (
+            <FormField
+              control={form.control}
+              name="itemsPerPage"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Hoeveelheid items per pagina</FormLabel>
+                  <FormControl>
+                    <Input type="number" {...field}
+                           placeholder="9999"
+                           {...field}
+                           onChange={(e) => {
+                             onFieldChange(field.name, e.target.value);
+                             field.onChange(e);
+                           }} />
+                  </FormControl>
                   <FormMessage />
                 </FormItem>
               )}

--- a/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/general.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/general.tsx
@@ -29,6 +29,8 @@ const formSchema = z.object({
   zoom: z.number().optional(),
   minZoom: z.number().optional(),
   maxZoom: z.number().optional(),
+  itemsPerPage: z.coerce.number(),
+  displayPagination: z.boolean().optional()
 });
 type FormData = z.infer<typeof formSchema>;
 
@@ -57,6 +59,8 @@ export default function DocumentGeneral(
       minZoom: props.minZoom || -6,
       maxZoom: props.maxZoom || 10,
       entireDocumentVisible: props.entireDocumentVisible || 'entirely',
+      itemsPerPage: props?.itemsPerPage || 9999,
+      displayPagination: props?.displayPagination || false,
     },
   });
 
@@ -240,6 +244,49 @@ export default function DocumentGeneral(
             </FormItem>
           )}
         />
+
+        <FormField
+          control={form.control}
+          name="displayPagination"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Paginering tonen</FormLabel>
+              <FormControl>
+                <Switch.Root
+                  className="block w-[50px] h-[25px] bg-stone-300 rounded-full relative focus:shadow-[0_0_0_2px] focus:shadow-black data-[state=checked]:bg-primary outline-none cursor-default"
+                  onCheckedChange={(e: boolean) => {
+                    props.onFieldChanged(field.name, e);
+                    field.onChange(e);
+                  }}
+                  checked={field.value}>
+                  <Switch.Thumb className="block w-[21px] h-[21px] bg-white rounded-full transition-transform duration-100 translate-x-0.5 will-change-transform data-[state=checked]:translate-x-[27px]" />
+                </Switch.Root>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        { !!form.watch('displayPagination') && (
+          <FormField
+            control={form.control}
+            name="itemsPerPage"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Hoeveelheid items per pagina</FormLabel>
+                <FormControl>
+                  <Input type="number" {...field}
+                         placeholder="9999"
+                         {...field}
+                         onChange={(e) => {
+                           onFieldChange(field.name, e.target.value);
+                           field.onChange(e);
+                         }} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        )}
 
         <Button
           type="submit"

--- a/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/general.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/general.tsx
@@ -29,7 +29,7 @@ const formSchema = z.object({
   zoom: z.number().optional(),
   minZoom: z.number().optional(),
   maxZoom: z.number().optional(),
-  itemsPerPage: z.coerce.number(),
+  itemsPerPage: z.coerce.number().optional(),
   displayPagination: z.boolean().optional()
 });
 type FormData = z.infer<typeof formSchema>;

--- a/packages/comments/src/index.css
+++ b/packages/comments/src/index.css
@@ -108,3 +108,7 @@
  color: var(--utrecht-button-secondary-action-color, white);
  border: 1px solid var(--utrecht-button-secondary-action-border-color, #ff0021);
 }
+
+.osc-comments-paginator .osc-paginator {
+ justify-content: center;
+}

--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -83,6 +83,8 @@ export type DocumentMapProps = BaseProps &
     closedText?: string;
     relativePathPrepend?: string;
     entireDocumentVisible?: 'entirely' | 'onlyTop';
+    itemsPerPage?: number;
+    displayPagination?: boolean;
   };
 
 
@@ -117,6 +119,8 @@ function DocumentMap({
   closedText = 'Het insturen van reacties is gesloten, u kunt niet meer reageren',
   relativePathPrepend = '',
   entireDocumentVisible = 'onlyTop',
+  itemsPerPage = 9999,
+  displayPagination = false,
   ...props
 }: DocumentMapProps) {
 
@@ -380,6 +384,10 @@ function DocumentMap({
           sentiment: 'no sentiment',
           tags: allTags,
         });
+
+        if (goToLastPage && displayPagination) {
+          goToLastPage();
+        }
 
         const addNewCommentToComments = [...filteredComments, newComment];
         const newIndex = newComment?.id;
@@ -683,6 +691,7 @@ function DocumentMap({
     const configVotingEnabled = props?.votes?.isActive || false;
     const votingEnabled = configVotingEnabled && args.canComment;
 
+    const [goToLastPage, setGoToLastPage] = useState<(() => void) | null>(null);
 
     return !bounds ? null : (
       <div className={`documentMap--container ${largeDoc ? '--largeDoc' : ''}`}>
@@ -975,6 +984,9 @@ function DocumentMap({
                 emptyListText={emptyListText}
                 loginText={loginText}
                 closedText={closedText}
+                itemsPerPage={itemsPerPage}
+                displayPagination={displayPagination}
+                onGoToLastPage={setGoToLastPage}
               />
             </div>
           )}

--- a/packages/resource-detail/src/resource-detail.tsx
+++ b/packages/resource-detail/src/resource-detail.tsx
@@ -482,6 +482,8 @@ function ResourceDetail({
             placeholder={props.commentsWidget?.placeholder}
             loginText={props.commentsWidget?.loginText}
             closedText={props.commentsWidget?.closedText}
+            itemsPerPage={props.commentsWidget?.itemsPerPage}
+            displayPagination={props.commentsWidget?.displayPagination}
             sentiment={useSentiments[0]}
           />
 
@@ -497,6 +499,8 @@ function ResourceDetail({
               placeholder={props.commentsWidget_multiple?.placeholder}
               loginText={props.commentsWidget_multiple?.loginText}
               closedText={props.commentsWidget_multiple?.closedText}
+              itemsPerPage={props.commentsWidget?.itemsPerPage}
+              displayPagination={props.commentsWidget?.displayPagination}
               sentiment={useSentiments[1]}
             />
           )}


### PR DESCRIPTION
Deze PR is een uitbreiding op de reactie widget. Dit zijn de verwerkte punten:

- Er moet instelbaar zijn hoeveel reacties er zijn per pagina;
- Wanneer het maximaal aantal reacties is bereikt, komt er een nieuwe pagina;
- Zelfde vormgeving en functionaliteit als bij het ideeënoverzicht