### PR TITLE
feat: Add health point for CMS

### DIFF
--- a/apps/cms-server/app.js
+++ b/apps/cms-server/app.js
@@ -21,6 +21,14 @@ const apostropheServer = {};
 let startUpIsBusy = false;
 let startUpQueue = [];
 
+app.get('/health', (req, res) => {
+  res.status(200).json({
+    status: 'UP',
+    message: 'Server is healthy',
+    timestamp: new Date().toISOString(),
+  });
+});
+
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/:sitePrefix?/config-reset', async function (req, res, next) {


### PR DESCRIPTION
This pull request adds a `/health` endpoint to `apps/cms-server/app.js`, which returns a JSON response with the server status, a message, and a timestamp to easily verify server health.

**Important:** Please consider whether the use of `/health` could conflict with an existing or future page slug. Ensure this does not introduce any routing issues.