### PR TITLE
chore(next): bump to 14.2.28

### DIFF
--- a/apps/admin-server/package-lock.json
+++ b/apps/admin-server/package-lock.json
@@ -102,6 +102,7 @@
       }
     },
     "../../packages/account": {
+      "name": "@openstad-headless/account",
       "version": "0.0.0",
       "dependencies": {
         "@openstad-headless/data-store": "file:../data-store",
@@ -131,6 +132,7 @@
       }
     },
     "../../packages/activity": {
+      "name": "@openstad-headless/activity",
       "version": "0.0.0",
       "dependencies": {
         "@openstad-headless/data-store": "file:../data-store",
@@ -160,6 +162,7 @@
       }
     },
     "../../packages/agenda": {
+      "name": "@openstad-headless/agenda",
       "version": "0.0.0",
       "dependencies": {
         "@openstad-headless/data-store": "file:../data-store",
@@ -188,6 +191,7 @@
       }
     },
     "../../packages/choiceguide": {
+      "name": "@openstad-headless/choiceguide",
       "version": "0.0.0",
       "dependencies": {
         "@openstad-headless/data-store": "file:../data-store",
@@ -221,6 +225,7 @@
       }
     },
     "../../packages/choiceguide-results": {
+      "name": "@openstad-headless/choiceguide-results",
       "version": "0.0.0",
       "dependencies": {
         "@openstad-headless/data-store": "file:../data-store",
@@ -254,6 +259,7 @@
       }
     },
     "../../packages/comments": {
+      "name": "@openstad-headless/comments",
       "version": "0.1.0",
       "dependencies": {
         "@openstad-headless/data-store": "file:../data-store",
@@ -284,6 +290,7 @@
       }
     },
     "../../packages/counter": {
+      "name": "@openstad-headless/counter",
       "version": "0.0.0",
       "dependencies": {
         "@openstad-headless/data-store": "file:../data-store",
@@ -314,6 +321,7 @@
       }
     },
     "../../packages/date-countdown-bar": {
+      "name": "@openstad-headless/date-countdown-bar",
       "version": "0.0.0",
       "dependencies": {
         "@openstad-headless/data-store": "file:../data-store",
@@ -345,6 +353,7 @@
       }
     },
     "../../packages/distribution-module": {
+      "name": "@openstad-headless/distribution-module",
       "version": "0.0.0",
       "dependencies": {
         "@openstad-headless/data-store": "file:../data-store",
@@ -371,6 +380,7 @@
       }
     },
     "../../packages/document-map": {
+      "name": "@openstad-headless/document-map",
       "version": "0.0.0",
       "dependencies": {
         "@openstad-headless/comments": "file:../comments",
@@ -402,6 +412,7 @@
       }
     },
     "../../packages/enquete": {
+      "name": "@openstad-headless/enquete",
       "version": "0.0.0",
       "dependencies": {
         "@openstad-headless/data-store": "file:../data-store",
@@ -428,6 +439,7 @@
       }
     },
     "../../packages/form": {
+      "name": "@openstad-headless/form",
       "version": "0.0.0",
       "dependencies": {
         "@openstad-headless/data-store": "file:../data-store",
@@ -461,6 +473,7 @@
       }
     },
     "../../packages/leaflet-map": {
+      "name": "@openstad-headless/leaflet-map",
       "version": "0.0.0",
       "dependencies": {
         "@openstad-headless/data-store": "file:../data-store",
@@ -497,6 +510,7 @@
       }
     },
     "../../packages/likes": {
+      "name": "@openstad-headless/likes",
       "version": "0.0.0",
       "dependencies": {
         "@openstad-headless/data-store": "file:../data-store",
@@ -528,6 +542,7 @@
       }
     },
     "../../packages/multi-project-resource-overview": {
+      "name": "@openstad-headless/multi-project-resource-overview",
       "version": "0.0.0",
       "dependencies": {
         "@openstad-headless/data-store": "file:../data-store",
@@ -561,6 +576,7 @@
       }
     },
     "../../packages/raw-resource": {
+      "name": "@openstad-headless/raw-resource",
       "version": "0.0.0",
       "dependencies": {
         "@openstad-headless/data-store": "file:../data-store",
@@ -587,6 +603,7 @@
       }
     },
     "../../packages/resource-detail": {
+      "name": "@openstad-headless/resource-detail",
       "version": "0.0.0",
       "dependencies": {
         "@openstad-headless/comments": "file:../comments",
@@ -616,6 +633,7 @@
       }
     },
     "../../packages/resource-detail-with-map": {
+      "name": "@openstad-headless/resource-detail-with-map",
       "version": "0.0.0",
       "dependencies": {
         "@openstad-headless/comments": "file:../comments",
@@ -645,6 +663,7 @@
       }
     },
     "../../packages/resource-form": {
+      "name": "@openstad-headless/resource-form",
       "version": "0.0.0",
       "dependencies": {
         "@openstad-headless/data-store": "file:../data-store",
@@ -678,6 +697,7 @@
       }
     },
     "../../packages/resource-overview": {
+      "name": "@openstad-headless/resource-overview",
       "version": "0.0.0",
       "dependencies": {
         "@openstad-headless/data-store": "file:../data-store",
@@ -711,6 +731,7 @@
       }
     },
     "../../packages/resource-overview-with-map": {
+      "name": "@openstad-headless/resource-overview-with-map",
       "version": "0.0.0",
       "dependencies": {
         "@openstad-headless/data-store": "file:../data-store",
@@ -739,6 +760,7 @@
       }
     },
     "../../packages/simple-voting": {
+      "name": "@openstad-headless/simple-voting",
       "version": "0.0.0",
       "dependencies": {
         "@openstad-headless/data-store": "file:../data-store",
@@ -768,6 +790,7 @@
       }
     },
     "../../packages/stem-begroot": {
+      "name": "@openstad-headless/stem-begroot",
       "version": "0.0.0",
       "dependencies": {
         "@openstad-headless/data-store": "file:../data-store",
@@ -799,6 +822,7 @@
       }
     },
     "../../packages/types": {
+      "name": "@openstad-headless/types",
       "version": "1.0.0",
       "license": "ISC",
       "peerDependencies": {
@@ -1644,9 +1668,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.26.tgz",
-      "integrity": "sha512-vO//GJ/YBco+H7xdQhzJxF7ub3SUwft76jwaeOyVVQFHCi5DCnkP16WHB+JBylo4vOKPoZBlR94Z8xBxNBdNJA=="
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.28.tgz",
+      "integrity": "sha512-PAmWhJfJQlP+kxZwCjrVd9QnR5x0R3u0mTXTiZDgSd4h5LdXmjxCCWbN9kq6hkZBOax8Rm3xDW5HagWyJuT37g=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "14.2.26",
@@ -1657,9 +1681,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.26.tgz",
-      "integrity": "sha512-zDJY8gsKEseGAxG+C2hTMT0w9Nk9N1Sk1qV7vXYz9MEiyRoF5ogQX2+vplyUMIfygnjn9/A04I6yrUTRTuRiyQ==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.28.tgz",
+      "integrity": "sha512-kzGChl9setxYWpk3H6fTZXXPFFjg7urptLq5o5ZgYezCrqlemKttwMT5iFyx/p1e/JeglTwDFRtb923gTJ3R1w==",
       "cpu": [
         "arm64"
       ],
@@ -1672,9 +1696,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.26.tgz",
-      "integrity": "sha512-U0adH5ryLfmTDkahLwG9sUQG2L0a9rYux8crQeC92rPhi3jGQEY47nByQHrVrt3prZigadwj/2HZ1LUUimuSbg==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.28.tgz",
+      "integrity": "sha512-z6FXYHDJlFOzVEOiiJ/4NG8aLCeayZdcRSMjPDysW297Up6r22xw6Ea9AOwQqbNsth8JNgIK8EkWz2IDwaLQcw==",
       "cpu": [
         "x64"
       ],
@@ -1687,9 +1711,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.26.tgz",
-      "integrity": "sha512-SINMl1I7UhfHGM7SoRiw0AbwnLEMUnJ/3XXVmhyptzriHbWvPPbbm0OEVG24uUKhuS1t0nvN/DBvm5kz6ZIqpg==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.28.tgz",
+      "integrity": "sha512-9ARHLEQXhAilNJ7rgQX8xs9aH3yJSj888ssSjJLeldiZKR4D7N08MfMqljk77fAwZsWwsrp8ohHsMvurvv9liQ==",
       "cpu": [
         "arm64"
       ],
@@ -1702,9 +1726,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.26.tgz",
-      "integrity": "sha512-s6JaezoyJK2DxrwHWxLWtJKlqKqTdi/zaYigDXUJ/gmx/72CrzdVZfMvUc6VqnZ7YEvRijvYo+0o4Z9DencduA==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.28.tgz",
+      "integrity": "sha512-p6gvatI1nX41KCizEe6JkF0FS/cEEF0u23vKDpl+WhPe/fCTBeGkEBh7iW2cUM0rvquPVwPWdiUR6Ebr/kQWxQ==",
       "cpu": [
         "arm64"
       ],
@@ -1717,9 +1741,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.26.tgz",
-      "integrity": "sha512-FEXeUQi8/pLr/XI0hKbe0tgbLmHFRhgXOUiPScz2hk0hSmbGiU8aUqVslj/6C6KA38RzXnWoJXo4FMo6aBxjzg==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.28.tgz",
+      "integrity": "sha512-nsiSnz2wO6GwMAX2o0iucONlVL7dNgKUqt/mDTATGO2NY59EO/ZKnKEr80BJFhuA5UC1KZOMblJHWZoqIJddpA==",
       "cpu": [
         "x64"
       ],
@@ -1732,9 +1756,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.26.tgz",
-      "integrity": "sha512-BUsomaO4d2DuXhXhgQCVt2jjX4B4/Thts8nDoIruEJkhE5ifeQFtvW5c9JkdOtYvE5p2G0hcwQ0UbRaQmQwaVg==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.28.tgz",
+      "integrity": "sha512-+IuGQKoI3abrXFqx7GtlvNOpeExUH1mTIqCrh1LGFf8DnlUcTmOOCApEnPJUSLrSbzOdsF2ho2KhnQoO0I1RDw==",
       "cpu": [
         "x64"
       ],
@@ -1747,9 +1771,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.26.tgz",
-      "integrity": "sha512-5auwsMVzT7wbB2CZXQxDctpWbdEnEW/e66DyXO1DcgHxIyhP06awu+rHKshZE+lPLIGiwtjo7bsyeuubewwxMw==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.28.tgz",
+      "integrity": "sha512-l61WZ3nevt4BAnGksUVFKy2uJP5DPz2E0Ma/Oklvo3sGj9sw3q7vBWONFRgz+ICiHpW5mV+mBrkB3XEubMrKaA==",
       "cpu": [
         "arm64"
       ],
@@ -1762,9 +1786,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.26.tgz",
-      "integrity": "sha512-GQWg/Vbz9zUGi9X80lOeGsz1rMH/MtFO/XqigDznhhhTfDlDoynCM6982mPCbSlxJ/aveZcKtTlwfAjwhyxDpg==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.28.tgz",
+      "integrity": "sha512-+Kcp1T3jHZnJ9v9VTJ/yf1t/xmtFAc/Sge4v7mVc1z+NYfYzisi8kJ9AsY8itbgq+WgEwMtOpiLLJsUy2qnXZw==",
       "cpu": [
         "ia32"
       ],
@@ -1777,9 +1801,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.26.tgz",
-      "integrity": "sha512-2rdB3T1/Gp7bv1eQTTm9d1Y1sv9UuJ2LAwOE0Pe2prHKe32UNscj7YS13fRB37d0GAiGNR+Y7ZcW8YjDI8Ns0w==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.28.tgz",
+      "integrity": "sha512-1gCmpvyhz7DkB1srRItJTnmR2UwQPAUXXIg9r0/56g3O8etGmwlX68skKXJOp9EejW3hhv7nSQUJ2raFiz4MoA==",
       "cpu": [
         "x64"
       ],
@@ -8555,11 +8579,11 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
     },
     "node_modules/next": {
-      "version": "14.2.26",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.26.tgz",
-      "integrity": "sha512-b81XSLihMwCfwiUVRRja3LphLo4uBBMZEzBBWMaISbKTwOmq3wPknIETy/8000tr7Gq4WmbuFYPS7jOYIf+ZJw==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.28.tgz",
+      "integrity": "sha512-QLEIP/kYXynIxtcKB6vNjtWLVs3Y4Sb+EClTC/CSVzdLD1gIuItccpu/n1lhmduffI32iPGEK2cLLxxt28qgYA==",
       "dependencies": {
-        "@next/env": "14.2.26",
+        "@next/env": "14.2.28",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -8574,15 +8598,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.26",
-        "@next/swc-darwin-x64": "14.2.26",
-        "@next/swc-linux-arm64-gnu": "14.2.26",
-        "@next/swc-linux-arm64-musl": "14.2.26",
-        "@next/swc-linux-x64-gnu": "14.2.26",
-        "@next/swc-linux-x64-musl": "14.2.26",
-        "@next/swc-win32-arm64-msvc": "14.2.26",
-        "@next/swc-win32-ia32-msvc": "14.2.26",
-        "@next/swc-win32-x64-msvc": "14.2.26"
+        "@next/swc-darwin-arm64": "14.2.28",
+        "@next/swc-darwin-x64": "14.2.28",
+        "@next/swc-linux-arm64-gnu": "14.2.28",
+        "@next/swc-linux-arm64-musl": "14.2.28",
+        "@next/swc-linux-x64-gnu": "14.2.28",
+        "@next/swc-linux-x64-musl": "14.2.28",
+        "@next/swc-win32-arm64-msvc": "14.2.28",
+        "@next/swc-win32-ia32-msvc": "14.2.28",
+        "@next/swc-win32-x64-msvc": "14.2.28"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
         "lodash": "^4.17.21",
         "lucide-react": "^0.276.0",
         "mjml-browser": "^4.15.3",
-        "next": "^14.2.3",
+        "next": "^14.2.26",
         "nunjucks": "^3.2.4",
         "pino": "^8.15.1",
         "postcss": "^8.4.38",
@@ -475,7 +475,6 @@
         "@apostrophecms/blog": "^1.0.4",
         "@apostrophecms/import-export": "^3.0.0",
         "@apostrophecms/redirect": "^1.4.2",
-        "@apostrophecms/scheduled-publishing": "^1.0.5",
         "@apostrophecms/seo": "^1.3.0",
         "apostrophe": "^4.13.0",
         "dotenv": "^16.0.3",
@@ -649,11 +648,6 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@apostrophecms/redirect/-/redirect-1.4.2.tgz",
       "integrity": "sha512-BfAsgKGyyfLnZJb6wXfi36ifr4Mqg8Ubf9FjOq6ZMuNtPLdgxU3rg7qxw0w0NQIoLp5Z2gZRUylhk3jHYUGhLA=="
-    },
-    "node_modules/@apostrophecms/scheduled-publishing": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@apostrophecms/scheduled-publishing/-/scheduled-publishing-1.0.5.tgz",
-      "integrity": "sha512-QIoFCs1Rs6JWOXVbaOTSPM6N13xpENdpYQRwCVPyL1VmXuew36hbbsdRM2jZGI9qvOEgbhg/KIDZY210KjZYSA=="
     },
     "node_modules/@apostrophecms/seo": {
       "version": "1.3.0",
@@ -4164,9 +4158,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.14",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.14.tgz",
-      "integrity": "sha512-/0hWQfiaD5//LvGNgc8PjvyqV50vGK0cADYzaoOOGN8fxzBn3iAiaq3S0tCRnFBldq0LVveLcxCTi41ZoYgAgg=="
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.28.tgz",
+      "integrity": "sha512-PAmWhJfJQlP+kxZwCjrVd9QnR5x0R3u0mTXTiZDgSd4h5LdXmjxCCWbN9kq6hkZBOax8Rm3xDW5HagWyJuT37g=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "14.2.14",
@@ -4177,9 +4171,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.14.tgz",
-      "integrity": "sha512-bsxbSAUodM1cjYeA4o6y7sp9wslvwjSkWw57t8DtC8Zig8aG8V6r+Yc05/9mDzLKcybb6EN85k1rJDnMKBd9Gw==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.28.tgz",
+      "integrity": "sha512-kzGChl9setxYWpk3H6fTZXXPFFjg7urptLq5o5ZgYezCrqlemKttwMT5iFyx/p1e/JeglTwDFRtb923gTJ3R1w==",
       "cpu": [
         "arm64"
       ],
@@ -4192,9 +4186,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.14.tgz",
-      "integrity": "sha512-cC9/I+0+SK5L1k9J8CInahduTVWGMXhQoXFeNvF0uNs3Bt1Ub0Azb8JzTU9vNCr0hnaMqiWu/Z0S1hfKc3+dww==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.28.tgz",
+      "integrity": "sha512-z6FXYHDJlFOzVEOiiJ/4NG8aLCeayZdcRSMjPDysW297Up6r22xw6Ea9AOwQqbNsth8JNgIK8EkWz2IDwaLQcw==",
       "cpu": [
         "x64"
       ],
@@ -4207,9 +4201,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.14.tgz",
-      "integrity": "sha512-RMLOdA2NU4O7w1PQ3Z9ft3PxD6Htl4uB2TJpocm+4jcllHySPkFaUIFacQ3Jekcg6w+LBaFvjSPthZHiPmiAUg==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.28.tgz",
+      "integrity": "sha512-9ARHLEQXhAilNJ7rgQX8xs9aH3yJSj888ssSjJLeldiZKR4D7N08MfMqljk77fAwZsWwsrp8ohHsMvurvv9liQ==",
       "cpu": [
         "arm64"
       ],
@@ -4222,9 +4216,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.14.tgz",
-      "integrity": "sha512-WgLOA4hT9EIP7jhlkPnvz49iSOMdZgDJVvbpb8WWzJv5wBD07M2wdJXLkDYIpZmCFfo/wPqFsFR4JS4V9KkQ2A==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.28.tgz",
+      "integrity": "sha512-p6gvatI1nX41KCizEe6JkF0FS/cEEF0u23vKDpl+WhPe/fCTBeGkEBh7iW2cUM0rvquPVwPWdiUR6Ebr/kQWxQ==",
       "cpu": [
         "arm64"
       ],
@@ -4237,9 +4231,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.14.tgz",
-      "integrity": "sha512-lbn7svjUps1kmCettV/R9oAvEW+eUI0lo0LJNFOXoQM5NGNxloAyFRNByYeZKL3+1bF5YE0h0irIJfzXBq9Y6w==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.28.tgz",
+      "integrity": "sha512-nsiSnz2wO6GwMAX2o0iucONlVL7dNgKUqt/mDTATGO2NY59EO/ZKnKEr80BJFhuA5UC1KZOMblJHWZoqIJddpA==",
       "cpu": [
         "x64"
       ],
@@ -4252,9 +4246,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.14.tgz",
-      "integrity": "sha512-7TcQCvLQ/hKfQRgjxMN4TZ2BRB0P7HwrGAYL+p+m3u3XcKTraUFerVbV3jkNZNwDeQDa8zdxkKkw2els/S5onQ==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.28.tgz",
+      "integrity": "sha512-+IuGQKoI3abrXFqx7GtlvNOpeExUH1mTIqCrh1LGFf8DnlUcTmOOCApEnPJUSLrSbzOdsF2ho2KhnQoO0I1RDw==",
       "cpu": [
         "x64"
       ],
@@ -4267,9 +4261,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.14.tgz",
-      "integrity": "sha512-8i0Ou5XjTLEje0oj0JiI0Xo9L/93ghFtAUYZ24jARSeTMXLUx8yFIdhS55mTExq5Tj4/dC2fJuaT4e3ySvXU1A==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.28.tgz",
+      "integrity": "sha512-l61WZ3nevt4BAnGksUVFKy2uJP5DPz2E0Ma/Oklvo3sGj9sw3q7vBWONFRgz+ICiHpW5mV+mBrkB3XEubMrKaA==",
       "cpu": [
         "arm64"
       ],
@@ -4282,9 +4276,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.14.tgz",
-      "integrity": "sha512-2u2XcSaDEOj+96eXpyjHjtVPLhkAFw2nlaz83EPeuK4obF+HmtDJHqgR1dZB7Gb6V/d55FL26/lYVd0TwMgcOQ==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.28.tgz",
+      "integrity": "sha512-+Kcp1T3jHZnJ9v9VTJ/yf1t/xmtFAc/Sge4v7mVc1z+NYfYzisi8kJ9AsY8itbgq+WgEwMtOpiLLJsUy2qnXZw==",
       "cpu": [
         "ia32"
       ],
@@ -4297,9 +4291,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.14",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.14.tgz",
-      "integrity": "sha512-MZom+OvZ1NZxuRovKt1ApevjiUJTcU2PmdJKL66xUPaJeRywnbGGRWUlaAOwunD6dX+pm83vj979NTC8QXjGWg==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.28.tgz",
+      "integrity": "sha512-1gCmpvyhz7DkB1srRItJTnmR2UwQPAUXXIg9r0/56g3O8etGmwlX68skKXJOp9EejW3hhv7nSQUJ2raFiz4MoA==",
       "cpu": [
         "x64"
       ],
@@ -20661,11 +20655,11 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/next": {
-      "version": "14.2.14",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.14.tgz",
-      "integrity": "sha512-Q1coZG17MW0Ly5x76shJ4dkC23woLAhhnDnw+DfTc7EpZSGuWrlsZ3bZaO8t6u1Yu8FVfhkqJE+U8GC7E0GLPQ==",
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.28.tgz",
+      "integrity": "sha512-QLEIP/kYXynIxtcKB6vNjtWLVs3Y4Sb+EClTC/CSVzdLD1gIuItccpu/n1lhmduffI32iPGEK2cLLxxt28qgYA==",
       "dependencies": {
-        "@next/env": "14.2.14",
+        "@next/env": "14.2.28",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -20680,15 +20674,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.14",
-        "@next/swc-darwin-x64": "14.2.14",
-        "@next/swc-linux-arm64-gnu": "14.2.14",
-        "@next/swc-linux-arm64-musl": "14.2.14",
-        "@next/swc-linux-x64-gnu": "14.2.14",
-        "@next/swc-linux-x64-musl": "14.2.14",
-        "@next/swc-win32-arm64-msvc": "14.2.14",
-        "@next/swc-win32-ia32-msvc": "14.2.14",
-        "@next/swc-win32-x64-msvc": "14.2.14"
+        "@next/swc-darwin-arm64": "14.2.28",
+        "@next/swc-darwin-x64": "14.2.28",
+        "@next/swc-linux-arm64-gnu": "14.2.28",
+        "@next/swc-linux-arm64-musl": "14.2.28",
+        "@next/swc-linux-x64-gnu": "14.2.28",
+        "@next/swc-linux-x64-musl": "14.2.28",
+        "@next/swc-win32-arm64-msvc": "14.2.28",
+        "@next/swc-win32-ia32-msvc": "14.2.28",
+        "@next/swc-win32-x64-msvc": "14.2.28"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",


### PR DESCRIPTION
This bumps next to 14.2.28, in both apps/admin-server and the root package-lock.json.