### PR TITLE
feat: Add image description fields

### DIFF
--- a/apps/admin-server/src/components/resource-form.tsx
+++ b/apps/admin-server/src/components/resource-form.tsx
@@ -70,8 +70,9 @@ const baseSchema = z.object({
 
     location: z.string().optional(),
     image: z.string().optional(),
+    imageDescription: z.string().optional(),
     images: z
-        .array(z.object({ url: z.string() }))
+        .array(z.object({ url: z.string(), description: z.string().optional() }))
         .optional()
         .default([]),
     document: z.string().optional(),
@@ -388,19 +389,37 @@ export default function ResourceForm({ onFormSubmit }: Props) {
             {imageFields.length > 0 && (
               <>
                 <label className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Afbeeldingen</label>
-                <section className="grid col-span-full grid-cols-3 gap-x-4 gap-y-8 ">
+                <section className="grid col-span-full grid-cols-1 gap-y-4">
                   {imageFields.map(({ id, url }, index) => {
                     return (
-                      <div key={id} className="relative">
+                      <div key={id} className="relative grid col-span-full grid-cols-3 gap-x-4 items-center">
                         <img src={url} alt={url} />
                         <Button
                           color="red"
                           onClick={() => {
                             removeImage(index);
                           }}
-                          className="absolute right-0 top-0">
+                          className="absolute left-0 top-0">
                           <X size={24} />
                         </Button>
+
+                        <FormField
+                          control={form.control}
+                          name={`images.${index}.description`}
+                          render={({ field }) => (
+                            <FormItem className="col-span-full sm:col-span-2 md:col-span-2 lg:col-span-2">
+                              <FormLabel>Beschrijving</FormLabel>
+                              <FormDescription>Op de detailpagina van de inzending is er een optie waarmee je deze beschrijving kunt tonen.</FormDescription>
+                              <FormControl>
+                                <Input
+                                  {...field}
+                                />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+
                       </div>
                     );
                   })}

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/display.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/display.tsx
@@ -19,6 +19,7 @@ import {useFieldDebounce} from "@/hooks/useFieldDebounce";
 
 const formSchema = z.object({
   displayImage: z.boolean(),
+  displayImageDescription: z.boolean(),
   displayTitle: z.boolean(),
   displayDescription: z.boolean(),
   displaySummary: z.boolean(),
@@ -53,6 +54,7 @@ export default function WidgetResourceDetailDisplay(
     resolver: zodResolver<any>(formSchema),
     defaultValues: {
       displayImage: undefinedToTrueOrProp(props?.displayImage),
+      displayImageDescription: undefinedToTrueOrProp(props?.displayImageDescription),
       displayTitle: undefinedToTrueOrProp(props?.displayTitle),
       displayDescription: undefinedToTrueOrProp(props?.displayDescription),
       displaySummary: undefinedToTrueOrProp(props?.displaySummary),
@@ -89,6 +91,17 @@ export default function WidgetResourceDetailDisplay(
             render={({ field }) => (
               <FormItem>
                 <FormLabel>Afbeelding weergeven</FormLabel>
+                {YesNoSelect(field, props)}
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="displayImageDescription"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Beschrijving van de afbeelding tonen</FormLabel>
                 {YesNoSelect(field, props)}
                 <FormMessage />
               </FormItem>

--- a/packages/resource-detail/src/resource-detail.css
+++ b/packages/resource-detail/src/resource-detail.css
@@ -155,6 +155,21 @@
   display: none;
 }
 
+.osc-resource-detail-content .osc-resource-detail-content-items .carousel-image-description {
+  position: absolute;
+  top: 5px;
+  left: 5px;
+  right: auto;
+  bottom: auto;
+  color: #000;
+  padding: 0.5rem;
+  font-size: 14px;
+  box-shadow: 0 2px 4px #00000026;
+  background-color: white;
+  line-height: 1.1;
+  max-width: calc(100% - 10px);
+}
+
 /* Text Colors */
 .color-FFFFFF { color: #FFFFFF; }
 .color-000000 { color: #000000; }

--- a/packages/resource-detail/src/resource-detail.tsx
+++ b/packages/resource-detail/src/resource-detail.tsx
@@ -32,6 +32,7 @@ import { hasRole } from '../../lib';
 type booleanProps = {
   [K in
   | 'displayImage'
+  | 'displayImageDescription'
   | 'displayTitle'
   | 'displayModBreak'
   | 'displaySummary'
@@ -88,6 +89,7 @@ type DocumentType = {
 
 function ResourceDetail({
   displayImage = true,
+  displayImageDescription = true,
   displayTitle = true,
   displayModBreak = true,
   displaySummary = true,
@@ -218,22 +220,35 @@ function ResourceDetail({
 
   const statusClasses = `${colorClass} ${backgroundColorClass}`.trim();
 
-  const renderImage = (src: string, clickableImage: boolean) => {
+  const renderImage = (src: string, clickableImage: boolean, imageDescription?: string) => {
     const imageElement = (
-      <Image
-        src={src}
-        imageFooter={
-          (displayStatusBar && resource.statuses && resource.statuses.length > 0) && (
-            <div>
-              <Paragraph className={`osc-resource-detail-content-item-status ${statusClasses}`}>
-                {resource.statuses
-                  ?.map((s: { name: string }) => s.name)
-                  ?.join(', ')}
-              </Paragraph>
-            </div>
-          )
-        }
-      />
+      <div
+        className="carousel-image-container"
+      >
+        <Image
+          src={src}
+          imageFooter={
+            (displayStatusBar && resource.statuses && resource.statuses.length > 0) && (
+              <div>
+                <Paragraph className={`osc-resource-detail-content-item-status ${statusClasses}`}>
+                  {resource.statuses
+                    ?.map((s: { name: string }) => s.name)
+                    ?.join(', ')}
+                </Paragraph>
+              </div>
+            )
+          }
+        />
+
+        {(displayImageDescription && imageDescription) && (
+          <p
+            className="carousel-image-description"
+          >
+            {imageDescription}
+          </p>
+        )}
+
+      </div>
     );
 
     return clickableImage ? (
@@ -288,7 +303,7 @@ function ResourceDetail({
                   items={resourceImages}
                   buttonText={{ next: 'Volgende afbeelding', previous: 'Vorige afbeelding' }}
                   itemRenderer={(i) => (
-                    renderImage(i.url, clickableImage)
+                    renderImage(i.url, clickableImage, i.description)
                   )}
                 />
               )}

--- a/packages/resource-detail/src/resource-detail.tsx
+++ b/packages/resource-detail/src/resource-detail.tsx
@@ -222,9 +222,7 @@ function ResourceDetail({
 
   const renderImage = (src: string, clickableImage: boolean, imageDescription?: string) => {
     const imageElement = (
-      <div
-        className="carousel-image-container"
-      >
+      <>
         <Image
           src={src}
           imageFooter={
@@ -247,8 +245,7 @@ function ResourceDetail({
             {imageDescription}
           </p>
         )}
-
-      </div>
+      </>
     );
 
     return clickableImage ? (


### PR DESCRIPTION
This PR adds support for displaying descriptions under images in the resource detail view.

- Image Descriptions: Added functionality to show descriptions for images when displayImageDescription is enabled.
- Added Field for Resource image descriptions: A new field has been added to allow users to provide descriptions for resource images.
- Enabled Description Display in the Detail Widget: Updated the detail widget to support and display resource image descriptions when enabled.