### PR TITLE
Feat/dh fixes 2603

### DIFF
--- a/apps/admin-server/src/lib/export-helpers/choiceguide-export.tsx
+++ b/apps/admin-server/src/lib/export-helpers/choiceguide-export.tsx
@@ -102,12 +102,14 @@ export const exportChoiceGuideToCSV = (data: any, widgetName: string, selectedWi
 
     try {
       parsedValue = JSON.parse(value);
-    } catch (error) {
-      return value;
-    }
+    } catch (error) {}
 
     if (Array.isArray(parsedValue)) {
       return [...parsedValue].join(', ')
+    }
+
+    if ( typeof value === 'string' ) {
+      return `"${value}"`;
     }
 
     return value;

--- a/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/content.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/content.tsx
@@ -33,6 +33,8 @@ const formSchema = z.object({
     infoPopupButtonText: z.string().optional(),
     openInfoPopupOnInit: z.string().optional(),
     relativePathPrepend: z.string().optional(),
+    popupNotLoggedInText: z.string().optional(),
+    popupNotLoggedInButton: z.string().optional(),
 });
 
 export default function DocumentContent(
@@ -62,6 +64,8 @@ export default function DocumentContent(
             largeDoc: props?.largeDoc || false,
             infoPopupButtonText: props?.infoPopupButtonText || '',
             relativePathPrepend: props?.relativePathPrepend || '',
+            popupNotLoggedInText: props?.popupNotLoggedInText || 'Om een reactie te plaatsen, moet je ingelogd zijn.',
+            popupNotLoggedInButton: props?.popupNotLoggedInButton || 'Inloggen',
         },
     });
 
@@ -163,6 +167,38 @@ export default function DocumentContent(
                             <FormItem>
                                 <FormLabel>
                                     Wat is de tekst bij het reactie overzicht wanneer je niet bent ingelogd?
+                                </FormLabel>
+                                <FormControl>
+                                    <Input {...field} />
+                                </FormControl>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+
+                    <FormField
+                        control={form.control}
+                        name="popupNotLoggedInText"
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormLabel>
+                                    Welke tekst staat in de pop-up wanneer je niet bent ingelogd?
+                                </FormLabel>
+                                <FormControl>
+                                    <Input {...field} />
+                                </FormControl>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+
+                    <FormField
+                        control={form.control}
+                        name="popupNotLoggedInButton"
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormLabel>
+                                    Welke tekst heeft de knop in de pop-up wanneer je niet bent ingelogd?
                                 </FormLabel>
                                 <FormControl>
                                     <Input {...field} />

--- a/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/general.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/general.tsx
@@ -8,7 +8,7 @@ import * as z from 'zod';
 import { Button } from '../../../../../../components/ui/button';
 import {
   Form,
-  FormControl,
+  FormControl, FormDescription,
   FormField,
   FormItem,
   FormLabel, FormMessage,
@@ -30,7 +30,8 @@ const formSchema = z.object({
   minZoom: z.number().optional(),
   maxZoom: z.number().optional(),
   itemsPerPage: z.coerce.number().optional(),
-  displayPagination: z.boolean().optional()
+  displayPagination: z.boolean().optional(),
+  onlyAllowClickOnImage: z.boolean().optional()
 });
 type FormData = z.infer<typeof formSchema>;
 
@@ -61,6 +62,7 @@ export default function DocumentGeneral(
       entireDocumentVisible: props.entireDocumentVisible || 'entirely',
       itemsPerPage: props?.itemsPerPage || 9999,
       displayPagination: props?.displayPagination || false,
+      onlyAllowClickOnImage: props?.onlyAllowClickOnImage || false,
     },
   });
 
@@ -241,6 +243,31 @@ export default function DocumentGeneral(
                   <SelectItem value="onlyTop">Focus op de bovenkant</SelectItem>
                 </SelectContent>
               </Select>
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="onlyAllowClickOnImage"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Alleen markers op de afbeelding toelaten?</FormLabel>
+              <FormDescription>
+                Als dit aan staat kunnen gebruikers alleen op de afbeelding klikken en niet op de ruimte er omheen.
+              </FormDescription>
+              <FormControl>
+                <Switch.Root
+                  className="block w-[50px] h-[25px] bg-stone-300 rounded-full relative focus:shadow-[0_0_0_2px] focus:shadow-black data-[state=checked]:bg-primary outline-none cursor-default"
+                  onCheckedChange={(e: boolean) => {
+                    props.onFieldChanged(field.name, e);
+                    field.onChange(e);
+                  }}
+                  checked={field.value}>
+                  <Switch.Thumb className="block w-[21px] h-[21px] bg-white rounded-full transition-transform duration-100 translate-x-0.5 will-change-transform data-[state=checked]:translate-x-[27px]" />
+                </Switch.Root>
+              </FormControl>
+              <FormMessage />
             </FormItem>
           )}
         />

--- a/packages/comments/src/comments.tsx
+++ b/packages/comments/src/comments.tsx
@@ -45,7 +45,7 @@ export type CommentsWidgetProps = BaseProps &
     sorting?: Array<{ value: string; label: string }>;
     setRefreshComments?: React.Dispatch<any>;
     itemsPerPage?: number;
-    overRidePage?: number;
+    overridePage?: number;
     displayPagination?: boolean;
     onGoToLastPage?: (goToLastPage: () => void) => void;
   } & Partial<Pick<CommentFormProps, 'formIntro' | 'placeholder'>>;
@@ -65,7 +65,7 @@ function CommentsInner({
   itemsPerPage,
   onGoToLastPage,
   displayPagination = false,
-  overRidePage = 0,
+  overridePage = 0,
   setRefreshComments: parentSetRefreshComments = () => {}, // parent setter as fallback
   ...props
 }: CommentsWidgetProps) {
@@ -87,10 +87,10 @@ function CommentsInner({
   }, [onGoToLastPage]);
 
   useEffect(() => {
-    if (overRidePage !== page) {
-      setPage(overRidePage);
+    if (overridePage !== page) {
+      setPage(overridePage);
     }
-  }, [overRidePage]);
+  }, [overridePage]);
 
   const refreshComments = () => {
     setRefreshKey(prevKey => prevKey + 1); // Increment the key to trigger a refresh
@@ -361,7 +361,7 @@ function Comments({
   loginText = 'Inloggen om deel te nemen aan de discussie.',
   setRefreshComments = () => {},
   onGoToLastPage,
-  overRidePage,
+  overridePage,
   ...props
 }: CommentsWidgetProps) {
   const [refreshKey, setRefreshKey] = useState(false);
@@ -389,7 +389,7 @@ function Comments({
         loginText={loginText}
         setRefreshComments={triggerRefresh}
         onGoToLastPage={onGoToLastPage}
-        overRidePage={overRidePage}
+        overridePage={overridePage}
         {...props}
       />
     </div>

--- a/packages/comments/src/comments.tsx
+++ b/packages/comments/src/comments.tsx
@@ -220,9 +220,19 @@ function CommentsInner({
     }
   }, [comments, pageSize]);
 
+  const randomId = Math.random().toString(36).replace('0.', 'container_');
+
+  const scrollToTop = () => {
+    const divElement = document.getElementById(randomId);
+
+    if (divElement) {
+      divElement.scrollIntoView({ block: "start", behavior: "auto" });
+    }
+  }
+
     return (
     <CommentWidgetContext.Provider value={{ ...args, setRefreshComments: refreshComments || defaultSetRefreshComments }}>
-      <section className="osc">
+      <section className="osc" id={randomId}>
         <Heading3 className="comments-title">
           {comments && title?.replace(/\[\[nr\]\]/, commentCount.toString()) }
           {!comments && title}
@@ -326,7 +336,10 @@ function CommentsInner({
               <Paginator
                 page={page || 0}
                 totalPages={totalPages || 1}
-                onPageChange={(newPage) => setPage(newPage)}
+                onPageChange={(newPage) => {
+                  setPage(newPage);
+                  scrollToTop();
+                }}
               />
             </div>
           </>

--- a/packages/comments/src/comments.tsx
+++ b/packages/comments/src/comments.tsx
@@ -45,6 +45,7 @@ export type CommentsWidgetProps = BaseProps &
     sorting?: Array<{ value: string; label: string }>;
     setRefreshComments?: React.Dispatch<any>;
     itemsPerPage?: number;
+    overRidePage?: number;
     displayPagination?: boolean;
     onGoToLastPage?: (goToLastPage: () => void) => void;
   } & Partial<Pick<CommentFormProps, 'formIntro' | 'placeholder'>>;
@@ -64,6 +65,7 @@ function CommentsInner({
   itemsPerPage,
   onGoToLastPage,
   displayPagination = false,
+  overRidePage = 0,
   setRefreshComments: parentSetRefreshComments = () => {}, // parent setter as fallback
   ...props
 }: CommentsWidgetProps) {
@@ -82,7 +84,13 @@ function CommentsInner({
     if (onGoToLastPage) {
       onGoToLastPage(goToLastPage);
     }
-  }, [onGoToLastPage, totalPages]);
+  }, [onGoToLastPage]);
+
+  useEffect(() => {
+    if (overRidePage !== page) {
+      setPage(overRidePage);
+    }
+  }, [overRidePage]);
 
   const refreshComments = () => {
     setRefreshKey(prevKey => prevKey + 1); // Increment the key to trigger a refresh
@@ -340,6 +348,7 @@ function Comments({
   loginText = 'Inloggen om deel te nemen aan de discussie.',
   setRefreshComments = () => {},
   onGoToLastPage,
+  overRidePage,
   ...props
 }: CommentsWidgetProps) {
   const [refreshKey, setRefreshKey] = useState(false);
@@ -367,6 +376,7 @@ function Comments({
         loginText={loginText}
         setRefreshComments={triggerRefresh}
         onGoToLastPage={onGoToLastPage}
+        overRidePage={overRidePage}
         {...props}
       />
     </div>

--- a/packages/comments/src/index.css
+++ b/packages/comments/src/index.css
@@ -112,3 +112,20 @@
 .osc-comments-paginator .osc-paginator {
  justify-content: center;
 }
+
+.comment-item .comment-item-header {
+ position: relative;
+ z-index: 1;
+}
+
+.comment-item .comment-item-header .edit-delete-button-group {
+ position: relative;
+}
+
+.comment-item .comment-item-header .edit-delete-button-group .DropdownMenuContent {
+ position: absolute;
+ top: 100%;
+ left: auto;
+ right: 0;
+ min-width: 170px;
+}

--- a/packages/comments/src/parts/comment.tsx
+++ b/packages/comments/src/parts/comment.tsx
@@ -45,6 +45,7 @@ function Comment({
   const { data: currentUser } = datastore.useCurrentUser({ ...args });
   const [isReplyFormActive, setIsReplyFormActive] = useState<boolean>(false);
   const [editMode, setEditMode] = useState<boolean>(false);
+  const [isOpen, setIsOpen] = useState<boolean>(false);
 
   function toggleReplyForm() {
     // todo: scrollto
@@ -140,17 +141,41 @@ function Comment({
           {args.comment.user && args.comment.user.role === 'admin' ? <span className='--isAdmin'>{adminLabel}</span> : null}
         </Heading>
         {canEdit() || canDelete() ? (
-          <DropDownMenu
-            items={[
-              { label: 'Bewerken', onClick: () => toggleEditForm() },
-              {
-                label: 'Verwijderen',
-                onClick: () => {
-                  if (args.comment && confirm('Weet u het zeker?'))
-                    args.comment.delete(args.comment.id);
-                },
-              },
-            ]}/>
+          <div className="edit-delete-button-group">
+            <Button appearance="subtle-button" onClick={() => setIsOpen(!isOpen)}>
+              <div>
+                <i className={isOpen ? "ri-close-fill" : "ri-more-fill"}></i>
+                <span className="sr-only">Bewerken</span>
+              </div>
+            </Button>
+
+            {isOpen && (
+              <div className="DropdownMenuContent">
+                  <ButtonGroup direction='column'>
+                    <Button
+                      appearance='secondary-action-button'
+                      className="DropdownMenuItem"
+                      onClick={() => {
+                        setIsOpen(false);
+                        toggleEditForm();
+                      }}
+                    >
+                      Bewerken
+                    </Button>
+                    <Button
+                      appearance='secondary-action-button'
+                      className="DropdownMenuItem"
+                      onClick={() => {
+                        if (args.comment && confirm('Weet u het zeker?'))
+                          args.comment.delete(args.comment.id);
+                      }}
+                    >
+                      Verwijderen
+                    </Button>
+                  </ButtonGroup>
+              </div>
+            )}
+          </div>
         ) : null}
       </section>
 

--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -482,18 +482,27 @@ function DocumentMap({
     color: string;
   }
 
+  const [overRidePage, setOverRidePage] = useState<number | null>(null);
+
   const scrollToComment = (index: number) => {
     let attempts = 0;
     const maxAttempts = 10;
     const interval = 100;
 
     const tryScrollToComment = () => {
-      const filteredComments = Array.from(document.getElementsByClassName('comment-item'));
-      filteredComments.forEach((comment, i) => {
+      const getAllComments = Array.from(document.getElementsByClassName('comment-item'));
+      getAllComments.forEach((comment, i) => {
         if (i !== index) {
           comment.classList.remove('selected');
         }
       });
+
+      if (displayPagination) {
+        const currentComment = filteredComments?.findIndex((comment: any) => parseInt(comment.id) === index);
+        const commentPage = Math.floor(currentComment / itemsPerPage);
+
+        setOverRidePage(commentPage);
+      }
 
       const commentElement = document.getElementById(`comment-${index}`);
       if (commentElement) {
@@ -711,6 +720,7 @@ function DocumentMap({
     const configVotingEnabled = props?.votes?.isActive || false;
     const votingEnabled = configVotingEnabled && args.canComment;
 
+    // const [goToPage, setGoToPage] = useState<((page:number) => void) | null>(null);
     const [goToLastPage, setGoToLastPage] = useState<(() => void) | null>(null);
 
     return !bounds ? null : (
@@ -1007,6 +1017,8 @@ function DocumentMap({
                 itemsPerPage={itemsPerPage}
                 displayPagination={displayPagination}
                 onGoToLastPage={setGoToLastPage}
+                // onGoToPage={setGoToPage}
+                overRidePage={overRidePage}
               />
             </div>
           )}

--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -87,6 +87,8 @@ export type DocumentMapProps = BaseProps &
     itemsPerPage?: number;
     displayPagination?: boolean;
     onlyAllowClickOnImage?: boolean;
+    popupNotLoggedInText?: string;
+    popupNotLoggedInButton?: string;
   };
 
 
@@ -124,6 +126,8 @@ function DocumentMap({
   itemsPerPage = 9999,
   displayPagination = false,
   onlyAllowClickOnImage = false,
+  popupNotLoggedInText = 'Om een reactie te plaatsen, moet je ingelogd zijn.',
+  popupNotLoggedInButton = 'Inloggen',
   ...props
 }: DocumentMapProps) {
 
@@ -782,18 +786,6 @@ function DocumentMap({
                 url={resource.images ? resource.images[0].url : ''}
                 bounds={bounds as LatLngBoundsLiteral}
                 aria-describedby={randomId}
-                eventHandlers={{
-                  click: (e) => {
-                    const bounds = e.target.getBounds();
-                    const clickedLatLng = e.latlng;
-
-                    if (bounds.contains(clickedLatLng)) {
-                      console.log("Klik op de afbeelding");
-                    } else {
-                      console.log("Klik buiten de afbeelding");
-                    }
-                  }
-                }}
               />
               {(popupPosition && !isDefinitive && args.canComment) && (
                 <Popup
@@ -804,7 +796,7 @@ function DocumentMap({
                 >
                   { !hasRole(currentUser, args.requiredUserRole) ? (
                     <>
-                      <Paragraph>Om een reactie te plaatsen, moet je ingelogd zijn.</Paragraph>
+                      <Paragraph>{popupNotLoggedInText}</Paragraph>
                       <Spacer size={1} />
                       <Button
                         appearance="primary-action-button"
@@ -814,7 +806,7 @@ function DocumentMap({
                           }
                         }}
                         type="button">
-                        Inloggen
+                        {popupNotLoggedInButton}
                       </Button>
                     </>
                   ) :

--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -482,7 +482,7 @@ function DocumentMap({
     color: string;
   }
 
-  const [overRidePage, setOverRidePage] = useState<number | null>(null);
+  const [overRidePage, setOverRidePage] = useState<number | undefined>(undefined);
 
   const scrollToComment = (index: number) => {
     let attempts = 0;
@@ -1017,7 +1017,6 @@ function DocumentMap({
                 itemsPerPage={itemsPerPage}
                 displayPagination={displayPagination}
                 onGoToLastPage={setGoToLastPage}
-                // onGoToPage={setGoToPage}
                 overRidePage={overRidePage}
               />
             </div>

--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -482,7 +482,7 @@ function DocumentMap({
     color: string;
   }
 
-  const [overRidePage, setOverRidePage] = useState<number | undefined>(undefined);
+  const [overridePage, setoverridePage] = useState<number | undefined>(undefined);
 
   const scrollToComment = (index: number) => {
     let attempts = 0;
@@ -501,7 +501,7 @@ function DocumentMap({
         const currentComment = filteredComments?.findIndex((comment: any) => parseInt(comment.id) === index);
         const commentPage = Math.floor(currentComment / itemsPerPage);
 
-        setOverRidePage(commentPage);
+        setoverridePage(commentPage);
       }
 
       const commentElement = document.getElementById(`comment-${index}`);
@@ -1017,7 +1017,7 @@ function DocumentMap({
                 itemsPerPage={itemsPerPage}
                 displayPagination={displayPagination}
                 onGoToLastPage={setGoToLastPage}
-                overRidePage={overRidePage}
+                overridePage={overridePage}
               />
             </div>
           )}

--- a/packages/resource-overview/src/resource-overview.tsx
+++ b/packages/resource-overview/src/resource-overview.tsx
@@ -565,6 +565,16 @@ function ResourceOverview({
     return ` --${variant}`;
   }
 
+  const randomId = Math.random().toString(36).replace('0.', 'container_');
+
+  const scrollToTop = () => {
+    const divElement = document.getElementById(randomId);
+
+    if (divElement) {
+      divElement.scrollIntoView({ block: "start", behavior: "auto" });
+    }
+  }
+
   return (
     <>
       <Dialog
@@ -655,7 +665,7 @@ function ResourceOverview({
             />
           ) : null}
 
-          <section className="osc-resource-overview-resource-collection">
+          <section className="osc-resource-overview-resource-collection" id={randomId}>
             {filteredResources &&
               filteredResources
                 ?.slice(page * pageSize, (page + 1) * pageSize)
@@ -678,7 +688,10 @@ function ResourceOverview({
               <Paginator
                 page={page || 0}
                 totalPages={totalPages || 1}
-                onPageChange={(newPage) => setPage(newPage)}
+                onPageChange={(newPage) => {
+                  setPage(newPage);
+                  scrollToTop();
+                }}
               />
             </div>
           </>

--- a/packages/stem-begroot/src/stem-begroot.tsx
+++ b/packages/stem-begroot/src/stem-begroot.tsx
@@ -467,6 +467,14 @@ function StemBegroot({
     }
   };
 
+  const scrollToTop = () => {
+    const divElement = document.getElementById("stem-begroot-resource-selections-list");
+
+    if (divElement) {
+      divElement.scrollIntoView({ block: "start", behavior: "auto" });
+    }
+  }
+
   return (
     <>
       <StemBegrootResourceDetailDialog
@@ -971,7 +979,10 @@ function StemBegroot({
                 <Paginator
                   page={resources?.metadata?.page || 0}
                   totalPages={resources?.metadata?.pageCount || 1}
-                  onPageChange={(page) => setPage(page)}
+                  onPageChange={(page) => {
+                    setPage(page);
+                    scrollToTop();
+                  }}
                 />
               </div>
             )}


### PR DESCRIPTION
Verschillende fixes, zoals:

- Keuzewijzer export zat een bug in waardoor waardes op nieuwe regels kwamen, wat alles in de war schopte.
- Optie om de pop-up content aan te passen bij de interactieve afbeelding wanneer je nog niet bent ingelogd.
- Bij de interactieve afbeelding een optie toegevoegd waarmee je er nu voor kan kiezen dat gebruikers niet buiten de afbeelding kunnen klikken om een marker te plaatsen.
- Pagination had geen scroll of iets als je naar een pagina navigeerde. Dat zit er nu wel in.
- Door de nieuwe pagination werd je niet naar een reactie genavigeerd als je bij de interactieve afbeelding klikte op een marker. Dat is nu opgelost.