### PR TITLE
Fix: pvc annotations and storage size

### DIFF
--- a/charts/openstad-headless/Chart.yaml
+++ b/charts/openstad-headless/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.20
+version: 0.0.21
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openstad-headless/templates/persistence-claim.yml
+++ b/charts/openstad-headless/templates/persistence-claim.yml
@@ -4,7 +4,10 @@ kind: PersistentVolumeClaim
 metadata:
   name: image-data-claim
   namespace: {{ .Release.Namespace }}
-  annotations: {{ .Values.persistence.annotations }}
+{{- if (.Values.persistence.annotations)}}
+  annotations:
+{{ toYaml .Values.persistence.annotations | indent 4 }}
+{{- end}}
 spec:
 {{- if (and .Values.persistence .Values.persistence.storageClassName) }}
   storageClassName: {{ .Values.persistence.storageClassName }}
@@ -24,7 +27,10 @@ kind: PersistentVolumeClaim
 metadata:
   name: docs-data-claim
   namespace: {{ .Release.Namespace }}
-  annotations: {{ .Values.persistence.annotations }}
+{{- if (.Values.persistence.annotations)}}
+  annotations:
+{{ toYaml .Values.persistence.annotations | indent 4 }}
+{{- end}}
 spec:
 {{- if (and .Values.persistence .Values.persistence.storageClassName) }}
   storageClassName: {{ .Values.persistence.storageClassName }}
@@ -44,7 +50,10 @@ kind: PersistentVolumeClaim
 metadata:
   name: cms-data-claim
   namespace: {{ .Release.Namespace }}
-  annotations: {{ .Values.persistence.annotations }}
+{{- if (.Values.persistence.annotations)}}
+  annotations:
+{{ toYaml .Values.persistence.annotations | indent 4 }}
+{{- end}}
 spec:
 {{- if (and .Values.persistence .Values.persistence.storageClassName) }}
   storageClassName: {{ .Values.persistence.storageClassName }}

--- a/charts/openstad-headless/templates/persistence-claim.yml
+++ b/charts/openstad-headless/templates/persistence-claim.yml
@@ -13,7 +13,11 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.image.volumes.data.size }}
+  {{- if (and .Values.persistence .Values.persistence.image .Values.persistence.image.size) }}
+      storage: {{ .Values.persistence.image.size | default "1Gi" }}
+  {{- else}}
+      storage: 1Gi
+  {{- end}}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -29,7 +33,11 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.image.volumes.data.size }}
+  {{- if (and .Values.persistence .Values.persistence.docs .Values.persistence.docs.size) }}
+      storage: {{ .Values.persistence.docs.size | default "1Gi" }}
+  {{- else}}
+      storage: 1Gi
+  {{- end}}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -45,4 +53,8 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: {{ .Values.cms.volumes.data.size }}
+  {{- if (and .Values.persistence .Values.persistence.cms .Values.persistence.cms.size) }}
+      storage: {{ .Values.persistence.cms.size | default "1Gi" }}
+  {{- else}}
+      storage: 1Gi
+  {{- end}}

--- a/charts/openstad-headless/values.yaml
+++ b/charts/openstad-headless/values.yaml
@@ -113,7 +113,7 @@ host:
 persistence:
   #configure the cloud-specific storageClassName, will use the clouds default if not specified
   storageClassName:
-  annotations: '{}'
+  annotations: {}
 
 admin:
   # Configure how many replicas exists of this service


### PR DESCRIPTION
This pull request includes updates to the Helm chart for the `openstad-headless` application, focusing on improving the configuration of persistent volume claims and incrementing the chart version.

Updates to persistent volume claims:

* [`charts/openstad-headless/templates/persistence-claim.yml`](diffhunk://#diff-32d4e45ce04de413576ea2a626cdce75613b96957c1dad53ab2be1ba4a8560b8L7-R10): Added conditional logic to include annotations only when they are defined, and updated the storage requests to use a default value of "1Gi" if specific sizes are not provided. [[1]](diffhunk://#diff-32d4e45ce04de413576ea2a626cdce75613b96957c1dad53ab2be1ba4a8560b8L7-R10) [[2]](diffhunk://#diff-32d4e45ce04de413576ea2a626cdce75613b96957c1dad53ab2be1ba4a8560b8L16-R33) [[3]](diffhunk://#diff-32d4e45ce04de413576ea2a626cdce75613b96957c1dad53ab2be1ba4a8560b8L32-R56) [[4]](diffhunk://#diff-32d4e45ce04de413576ea2a626cdce75613b96957c1dad53ab2be1ba4a8560b8L48-R69)

Version increment:

* [`charts/openstad-headless/Chart.yaml`](diffhunk://#diff-1225aa8e7e1443ee977d5bd30ff47cac1992fe2692c8429a8452e2fff0445ae0L19-R19): Incremented the chart version from `0.0.20` to `0.0.21`.

Configuration updates:

* [`charts/openstad-headless/values.yaml`](diffhunk://#diff-561af82ef20c0833bcb50272b5b09310f1b63fa94e8140bf7589d79a80b2a312L116-R116): Simplified the default value for `annotations` in the `persistence` section.