### PR TITLE
Feat/restrict admin access

### DIFF
--- a/apps/api-server/src/adapter/openstad/router.js
+++ b/apps/api-server/src/adapter/openstad/router.js
@@ -271,6 +271,24 @@ router
       .catch(next)
   })
   .get(function (req, res, next) {
+    if (!req?.userData?.projectId || (req?.userData?.projectId && req?.userData?.projectId !== 1)) return next();
+
+    const privilegedRoles = [
+      'admin',
+      'moderator',
+      'editor'
+    ];
+
+    const userRole = req?.userData?.role || "";
+    const isPrivileged = privilegedRoles.includes(userRole);
+
+    if (!isPrivileged) {
+        return next(createError(403, 'Je hebt geen toegang tot deze omgeving'));
+    }
+
+    return next();
+  })
+  .get(function (req, res, next) {
     if (!req.redirectUrl.match('[[jwt]]')) return next();
     jwt.sign({userId: req.userData.id, authProvider: req.authConfig.provider}, req.authConfig.jwtSecret, {expiresIn: 182 * 24 * 60 * 60}, (err, token) => {
       if (err) return next(err)

--- a/apps/api-server/src/adapter/openstad/router.js
+++ b/apps/api-server/src/adapter/openstad/router.js
@@ -164,8 +164,6 @@ router
     let code = req.query.code;
     if (!code) throw createError(403, 'Je bent niet ingelogd');
 
-    console.log( "Req first", req );
-
     let url = `${req.authConfig.serverUrlInternal}/oauth/token`;
     let data = {
       client_id: req.authConfig.clientId,
@@ -311,7 +309,7 @@ router
     });
   })
   .get(function (req, res, next) {
-    res.redirect();
+    res.redirect(req.redirectUrl);
   });
 
 // ----------------------------------------------------------------------------------------------------

--- a/apps/api-server/src/adapter/openstad/router.js
+++ b/apps/api-server/src/adapter/openstad/router.js
@@ -164,6 +164,8 @@ router
     let code = req.query.code;
     if (!code) throw createError(403, 'Je bent niet ingelogd');
 
+    console.log( "Req first", req );
+
     let url = `${req.authConfig.serverUrlInternal}/oauth/token`;
     let data = {
       client_id: req.authConfig.clientId,
@@ -283,7 +285,19 @@ router
     const isPrivileged = privilegedRoles.includes(userRole);
 
     if (!isPrivileged) {
-        return next(createError(403, 'Je hebt geen toegang tot deze omgeving'));
+        let logoutUrl = '/signout';
+
+        try {
+            if (req.redirectUrl) {
+                const url = new URL(req.redirectUrl);
+                logoutUrl = `${url.origin}/signout`;
+            }
+        } catch (e) {}
+
+        return res.status(403).json({
+            error: 'Je hebt geen toegang tot deze omgeving',
+            logoutLink: logoutUrl
+        });
     }
 
     return next();
@@ -297,7 +311,7 @@ router
     });
   })
   .get(function (req, res, next) {
-    res.redirect(req.redirectUrl);
+    res.redirect();
   });
 
 // ----------------------------------------------------------------------------------------------------

--- a/apps/auth-server/controllers/auth/url.js
+++ b/apps/auth-server/controllers/auth/url.js
@@ -77,14 +77,19 @@ exports.register = (req, res, next) => {
 }
 
 const handleSending = async (req, res, next) => {
-    let isPriviligedRoute = req.params.priviligedRoute === 'admin';
+    let isPrivilegedRoute = req.params.priviligedRoute === 'admin';
 
-    if ( !isPriviligedRoute ) {
-        isPriviligedRoute = req?.query?.priviligedRoute === 'admin' || false;
+    if ( !isPrivilegedRoute ) {
+        isPrivilegedRoute = req?.query?.priviligedRoute === 'admin' || false;
+    }
+
+    // Mark route as privileged if the client ID is 1 (Admin panel)
+    if ( req?.client?.id && req?.client?.id === 1) {
+        isPrivilegedRoute = true;
     }
 
     try {
-        if (isPriviligedRoute) {
+        if (isPrivilegedRoute) {
             req.user = await authService.validatePrivilegeUser(req.body.email, req.client.id);
         }
 

--- a/apps/auth-server/controllers/auth/url.js
+++ b/apps/auth-server/controllers/auth/url.js
@@ -104,7 +104,7 @@ const handleSending = async (req, res, next) => {
 
         let redirectUrl = '/auth/url/login?clientId=' + req.client.clientId + '&redirect_uri=' + req.redirectUrl;
 
-        if (isPriviligedRoute) {
+        if (isPrivilegedRoute) {
             redirectUrl += '&priviligedRoute=admin';
         }
 

--- a/apps/auth-server/repositories/userRepository.js
+++ b/apps/auth-server/repositories/userRepository.js
@@ -7,7 +7,7 @@ exports.getUserByClientAndRoles = function(email, clientId, roles) {
     .then( user => {
       return user
         .getRoleForClient(clientId)
-        .then( userrole => roles.find(role => role.name == userrole.name) ? user : undefined );
+        .then( userrole => roles.find(role => role == userrole) ? user : undefined );
     })
 
 }


### PR DESCRIPTION
Deze PR voorkomt dat gebruikers zonder de juiste rol kunnen inloggen op de adminomgeving. Bij inloggen via e-mail wordt een foutmelding weergegeven als het verzenden van de loginmail mislukt. Bij andere inlogmethoden krijgen gebruikers zonder adminrechten een foutmelding te zien.