### PR TITLE
Feat/choiceguide results fixes

### DIFF
--- a/apps/cms-server/modules/asset/ui/src/scss/_widgets.scss
+++ b/apps/cms-server/modules/asset/ui/src/scss/_widgets.scss
@@ -5,3 +5,7 @@
 .bp-image-widget {
   max-width: 100%;
 }
+
+.apos-area-widget-inner .apos-area-widget-controls{
+  z-index:999
+}

--- a/packages/choiceguide-results/src/style.css
+++ b/packages/choiceguide-results/src/style.css
@@ -237,6 +237,10 @@ figure.info-image-container {
   /*  rotate thumb  */
 }
 
+.osc-choiceguide-results-container .osc-choices-container .expand-trigger {
+  display: none;
+}
+
 .osc-choice-default .osc-choice-bar-progress[data-score="0"] {width: 0%;}
 .osc-choice-default .osc-choice-bar-progress[data-score="1"] {width: 1%;}
 .osc-choice-default .osc-choice-bar-progress[data-score="2"] {width: 2%;}


### PR DESCRIPTION
Dit lost 2 punten op:
- De 'Details bekijken/verbergen' knop wordt hiermee weggehaald. Dit werd getoond bij de resultaten aangezien de resultaten widget origineel een component is uit de keuzewijzer. Bij de keuzewijzer is de knop wel aanwezig en logisch om te hebben.
- De apostrophe controls kwamen achter de resultaten widget te staan, vandaar de verhoging van de z-index voor de controls