### PR TITLE
fix: Use POST for showing the preview to prevent HTTP2 error

### DIFF
--- a/apps/admin-server/src/components/widget-preview.tsx
+++ b/apps/admin-server/src/components/widget-preview.tsx
@@ -37,14 +37,15 @@ export default function WidgetPreview({ type, config, projectId }: Props) {
 
     if (previewContainer && projectId && config) {
       fetch(`/api/openstad/widget/preview?projectId=${projectId}`, {
+        method: 'POST',
         headers: {
           'cache-control': 'no-cache',
-          'Content-Type': 'application/json',
-          'Widget-Config': JSON.stringify({
-            widgetType: type,
-            ...config,
-          }),
+          'Content-Type': 'application/json'
         },
+        body: JSON.stringify({
+          widgetType: type,
+          ...config,
+        }),
       })
         .then((v) => {
           if (v.ok) {

--- a/apps/api-server/src/routes/widget/widget.js
+++ b/apps/api-server/src/routes/widget/widget.js
@@ -23,16 +23,13 @@ router.use(bruteForce.globalMiddleware);
 // All keys except for `widgetType` will be passed to the widget as config
 router
   .route('/preview')
+  .post(async (req, res, next) => {
+    req.widgetConfig = req.body;
+    return next();
+  })
   .all((req, res, next) => {
-    const config = req.header('Widget-Config');
-    if (!config) {
+    if (!req.widgetConfig) {
       return next(createError(401, 'No widget config provided'));
-    }
-
-    try {
-      req.widgetConfig = JSON.parse(config);
-    } catch (e) {
-      return next(createError(401, 'Invalid widget config provided'));
     }
 
     if (!req.widgetConfig.widgetType) {
@@ -41,7 +38,7 @@ router
 
     return next();
   })
-  .get(async (req, res, next) => {
+  .post(async (req, res, next) => {
     const projectId = req.query.projectId;
     const widgetId = Math.floor(Math.random() * 1000000);
     const randomId = Math.floor(Math.random() * 1000000);


### PR DESCRIPTION
In sommige gevallen werkte de preview niet doordat de config d.m.v. een header werd doorgestuurd om vervolgens de preview te initialiseren. Als dat te lang is krijg je de error
`Failed to load resource: net::ERR_HTTP2_PROTOCOL_ERROR`
Hierdoor werd de preview niet getoond van een widget.

Dit is nu opgelost door het een POST request te maken en de config in de body mee te geven.