### PR TITLE
Feat/pre filter resource overview

### DIFF
--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -156,7 +156,11 @@ function DocumentMap({
     type: ''
   });
 
-  const tagIdsArray = tagIds.split(',').map(id => parseInt(id.trim(), 10)).filter(id => !isNaN(id));
+  const stringToArray = (str: string) => {
+    return str.split(',').map(id => parseInt(id.trim(), 10)).filter(id => !isNaN(id))
+  }
+
+  const tagIdsArray = stringToArray(tagIds);
 
   function determineTags(includeOrExclude: string, allTags: any, tagIdsArray: Array<number>) {
     let filteredTagIdsArray: Array<number> = [];
@@ -191,8 +195,12 @@ function DocumentMap({
     tags: filteredTagIdsArray
   } = determineTags(includeOrExclude, allTags, tagIdsArray);
 
-  const [selectedTags, setSelectedTags] = useState<Array<number>>([]);
-  const [selectedTagsString, setSelectedTagsString] = useState<string>('');
+  const urlParams = new URLSearchParams(window.location.search);
+  const urlTagIds = urlParams.get('tagIds');
+  const urlTagIdsArray = urlTagIds ? stringToArray(urlTagIds) : [];
+
+  const [selectedTags, setSelectedTags] = useState<Array<number>>(urlTagIdsArray);
+  const [selectedTagsString, setSelectedTagsString] = useState<string>( urlTagIdsArray?.join(',') || '' );
 
   const useCommentsData = {
     projectId: props.projectId,
@@ -1103,6 +1111,7 @@ function DocumentMap({
               sorting={[]}
               tagGroups={tagGroups}
               tagsLimitation={filteredTagIdsArray}
+              preFilterTags={urlTagIdsArray}
             />
           ) : null}
 

--- a/packages/resource-overview/src/resource-overview.tsx
+++ b/packages/resource-overview/src/resource-overview.tsx
@@ -388,25 +388,34 @@ function ResourceOverview({
     api: props.api,
   });
 
-  // const recourceTagsInclude = only
-  const tagIdsToLimitResourcesTo = onlyIncludeTagIds
-    .trim()
-    .split(',')
-    .filter((t) => t && !isNaN(+t.trim()))
-    .map((t) => Number.parseInt(t));
+  const stringToArray = (str: string) => {
+    return str
+      .trim()
+      .split(',')
+      .filter((t) => t && !isNaN(+t.trim()))
+      .map((t) => Number.parseInt(t));
+  }
 
-  const statusIdsToLimitResourcesTo = onlyIncludeStatusIds
-    .trim()
-    .split(',')
-    .filter((t) => t && !isNaN(+t.trim()))
-    .map((t) => Number.parseInt(t));
+  // const recourceTagsInclude = only
+  const tagIdsToLimitResourcesTo = stringToArray(onlyIncludeTagIds);
+  const statusIdsToLimitResourcesTo = stringToArray(onlyIncludeStatusIds);
+
+  const urlParams = new URLSearchParams(window.location.search);
+  const urlTagIds = urlParams.get('tagIds');
+  const urlStatusIds = urlParams.get('statusIds');
+
+  const urlTagIdsArray = urlTagIds ? stringToArray(urlTagIds) : undefined;
+  const urlStatusIdsArray = urlStatusIds ? stringToArray(urlStatusIds) : undefined;
 
   const [open, setOpen] = React.useState(false);
 
+  const initTags = urlTagIdsArray && urlTagIdsArray.length > 0 ? urlTagIdsArray : tagIdsToLimitResourcesTo || [];
+  const initStatuses = urlStatusIdsArray && urlStatusIdsArray.length > 0 ? urlStatusIdsArray : statusIdsToLimitResourcesTo || [];
+
   // Filters that when changed reupdate the useResources value automatically
   const [search, setSearch] = useState<string>('');
-  const [statuses, setStatuses] = useState<number[]>(statusIdsToLimitResourcesTo || []);
-  const [tags, setTags] = useState<number[]>(tagIdsToLimitResourcesTo || []);
+  const [statuses, setStatuses] = useState<number[]>(initStatuses);
+  const [tags, setTags] = useState<number[]>(initTags);
   const [page, setPage] = useState<number>(0);
   const [totalPages, setTotalPages] = useState(0);
   const [pageSize, setPageSize] = useState<number>(itemsPerPage || 10);
@@ -666,6 +675,7 @@ function ResourceOverview({
                 setSearch(f.search.text);
               }}
               quickFixTags={quickFixTags || []}
+              preFilterTags={urlTagIdsArray}
             />
           ) : null}
 

--- a/packages/stem-begroot/src/stem-begroot.tsx
+++ b/packages/stem-begroot/src/stem-begroot.tsx
@@ -140,21 +140,30 @@ function StemBegroot({
 
   const [activeTagTab, setActiveTagTab] = useState<string>('');
 
-  const tagIdsToLimitResourcesTo = onlyIncludeTagIds
-    .trim()
-    .split(',')
-    .filter((t) => t && !isNaN(+t.trim()))
-    .map((t) => Number.parseInt(t));
+  const stringToArray = (str: string) => {
+    return str
+      .trim()
+      .split(',')
+      .filter((t) => t && !isNaN(+t.trim()))
+      .map((t) => Number.parseInt(t));
+  }
 
-  const statusIdsToLimitResourcesTo = onlyIncludeStatusIds
-    .trim()
-    .split(',')
-    .filter((t) => t && !isNaN(+t.trim()))
-    .map((t) => Number.parseInt(t));
+  const tagIdsToLimitResourcesTo = stringToArray(onlyIncludeTagIds);
+  const statusIdsToLimitResourcesTo = stringToArray(onlyIncludeStatusIds);
+
+  const urlParams = new URLSearchParams(window.location.search);
+  const urlTagIds = urlParams.get('tagIds');
+  const urlStatusIds = urlParams.get('statusIds');
+
+  const urlTagIdsArray = urlTagIds ? stringToArray(urlTagIds) : undefined;
+  const urlStatusIdsArray = urlStatusIds ? stringToArray(urlStatusIds) : undefined;
+
+  const initTags = urlTagIdsArray && urlTagIdsArray.length > 0 ? urlTagIdsArray : tagIdsToLimitResourcesTo || [];
+  const initStatuses = urlStatusIdsArray && urlStatusIdsArray.length > 0 ? urlStatusIdsArray : statusIdsToLimitResourcesTo || [];
 
   const [tagCounter, setTagCounter] = useState<Array<TagType>>([]);
 
-  const [tags, setTags] = useState<number[]>(tagIdsToLimitResourcesTo);
+  const [tags, setTags] = useState<number[]>(initTags);
   const [sort, setSort] = useState<string | undefined>(props.defaultSorting || undefined);
   const [search, setSearch] = useState<string | undefined>();
   const [page, setPage] = useState<number>(0);
@@ -533,7 +542,7 @@ function StemBegroot({
           }
         }}
         resourceDetailIndex={resourceDetailIndex}
-        statusIdsToLimitResourcesTo={statusIdsToLimitResourcesTo || []}
+        statusIdsToLimitResourcesTo={initStatuses}
         tagIdsToLimitResourcesTo={tags}
         sort={sort}
         allTags={allTags}
@@ -915,6 +924,7 @@ function StemBegroot({
                         setSort(f.sort);
                         setSearch(f.search.text);
                       }}
+                      preFilterTags={urlTagIdsArray}
                     />
                   ) : null}
 
@@ -968,7 +978,7 @@ function StemBegroot({
                   }
                 }
               }}
-              statusIdsToLimitResourcesTo={statusIdsToLimitResourcesTo || []}
+              statusIdsToLimitResourcesTo={initStatuses}
               tagIdsToLimitResourcesTo={tags}
               sort={sort}
               allTags={allTags}

--- a/packages/ui/src/stem-begroot-and-resource-overview/filter/index.tsx
+++ b/packages/ui/src/stem-begroot-and-resource-overview/filter/index.tsx
@@ -235,7 +235,7 @@ export function Filters({
                     placeholder={tagGroup.label}
                     onlyIncludeIds={tagsLimitation}
                     onUpdateFilter={(updatedTag, updatedLabel, forceSelected) => {
-                      updateTagListMultiple(tagGroup.type, updatedTag, updatedLabel, forceSelected || false);
+                      updateTagListMultiple(tagGroup.type, updatedTag, updatedLabel || '', forceSelected || false);
                     }}
                     tagGroupProjectId={tagGroup.projectId || ''}
                     quickFixTags={props.quickFixTags || []}

--- a/packages/ui/src/stem-begroot-and-resource-overview/filter/multiselect-tag-filter.tsx
+++ b/packages/ui/src/stem-begroot-and-resource-overview/filter/multiselect-tag-filter.tsx
@@ -83,7 +83,7 @@ const MultiSelectTagFilter = ({
     }
   }, [preFilterTags]);
 
-  const combinedSelects = stopUsingDefaultValue ? selected : [...new Set([...selected, ...prefilterTagsSelected])];
+  const combinedSelects = stopUsingDefaultValue ? selected : Array.from( new Set([...selected, ...prefilterTagsSelected]) );
 
   return (
     <div className="form-element">

--- a/packages/ui/src/stem-begroot-and-resource-overview/filter/multiselect-tag-filter.tsx
+++ b/packages/ui/src/stem-begroot-and-resource-overview/filter/multiselect-tag-filter.tsx
@@ -44,6 +44,7 @@ const MultiSelectTagFilter = ({
   });
 
   const [stopUsingDefaultValue, setStopUsingDefaultValue] = useState(false);
+  const [prefilterTagsSelected, setPrefilterTagsSelected] = useState<number[]>([]);
 
   useEffect(() => {
     if (parentStopUsingDefaultValue) {
@@ -64,19 +65,25 @@ const MultiSelectTagFilter = ({
   const filterTags = quickFixTags.length > 0 ? (quickFixTags.filter(tag => tag.projectId === parseInt(props.tagGroupProjectId))) : tags;
 
   useEffect(() => {
-    if (!stopUsingDefaultValue && preFilterTags && preFilterTags.length > 0 && onUpdateFilter) {
-      preFilterTags.forEach((tagId) => {
+    if ((!stopUsingDefaultValue && !parentStopUsingDefaultValue) && preFilterTags && preFilterTags.length > 0 && onUpdateFilter) {
+      preFilterTags.forEach(async (tagId) => {
         const tag = filterTags.find((tag: TagDefinition) => tag.id === tagId);
+
         if (tag) {
           onUpdateFilter(tag.id, tag.name, true);
 
-          if ( !selected.includes(tag.id) ) {
-            selected.push(tag.id);
-          }
+          setPrefilterTagsSelected(prevTags => {
+            if (!prevTags.includes(tag.id)) {
+              return [...prevTags, tag.id];
+            }
+            return prevTags;
+          });
         }
       });
     }
   }, [preFilterTags]);
+
+  const combinedSelects = stopUsingDefaultValue ? selected : [...new Set([...selected, ...prefilterTagsSelected])];
 
   return (
     <div className="form-element">
@@ -91,7 +98,7 @@ const MultiSelectTagFilter = ({
         options={(filterTags || []).map((tag: TagDefinition) => ({
           value: tag.id,
           label: tag.name,
-          checked: selected.includes(tag.id),
+          checked: combinedSelects.includes(tag.id),
         }))}
       />
     </div>

--- a/packages/ui/src/stem-begroot-and-resource-overview/filter/multiselect-tag-filter.tsx
+++ b/packages/ui/src/stem-begroot-and-resource-overview/filter/multiselect-tag-filter.tsx
@@ -66,7 +66,7 @@ const MultiSelectTagFilter = ({
 
   useEffect(() => {
     if ((!stopUsingDefaultValue && !parentStopUsingDefaultValue) && preFilterTags && preFilterTags.length > 0 && onUpdateFilter) {
-      preFilterTags.forEach(async (tagId) => {
+      preFilterTags.forEach((tagId) => {
         const tag = filterTags.find((tag: TagDefinition) => tag.id === tagId);
 
         if (tag) {


### PR DESCRIPTION
Deze PR voegt de mogelijkheid toe om een overzicht te filteren door middel van tag ids in de URL. Om dit te gebruiken zet je in de URL

`?tagIds=1,2,26`

Dit is van toepassing op het inzendingsoverzicht, interactieve afbeelding en begroot- of stemmodule. Bij het inzendingsoverzicht en de begroot- of stemmodule kun je ook het volgende gebruiken om dit effect te krijgen, maar dan met op basis van status:

`?statusIds=1,2,26`

Verder wordt de URL ook geüpdatet met de actieve filters, zodat de filters in de geschiedenis blijven zitten mocht je navigeren naar een andere pagina en vervolgens weer teruggaan.