### PR TITLE
Fix/document drag popup delay

### DIFF
--- a/packages/document-map/src/document-map.css
+++ b/packages/document-map/src/document-map.css
@@ -453,6 +453,10 @@ section.comment-item-footer .utrecht-button--disabled:before,
   flex-direction: column;
   padding: 30px;
   text-align: center;
+
+  @media only screen and (max-width: 479px) {
+    font-size: 1.15em;
+  }
 }
 
 .documentMap--container .touch-overlay.show {

--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -821,7 +821,7 @@ function DocumentMap({
 
             {isTouchDevice && showOverlay && (
               <div className="touch-overlay show">
-                <i className="ri-hand">&#xEF89;</i>
+                <i className="ri-">&#xEF89;</i>
                 Use two fingers to navigate <br />
                 and zoom in or out
               </div>

--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -484,6 +484,14 @@ function DocumentMap({
 
   const [overridePage, setoverridePage] = useState<number | undefined>(undefined);
 
+  const isScrollable = function (ele: HTMLElement) {
+    const hasScrollableContent = ele.scrollHeight > ele.clientHeight;
+    const overflowYStyle = window.getComputedStyle(ele).overflowY;
+    const isOverflowHidden = overflowYStyle.indexOf('hidden') !== -1;
+
+    return hasScrollableContent && !isOverflowHidden;
+  };
+
   const scrollToComment = (index: number) => {
     let attempts = 0;
     const maxAttempts = 10;
@@ -516,14 +524,16 @@ function DocumentMap({
           const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
           const commentTop = commentRect.top + scrollTop;
 
-          if (window.innerWidth <= 1000) {
-            window.scrollTo({
-              top: commentTop,
+          const canScrollCommentContainer = isScrollable(containerEl);
+
+          if (canScrollCommentContainer) {
+            containerEl.scrollTo({
+              top: commentEl.offsetTop - containerEl.offsetTop,
               behavior: 'smooth'
             });
           } else {
-            containerEl.scrollTo({
-              top: commentEl.offsetTop - containerEl.offsetTop,
+            window.scrollTo({
+              top: commentTop,
               behavior: 'smooth'
             });
           }
@@ -746,7 +756,7 @@ function DocumentMap({
 
         const dragDifference = Math.abs(lastTouchPositionY - startTouchPositionY);
 
-        if (e.touches.length === 1 && dragDifference > 10 && !showOverlay) {
+        if (e.touches.length === 1 && dragDifference > 20 && !showOverlay) {
           setShowOverlay(true);
         } else if (!!showOverlay) {
           setShowOverlay(false);

--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -733,20 +733,24 @@ function DocumentMap({
     }, []);
 
     let lastTouchPositionY = 0;
+    let startTouchPositionY = 0;
 
     const handleTouchStart = (e: TouchEvent) => {
       lastTouchPositionY = e.touches[0].clientY;
-
-      if (e.touches.length === 1) {
-        setShowOverlay(true);
-      } else {
-        setShowOverlay(false);
-      }
+      startTouchPositionY = e.touches[0].clientY;
     };
 
     const handleTouchMove = (e: TouchEvent) => {
       if (e.touches.length === 1) {
         e.stopPropagation();
+
+        const dragDifference = Math.abs(lastTouchPositionY - startTouchPositionY);
+
+        if (e.touches.length === 1 && dragDifference > 10 && !showOverlay) {
+          setShowOverlay(true);
+        } else if (!!showOverlay) {
+          setShowOverlay(false);
+        }
 
         const deltaY = e.touches[0].clientY - lastTouchPositionY;
         window.scrollBy(0, -deltaY);


### PR DESCRIPTION
Verschillende fixes zitten in deze PR

- Als je op mobiel wil scrollen via de kaart zit er een delay op de pop-up nu
- Het lettertype van de pop-up is kleiner gemaakt op mobiel
- Er zat een check op site breedte die bepaalde of de container van de reacties op de interactieve afbeelding zou scrollen of de pagina zelf. Nu zit er een check op of de container scrollbaar is, zodat het onafhankelijk van de weergave is als die is aangepast door styling