### PR TITLE
feat: Improve filtering issues with include / exclude

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourceoverview/[id]/include.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourceoverview/[id]/include.tsx
@@ -20,8 +20,12 @@ import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 import useStatuses from "@/hooks/use-statuses";
 import React from "react";
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from "@/components/ui/select";
+import { Spacer } from '@/components/ui/spacer';
 
 const formSchema = z.object({
+  includeOrExcludeTagIds: z.string().optional(),
+  includeOrExcludeStatusIds: z.string().optional(),
   onlyIncludeTagIds: z.string().optional(),
   onlyIncludeStatusIds: z.string().optional()
 });
@@ -51,6 +55,8 @@ export default function WidgetResourceOverviewInclude(
   const form = useForm<FormData>({
     resolver: zodResolver<any>(formSchema),
     defaultValues: {
+      includeOrExcludeTagIds: props?.includeOrExcludeTagIds || 'include',
+      includeOrExcludeStatusIds: props?.includeOrExcludeStatusIds || 'include',
       onlyIncludeTagIds: props?.onlyIncludeTagIds || '',
       onlyIncludeStatusIds: props?.onlyIncludeStatusIds || '',
     },
@@ -75,10 +81,49 @@ export default function WidgetResourceOverviewInclude(
             </div>
           )}
 
+          <FormField
+            control={form.control}
+            name="includeOrExcludeTagIds"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Toon inzendingen gekoppeld aan onderstaande tags
+                </FormLabel>
+                <FormDescription>
+                  Gebruik het selectievakje om te kiezen hoe de geselecteerde tags de weergave van inzendingen
+                  beïnvloeden:
+                  <br/>
+                  Maak je keuze op basis van hoe je de inzendingen wil filteren in relatie tot de geselecteerde tags.
+                  <br/>
+                  <br/>
+                </FormDescription>
+                <Select
+                  onValueChange={field.onChange}
+                  value={field.value || 'include'}
+                >
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Inclusief" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="include"><strong>Inclusief</strong>: Als je deze optie kiest, worden alleen de
+                      inzendingen getoond die gekoppeld zijn aan de
+                      geselecteerde tags.</SelectItem>
+                    <SelectItem value="exclude"><strong>Exclusief</strong>: Als je deze optie kiest, worden juist de
+                      inzendingen die gekoppeld zijn aan de
+                      geselecteerde tags niet getoond.</SelectItem>
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
           <CheckboxList
             form={form}
             fieldName="onlyIncludeTagIds"
-            fieldLabel="Geef enkel de resources met de volgende tags weer:"
+            fieldLabel=""
             label={(t) => t.name}
             keyForGrouping="type"
             keyPerItem={(t) => `${t.id}`}
@@ -101,10 +146,51 @@ export default function WidgetResourceOverviewInclude(
             }}
           />
 
+          <Spacer />
+
+          <FormField
+            control={form.control}
+            name="includeOrExcludeStatusIds"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Toon inzendingen gekoppeld aan onderstaande statussen
+                </FormLabel>
+                <FormDescription>
+                  Gebruik het selectievakje om te kiezen hoe de geselecteerde statussen de weergave van inzendingen
+                  beïnvloeden:
+                  <br/>
+                  Maak je keuze op basis van hoe je de inzendingen wil filteren in relatie tot de geselecteerde statussen.
+                  <br/>
+                  <br/>
+                </FormDescription>
+                <Select
+                  onValueChange={field.onChange}
+                  value={field.value || 'include'}
+                >
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Inclusief" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="include"><strong>Inclusief</strong>: Als je deze optie kiest, worden alleen de
+                      inzendingen getoond die gekoppeld zijn aan de
+                      geselecteerde statussen.</SelectItem>
+                    <SelectItem value="exclude"><strong>Exclusief</strong>: Als je deze optie kiest, worden juist de
+                      inzendingen die gekoppeld zijn aan de
+                      geselecteerde statussen niet getoond.</SelectItem>
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
           <CheckboxList
             form={form}
             fieldName="onlyIncludeStatusIds"
-            fieldLabel="Geef enkel de inzendingen met de volgende status weer:"
+            fieldLabel=""
             layout="vertical"
             label={(t) => t.name}
             keyPerItem={(t) => `${t.id}`}

--- a/packages/resource-overview/src/resource-overview.tsx
+++ b/packages/resource-overview/src/resource-overview.tsx
@@ -102,6 +102,8 @@ export type ResourceOverviewWidgetProps = BaseProps &
     }[];
     multiProjectResources?: any[];
     quickFixTags?: Array<{ id: number; name: string }>;
+    includeOrExcludeTagIds?: string;
+    includeOrExcludeStatusIds?: string;
   };
 
 //Temp: Header can only be made when the map works so for now a banner
@@ -381,6 +383,8 @@ function ResourceOverview({
   multiProjectResources = [],
   selectedProjects = [],
   quickFixTags = [],
+  includeOrExcludeTagIds = 'include',
+  includeOrExcludeStatusIds = 'include',
   ...props
 }: ResourceOverviewWidgetProps) {
   const datastore = new DataStore({
@@ -396,9 +400,51 @@ function ResourceOverview({
       .map((t) => Number.parseInt(t));
   }
 
-  // const recourceTagsInclude = only
-  const tagIdsToLimitResourcesTo = stringToArray(onlyIncludeTagIds);
   const statusIdsToLimitResourcesTo = stringToArray(onlyIncludeStatusIds);
+
+  const {data: allTags} = datastore.useTags({
+    projectId: props.projectId,
+    type: ''
+  });
+
+  function determineTags(includeOrExclude: string, allTags: any, tagIdsArray: Array<number>) {
+    let filteredTagIdsArray: Array<number> = [];
+    try {
+      if (includeOrExclude === 'exclude' && tagIdsArray.length > 0) {
+        const filteredTags = allTags.filter((tag: { id: number }) => !tagIdsArray.includes((tag.id)));
+        const filteredTagIds = filteredTags.map((tag: { id: number }) => tag.id);
+
+        filteredTagIdsArray = filteredTagIds;
+      } else if (includeOrExclude === 'include') {
+        filteredTagIdsArray = tagIdsArray;
+      }
+
+      const filteredTagsIdsString = filteredTagIdsArray.join(',');
+
+      return {
+        tagsString: filteredTagsIdsString || '',
+        tags: filteredTagIdsArray || []
+      };
+
+    } catch (error) {
+      console.error('Error processing tags:', error);
+
+      return {
+        tagsString: '',
+        tags: []
+      };
+    }
+  }
+
+  useEffect(() => {
+    const {
+      tags: filteredTagIdsArray
+    } = determineTags(includeOrExcludeTagIds, allTags, stringToArray(onlyIncludeTagIds));
+
+    setTagIdsToLimitResourcesTo(filteredTagIdsArray);
+  }, [allTags]);
+
+  const [tagIdsToLimitResourcesTo, setTagIdsToLimitResourcesTo] = useState< Array<number> >([]);
 
   const urlParams = new URLSearchParams(window.location.search);
   const urlTagIds = urlParams.get('tagIds');
@@ -408,14 +454,30 @@ function ResourceOverview({
   const urlStatusIdsArray = urlStatusIds ? stringToArray(urlStatusIds) : undefined;
 
   const [open, setOpen] = React.useState(false);
-
-  const initTags = urlTagIdsArray && urlTagIdsArray.length > 0 ? urlTagIdsArray : tagIdsToLimitResourcesTo || [];
   const initStatuses = urlStatusIdsArray && urlStatusIdsArray.length > 0 ? urlStatusIdsArray : statusIdsToLimitResourcesTo || [];
+
+  useEffect(() => {
+    const initTags = Array.from(new Set([...(urlTagIdsArray || []), ...tagIdsToLimitResourcesTo]) )
+
+    const includeTags = includeOrExcludeTagIds === 'include'
+      ? initTags
+      : urlTagIdsArray || [];
+
+    const excludeTags = includeOrExcludeTagIds === 'exclude' ? stringToArray(onlyIncludeTagIds) : [];
+
+    setIncludeTags(includeTags);
+    setTags(includeTags);
+
+    setExcludeTags(excludeTags);
+  }, [tagIdsToLimitResourcesTo.length]);
+
+  const [includeTags, setIncludeTags] = useState<number[]>([]);
+  const [excludeTags, setExcludeTags] = useState<number[]>([]);
 
   // Filters that when changed reupdate the useResources value automatically
   const [search, setSearch] = useState<string>('');
   const [statuses, setStatuses] = useState<number[]>(initStatuses);
-  const [tags, setTags] = useState<number[]>(initTags);
+  const [tags, setTags] = useState<number[]>([]);
   const [page, setPage] = useState<number>(0);
   const [totalPages, setTotalPages] = useState(0);
   const [pageSize, setPageSize] = useState<number>(itemsPerPage || 10);
@@ -430,9 +492,18 @@ function ResourceOverview({
     pageSize: 999999,
     ...props,
     search,
-    tags,
+    tags: [],
     sort,
   });
+
+  useEffect(() => {
+    if ( JSON.stringify(tags) !== JSON.stringify(includeTags) ) {
+      // Tags from setTags are sometimes strings apparently
+      // @ts-ignore
+      const tagsForIncluding = tags.map((tag) => parseInt(tag, 10))
+      setIncludeTags(tagsForIncluding)
+    }
+  }, [tags])
 
   const [resourceDetailIndex, setResourceDetailIndex] = useState<number>(0);
 
@@ -443,11 +514,6 @@ function ResourceOverview({
       setResources(multiProjectResources);
     }
   }, [multiProjectResources, selectedProjects, resourcesWithPagination, pageSize]);
-
-  const {data: allTags} = datastore.useTags({
-    projectId: props.projectId,
-    type: ''
-  });
 
   useEffect(() => {
     // @ts-ignore
@@ -468,19 +534,31 @@ function ResourceOverview({
     });
 
     const filtered = resources && (
-        Object.keys(groupedTags).length === 0
-            ? resources
-            : resources.filter((resource: any) => {
-              return Object.keys(groupedTags).every(tagType => {
-                return groupedTags[tagType].some(tagId =>
-                    resource.tags && Array.isArray(resource.tags) && resource.tags.some((o: { id: number }) => o.id === tagId)
-                );
-              });
-            })
+      resources.filter((resource: any) => {
+          const hasExcludedTag = resource.tags?.some((tag: { id: number }) =>
+            excludeTags.includes(tag.id)
+          );
+          if (hasExcludedTag) return false;
+
+          if (includeTags.length > 0) {
+            const hasIncludedTag = resource.tags?.some((tag: { id: number }) =>
+              includeTags.includes(tag.id)
+            );
+            return hasIncludedTag;
+          }
+
+          return true;
+        })
     )
-        ?.filter((resource: any) =>
-            (!statusIdsToLimitResourcesTo || statusIdsToLimitResourcesTo.length === 0) || statusIdsToLimitResourcesTo.some((statusId) => resource.statuses && Array.isArray(resource.statuses) && resource.statuses.some((o: { id: number }) => o.id === statusId))
-        )
+        ?.filter((resource: any) => {
+          if (!statusIdsToLimitResourcesTo?.length) return true;
+
+          const hasMatchingStatus = resource.statuses?.some((o: { id: number }) =>
+            statusIdsToLimitResourcesTo.includes(o.id)
+          );
+
+          return includeOrExcludeStatusIds === 'include' === hasMatchingStatus;
+        })
         ?.sort((a: any, b: any) => {
           if (sort === 'createdAt_desc') {
             return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
@@ -506,7 +584,7 @@ function ResourceOverview({
         });
 
     setFilteredResources(filtered);
-  }, [resources, tags, statuses, search, sort, allTags]);
+  }, [resources, tags, statuses, search, sort, allTags, excludeTags, includeTags]);
 
   useEffect(() => {
     if (filteredResources) {
@@ -665,7 +743,7 @@ function ResourceOverview({
               showActiveTags={showActiveTags}
               onUpdateFilter={(f) => {
                 if (f.tags.length === 0) {
-                  setTags(tagIdsToLimitResourcesTo);
+                  setTags(includeOrExcludeTagIds === 'include' ? tagIdsToLimitResourcesTo : []);
                 } else {
                   setTags(f.tags);
                 }

--- a/packages/resource-overview/src/resource-overview.tsx
+++ b/packages/resource-overview/src/resource-overview.tsx
@@ -498,9 +498,7 @@ function ResourceOverview({
 
   useEffect(() => {
     if ( JSON.stringify(tags) !== JSON.stringify(includeTags) ) {
-      // Tags from setTags are sometimes strings apparently
-      // @ts-ignore
-      const tagsForIncluding = tags.map((tag) => parseInt(tag, 10))
+      const tagsForIncluding = tags.map((tag) => typeof(tag) === 'string' ? parseInt(tag, 10) : tag)
       setIncludeTags(tagsForIncluding)
     }
   }, [tags])

--- a/packages/ui/src/stem-begroot-and-resource-overview/filter/multiselect-tag-filter.tsx
+++ b/packages/ui/src/stem-begroot-and-resource-overview/filter/multiselect-tag-filter.tsx
@@ -85,7 +85,7 @@ const MultiSelectTagFilter = ({
 
   const combinedSelects = stopUsingDefaultValue ? selected : Array.from( new Set([...selected, ...prefilterTagsSelected]) );
 
-  return (
+  return filterTags.length > 0 && (
     <div className="form-element">
       <FormLabel htmlFor={getRandomId(props.placeholder)}>{props.placeholder || 'Selecteer item'}</FormLabel>
       <MultiSelect


### PR DESCRIPTION
This pull request introduces functionality to filter resources based on inclusion or exclusion of specific tags and statuses. It adds new fields, UI components, and logic to handle these filters effectively. The changes primarily focus on enhancing the filtering capabilities in the `ResourceOverview` component and related UI.

### New Filtering Capabilities

* Added support for filtering resources by including or excluding specific tags and statuses. Introduced new fields `includeOrExcludeTagIds` and `includeOrExcludeStatusIds` in the form schema and default values. 

* Updated the `ResourceOverview` component to process and apply these new filters. This includes new state variables (`includeTags`, `excludeTags`) and utility functions (`determineTags`) for managing filtering logic.

### UI Enhancements

* Added new `Select` components to the form for users to choose whether to include or exclude resources based on tags or statuses. These components provide clear descriptions and options for filtering behavior.

* Improved the `MultiSelectTagFilter` component to ensure it only renders when there are available tags to filter, optimizing the UI experience.

### Filtering Logic Updates

* Refactored resource filtering logic to incorporate the new inclusion/exclusion functionality for both tags and statuses. This ensures resources are filtered correctly based on user preferences.

* Adjusted tag and status initialization to account for the new filters, ensuring proper state management and synchronization with user input.