### PR TITLE
Fix/map tiles variant settings

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/settings/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/settings/index.tsx
@@ -417,7 +417,7 @@ export default function ProjectSettings() {
                     <section>
                       <br/>
                       <Heading size={'lg'}>Nederlandse Kaart</Heading>
-                      <p>De "Nederlandse Kaart" variant maakt gebruik van <mark>https://service.pdok.nl</mark>.
+                      <p>De &quot;Nederlandse Kaart&quot; variant maakt gebruik van <mark>https://service.pdok.nl</mark>.
                         Deze bron is al opgenomen in de <code>img-src</code> in de CSP, aangezien het de standaard kaart
                         is.</p>
                     </section>
@@ -425,7 +425,7 @@ export default function ProjectSettings() {
                     <section>
                       <br/>
                       <Heading size={'lg'}>Amsterdam Kaart</Heading>
-                      <p>De "Amsterdam Kaart" variant haalt tegels van de volgende subdomeinen van de stad
+                      <p>De &quot;Amsterdam Kaart&quot; variant haalt tegels van de volgende subdomeinen van de stad
                         Amsterdam:</p>
                       <ul>
                         <mark>https://t1.data.amsterdam.nl</mark>
@@ -464,7 +464,7 @@ export default function ProjectSettings() {
                     <section>
                       <br/>
                       <Heading size={'lg'}>CartoDB Light</Heading>
-                      <p>De "CartoDB Light" variant haalt tegels op van de volgende subdomeinen:</p>
+                      <p>De &quot;CartoDB Light&quot; variant haalt tegels op van de volgende subdomeinen:</p>
                       <ul>
                         <mark>https://a.basemaps.cartocdn.com</mark>
                         <br/>

--- a/apps/admin-server/src/pages/projects/[project]/settings/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/settings/index.tsx
@@ -395,7 +395,8 @@ export default function ProjectSettings() {
                 <Separator className="my-4" />
                 <div className="space-y-4">
                   <div>
-                    Indien je gebruik wilt maken van de Content-Security-Policy header, dan vind je hieronder de standaardheader die je kunt gebruiken. Deze kun je naar wens aanpassen.
+                    Indien je gebruik wilt maken van de Content-Security-Policy header, dan vind je hieronder de
+                    standaardheader die je kunt gebruiken. Deze kun je naar wens aanpassen.
                   </div>
 
                   <div>
@@ -404,18 +405,93 @@ export default function ProjectSettings() {
                     </p>
                   </div>
                   <div className="flex gap-4 p-0">
-                    <Button onClick={() => onCopy(cspHeader, 'Content-Security-Policy header')}>Kopieer Content-Security-Policy header</Button>
+                    <Button onClick={() => onCopy(cspHeader, 'Content-Security-Policy header')}>Kopieer
+                      Content-Security-Policy header</Button>
                   </div>
+
+                  <div className="csp-overview">
+                    <br/>
+                    <Separator className="my-4"/>
+                    <Heading size={'xl'}>Content Security Policy (CSP) Headers voor de verschillende Kaart Tegel Varianten</Heading>
+
+                    <section>
+                      <br/>
+                      <Heading size={'lg'}>Nederlandse Kaart</Heading>
+                      <p>De "Nederlandse Kaart" variant maakt gebruik van <mark>https://service.pdok.nl</mark>.
+                        Deze bron is al opgenomen in de <code>img-src</code> in de CSP, aangezien het de standaard kaart
+                        is.</p>
+                    </section>
+
+                    <section>
+                      <br/>
+                      <Heading size={'lg'}>Amsterdam Kaart</Heading>
+                      <p>De "Amsterdam Kaart" variant haalt tegels van de volgende subdomeinen van de stad
+                        Amsterdam:</p>
+                      <ul>
+                        <mark>https://t1.data.amsterdam.nl</mark>
+                        <br/>
+                        <mark>https://t2.data.amsterdam.nl</mark>
+                        <br/>
+                        <mark>https://t3.data.amsterdam.nl</mark>
+                        <br/>
+                        <mark>https://t4.data.amsterdam.nl</mark>
+                      </ul>
+                      <p>Zorg ervoor dat je deze subdomeinen toestaat in je CSP voor de <code>img-src</code>.</p>
+                      <p>Of sta toe door <mark>https://*.data.amsterdam.nl</mark> in de CSP voor
+                        de <code>img-src</code> op
+                        te nemen.
+                      </p>
+                    </section>
+
+                    <section>
+                      <br/>
+                      <Heading size={'lg'}>OpenStreetMap</Heading>
+                      <p>De OpenStreetMap tegels worden geladen van de subdomeinen:</p>
+                      <ul>
+                        <mark>https://a.tile.openstreetmap.org</mark>
+                        <br/>
+                        <mark>https://b.tile.openstreetmap.org</mark>
+                        <br/>
+                        <mark>https://c.tile.openstreetmap.org</mark>
+                      </ul>
+                      <p>Zorg ervoor dat je deze subdomeinen toestaat in je CSP voor de <code>img-src</code>.</p>
+                      <p>Of sta toe door <mark>https://*.tile.openstreetmap.org</mark> in de CSP voor
+                        de <code>img-src</code> op
+                        te nemen.
+                      </p>
+                    </section>
+
+                    <section>
+                      <br/>
+                      <Heading size={'lg'}>CartoDB Light</Heading>
+                      <p>De "CartoDB Light" variant haalt tegels op van de volgende subdomeinen:</p>
+                      <ul>
+                        <mark>https://a.basemaps.cartocdn.com</mark>
+                        <br/>
+                        <mark>https://b.basemaps.cartocdn.com</mark>
+                        <br/>
+                        <mark>https://c.basemaps.cartocdn.com</mark>
+                      </ul>
+                      <p>Zorg ervoor dat je deze subdomeinen toestaat in je CSP voor de <code>img-src</code>.</p>
+                      <p>Of sta toe door <mark>https://*.basemaps.cartocdn.com</mark> in de CSP voor
+                        de <code>img-src</code> op
+                        te nemen.
+                      </p>
+                    </section>
+                  </div>
+
+
                 </div>
               </div>
             </TabsContent>
             <TabsContent value="projecthasended" className="p-0">
               <div className="p-6 bg-white rounded-md">
                 <Heading size="xl">Project beëindigen</Heading>
-                <Separator className="my-4" />
+                <Separator className="my-4"/>
                 <div className="space-y-4">
                   <div>
-                    Wanneer je het project beëindigt, sluiten automatisch de mogelijkheden om plannen in te dienen, reacties te plaatsen en te stemmen.
+                    Wanneer je het project beëindigt, sluiten automatisch de mogelijkheden om plannen in te dienen,
+                    reacties te plaatsen en te stemmen.
                   </div>
                   <div>
                     Project beëindigen
@@ -425,7 +501,8 @@ export default function ProjectSettings() {
                         setProjectHasEnded(!projectHasEnded)
                       }}
                       checked={projectHasEnded}>
-                      <Switch.Thumb className="block w-[21px] h-[21px] bg-white rounded-full transition-transform duration-100 translate-x-0.5 will-change-transform data-[state=checked]:translate-x-[27px]" />
+                      <Switch.Thumb
+                        className="block w-[21px] h-[21px] bg-white rounded-full transition-transform duration-100 translate-x-0.5 will-change-transform data-[state=checked]:translate-x-[27px]"/>
                     </Switch.Root>
                   </div>
                   <Button
@@ -439,14 +516,14 @@ export default function ProjectSettings() {
             <TabsContent value="advanced" className="p-0">
               <div className="p-6 bg-white rounded-md">
                 <Heading size="xl">Project archiveren</Heading>
-                <Separator className="my-4" />
+                <Separator className="my-4"/>
                 <div className="space-y-4">
                   <div>
                     Let op! Deze actie is <b>definitief</b> en
                     <b> kan niet ongedaan gemaakt worden</b>.
                   </div>
                   <div className="space-y-2">
-                  Het project moet eerst zijn beëindigd voordat deze actie uitgevoerd kan worden.
+                    Het project moet eerst zijn beëindigd voordat deze actie uitgevoerd kan worden.
                   </div>
 
                   <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>

--- a/apps/admin-server/src/pages/projects/[project]/settings/map.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/settings/map.tsx
@@ -227,7 +227,7 @@ export default function ProjectSettingsMap() {
                   }}
                   className="lg:w-full lg:col-span-2"
                 >
-                  <strong>Let op!</strong> Wanneer je een andere kaartweergave kiest dan de "Nederlandse Kaart", en je hebt een Content
+                  <strong>Let op!</strong> Wanneer je een andere kaartweergave kiest dan de &quot;Nederlandse Kaart&quot;, en je hebt een Content
                   Security Policy (CSP) ingesteld, moet je ervoor zorgen dat je de juiste headers toevoegt aan je
                   CSP. <br /> <br />
                   Lees meer over CSP instellingen voor kaartweergaven bij <strong>Projectinstellingen &gt; Algemeen &gt; Beveiligingsheaders</strong>

--- a/apps/admin-server/src/pages/projects/[project]/settings/map.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/settings/map.tsx
@@ -213,11 +213,32 @@ export default function ProjectSettingsMap() {
                 )}
               />
 
+              {form.watch('tilesVariant') !== 'nlmaps' && (
+                <p
+                  style={{
+                    backgroundColor: '#d69e2e',
+                    color: 'black',
+                    padding: '15px',
+                    borderLeft: '4px solid black',
+                    borderTopRightRadius: '5px',
+                    borderBottomRightRadius: '5px',
+                    marginTop: '10px',
+                    fontSize: '13px'
+                  }}
+                  className="lg:w-full lg:col-span-2"
+                >
+                  <strong>Let op!</strong> Wanneer je een andere kaartweergave kiest dan de "Nederlandse Kaart", en je hebt een Content
+                  Security Policy (CSP) ingesteld, moet je ervoor zorgen dat je de juiste headers toevoegt aan je
+                  CSP. <br /> <br />
+                  Lees meer over CSP instellingen voor kaartweergaven bij <strong>Projectinstellingen &gt; Algemeen &gt; Beveiligingsheaders</strong>
+                </p>
+              )}
+
               {form.watch('tilesVariant') === 'custom' && (
                 <FormField
                   control={form.control}
                   name="customUrl"
-                  render={({ field }) => (
+                  render={({field}) => (
                     <FormItem className="col-span-1">
                       <FormLabel>
                         Aangepaste URL

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourcesmap/[id]/map.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourcesmap/[id]/map.tsx
@@ -255,6 +255,27 @@ export default function WidgetResourcesMapMap(
             )}
           />
 
+          {form.watch('tilesVariant') !== 'nlmaps' && (
+            <p
+              style={{
+                backgroundColor: '#d69e2e',
+                color: 'black',
+                padding: '15px',
+                borderLeft: '4px solid black',
+                borderTopRightRadius: '5px',
+                borderBottomRightRadius: '5px',
+                marginTop: '10px',
+                fontSize: '13px'
+              }}
+              className="lg:w-full lg:col-span-2"
+            >
+              <strong>Let op!</strong> Wanneer je een andere kaartweergave kiest dan de "Nederlandse Kaart", en je hebt een Content
+              Security Policy (CSP) ingesteld, moet je ervoor zorgen dat je de juiste headers toevoegt aan je
+              CSP. <br /> <br />
+              Lees meer over CSP instellingen voor kaartweergaven bij <strong>Projectinstellingen &gt; Algemeen &gt; Beveiligingsheaders</strong>
+            </p>
+          )}
+
           {form.watch('tilesVariant') === 'custom' && (
             <FormField
               control={form.control}

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourcesmap/[id]/map.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourcesmap/[id]/map.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Form,
-  FormControl,
+  FormControl, FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -25,6 +25,7 @@ import { useFieldDebounce } from '@/hooks/useFieldDebounce';
 import { EditFieldProps } from '@/lib/form-widget-helpers/EditFieldProps';
 import * as z from 'zod';
 import { ResourceOverviewMapWidgetTabProps } from '.';
+import * as React from "react";
 
 type Tag = {
   id: number;
@@ -42,6 +43,7 @@ const formSchema = z.object({
     isActive: z.boolean().optional(),
   }),
   tilesVariant: z.string().optional(),
+  customUrl: z.string().optional(),
   width: z.string().optional(),
   height: z.string().optional(),
 });
@@ -72,6 +74,7 @@ export default function WidgetResourcesMapMap(
       clustering: props?.clustering || {},
       categorize: props?.categorize || {},
       tilesVariant: props?.tilesVariant || '',
+      customUrl: props?.customUrl || '',
       width: props?.width || '',
       height: props?.height || ''
     },
@@ -92,6 +95,14 @@ export default function WidgetResourcesMapMap(
       setGroupedNames(groupNames);
     }
   }, [tags]);
+
+  const tileLayerOptions = [
+    { value: 'nlmaps', label: 'Nederlandse Kaart' },
+    { value: 'amaps', label: 'Amsterdam Kaart' },
+    { value: 'openstreetmaps', label: 'OpenStreetMap' },
+    { value: 'n3s', label: 'CartoDB Light' },
+    { value: 'custom', label: 'Aangepaste Kaart' },
+  ];
 
   return (
     <div className="p-6 bg-white rounded-md">
@@ -232,15 +243,36 @@ export default function WidgetResourcesMapMap(
                   </FormControl>
                   <SelectContent>
                     <SelectItem value="" disabled>Selecteer een optie</SelectItem>
-                    <SelectItem value="nlmaps">NL maps</SelectItem>
-                    <SelectItem value="amaps">Amsterdams</SelectItem>
-                    <SelectItem value="openstreetmaps">Open Street Maps</SelectItem>
+                    {tileLayerOptions.map(option => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
                 <FormMessage />
               </FormItem>
             )}
           />
+
+          {form.watch('tilesVariant') === 'custom' && (
+            <FormField
+              control={form.control}
+              name="customUrl"
+              render={({ field }) => (
+                <FormItem className="col-span-1">
+                  <FormLabel>
+                    Aangepaste URL
+                  </FormLabel>
+                  <FormDescription>{`Voer de URL in voor de aangepaste kaartweergave. Bijvoorbeeld: https://example.com/tiles/{z}/{x}/{y}.png`}</FormDescription>
+                  <FormControl>
+                    <Input placeholder="https://example.com/tiles/{z}/{x}/{y}.png" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          )}
 
           <FormField
             control={form.control}

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourcesmap/[id]/map.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourcesmap/[id]/map.tsx
@@ -269,7 +269,7 @@ export default function WidgetResourcesMapMap(
               }}
               className="lg:w-full lg:col-span-2"
             >
-              <strong>Let op!</strong> Wanneer je een andere kaartweergave kiest dan de "Nederlandse Kaart", en je hebt een Content
+              <strong>Let op!</strong> Wanneer je een andere kaartweergave kiest dan de &quot;Nederlandse Kaart&quot;, en je hebt een Content
               Security Policy (CSP) ingesteld, moet je ervoor zorgen dat je de juiste headers toevoegt aan je
               CSP. <br /> <br />
               Lees meer over CSP instellingen voor kaartweergaven bij <strong>Projectinstellingen &gt; Algemeen &gt; Beveiligingsheaders</strong>

--- a/packages/leaflet-map/src/resource-overview-map.tsx
+++ b/packages/leaflet-map/src/resource-overview-map.tsx
@@ -270,6 +270,14 @@ const ResourceOverviewMap = ({
 
   const visibleMapDataLayers = mapDataLayers.filter(layer => activeLayers[layer.id]);
 
+  if ( !!props?.map && typeof(props?.map) === 'object' ) {
+    props.map = {
+      ...props.map,
+      tilesVariant: props?.tilesVariant || props?.map?.tilesVariant || 'nlmaps',
+      customUrl: props?.customUrl || props?.map?.customUrl || '',
+    }
+  }
+
   return ((polygon && center) || !areaId) ? (
     <div className='map-container--buttons'>
       <Button appearance='primary-action-button' className='skip-link' onClick={skipMarkers}>Sla kaart over</Button>

--- a/packages/leaflet-map/src/tile-layer.tsx
+++ b/packages/leaflet-map/src/tile-layer.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { TileLayer as LeafletTileLayer } from 'react-leaflet'
 import type { MapTilesProps } from './types/map-tiles-props';
 import { useEffect, useState } from 'react';


### PR DESCRIPTION
De map varianten stonden alleen in de globale instellingen goed ingesteld. Nu staan ze ook goed ingesteld bij de andere velden waar je kon kiezen voor de kaart.

Verder is er een uitleg bij de CSP toegevoegd voor de verschillende mogelijke kaarten en een melding als je kiest voor iets anders dan de standaard kaart.

![Screenshot 2025-03-19 at 17 33 02](https://github.com/user-attachments/assets/b4b8bcaf-8224-4a24-ad5e-e3c8e50c868b)
![Screenshot 2025-03-19 at 17 14 02](https://github.com/user-attachments/assets/537859e7-f1dc-4021-8baf-47a72f936065)

