### PR TITLE
feat: Only allow scrolling and zooming in map with 2 fingers on mobile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -279,6 +279,8 @@ services:
       - API_KEY=${API_FIXED_AUTH_KEY}
       - FORCE_HTTP=${FORCE_HTTP}
       - APOS_RELEASE_ID=${APOS_RELEASE_ID}
+      - REACT_CDN=${REACT_CDN}
+      - REACT_DOM_CDN=${REACT_DOM_CDN}
     ports:
       - '${CMS_PORT}:${CMS_PORT}'
     volumes:

--- a/packages/document-map/src/document-map.css
+++ b/packages/document-map/src/document-map.css
@@ -433,3 +433,34 @@ section.comment-item-footer .utrecht-button--disabled:before,
   line-height: 13px;
   font-weight: 500;
 }
+
+.documentMap--container .touch-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  color: white;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 1.5em;
+  font-weight: bold;
+  z-index: 1000;
+  pointer-events: none;
+  visibility: hidden;
+  flex-direction: column;
+  padding: 30px;
+  text-align: center;
+}
+
+.documentMap--container .touch-overlay.show {
+  visibility: visible;
+}
+
+.documentMap--container .touch-overlay i {
+  margin-bottom: 10px;
+  font-weight: 200;
+  font-size: 36px;
+}


### PR DESCRIPTION
Deze PR zorgt ervoor dat je op mobiel bij de interactieve afbeelding alleen de kaart kan verplaatsen of zoomen met 2 vingers. Hierdoor kun je met 1 vinger gewoon voorbij het element scrollen