### PR TITLE
Fix/require db ssl check

### DIFF
--- a/apps/api-server/src/db.js
+++ b/apps/api-server/src/db.js
@@ -32,7 +32,7 @@ if (dbConfig.mysqlCaCert?.trim?.()) {
 	ssl.ca = [ dbConfig.mysqlCaCert ];
 }
 
-if (dbConfig.requireSsl !== "false" && dbConfig.requireSsl !== false) {
+if (dbConfig.requireSsl === "true" || dbConfig.requireSsl === true) {
 	ssl.rejectUnauthorized = true;
 	ssl.require = true;
 }

--- a/apps/api-server/src/db.js
+++ b/apps/api-server/src/db.js
@@ -32,7 +32,7 @@ if (dbConfig.mysqlCaCert?.trim?.()) {
 	ssl.ca = [ dbConfig.mysqlCaCert ];
 }
 
-if (dbConfig.requireSsl !== "false") {
+if (dbConfig.requireSsl !== "false" && dbConfig.requireSsl !== false) {
 	ssl.rejectUnauthorized = true;
 	ssl.require = true;
 }

--- a/apps/auth-server/app-init.js
+++ b/apps/auth-server/app-init.js
@@ -51,7 +51,7 @@ const initializeApp = async () => {
       ssl.rejectUnauthorized = true
     }
     
-    if (process.env.DB_REQUIRE_SSL !== "false") {
+    if (process.env.DB_REQUIRE_SSL !== "false" && process.env.DB_REQUIRE_SSL !== false) {
       ssl.require = true
       ssl.rejectUnauthorized = true
     }

--- a/apps/auth-server/app-init.js
+++ b/apps/auth-server/app-init.js
@@ -51,7 +51,7 @@ const initializeApp = async () => {
       ssl.rejectUnauthorized = true
     }
     
-    if (process.env.DB_REQUIRE_SSL !== "false" && process.env.DB_REQUIRE_SSL !== false) {
+    if (process.env.DB_REQUIRE_SSL === "true" || process.env.DB_REQUIRE_SSL === true) {
       ssl.require = true
       ssl.rejectUnauthorized = true
     }

--- a/apps/auth-server/db.js
+++ b/apps/auth-server/db.js
@@ -12,7 +12,7 @@ if (process.env.MYSQL_CA_CERT) {
   ssl.rejectUnauthorized = true;
 }
 
-if (process.env.DB_REQUIRE_SSL !== "false" && process.env.DB_REQUIRE_SSL !== false) {
+if (process.env.DB_REQUIRE_SSL === "true" || process.env.DB_REQUIRE_SSL === true) {
   ssl.require = true;
   ssl.rejectUnauthorized = true;
 }

--- a/apps/auth-server/db.js
+++ b/apps/auth-server/db.js
@@ -12,7 +12,7 @@ if (process.env.MYSQL_CA_CERT) {
   ssl.rejectUnauthorized = true;
 }
 
-if (process.env.DB_REQUIRE_SSL !== "false") {
+if (process.env.DB_REQUIRE_SSL !== "false" && process.env.DB_REQUIRE_SSL !== false) {
   ssl.require = true;
   ssl.rejectUnauthorized = true;
 }


### PR DESCRIPTION
Deze PR lost een probleem op met de check voor het vereisen van SSL voor de database. De oude check `(!== 'false')` gaf false positives.