### PR TITLE
fix: Pagination for stem begroot

### DIFF
--- a/packages/stem-begroot/src/stem-begroot.tsx
+++ b/packages/stem-begroot/src/stem-begroot.tsx
@@ -565,6 +565,8 @@ function StemBegroot({
         voteType={props?.votes?.voteType || 'likes'}
         typeSelector={typeSelector}
         activeTagTab={activeTagTab}
+        currentPage={page}
+        pageSize={itemsPerPage}
       />
 
       <div className="osc">

--- a/packages/stem-begroot/src/stem-begroot.tsx
+++ b/packages/stem-begroot/src/stem-begroot.tsx
@@ -168,16 +168,16 @@ function StemBegroot({
   const [search, setSearch] = useState<string | undefined>();
   const [page, setPage] = useState<number>(0);
   const [itemsPerPage, setPageSize] = useState<number>(
-    props.itemsPerPage || 10
+    props.itemsPerPage || 999
   );
+  const [totalPages, setTotalPages] = useState(0);
 
   const { data: resources, submitVotes } = datastore.useResources({
     projectId: props.projectId,
     tags,
     sort,
     search,
-    page,
-    itemsPerPage,
+    pageSize: 999,
   });
 
   // Replace with type when available from datastore
@@ -487,6 +487,19 @@ function StemBegroot({
       divElement.scrollIntoView({ block: "start", behavior: "auto" });
     }
   }
+
+  useEffect(() => {
+    if (filteredResources) {
+      const filtered: any = filteredResources || [];
+      const totalPagesCalc = Math.ceil(filtered?.length / itemsPerPage);
+
+      if (totalPagesCalc !== totalPages) {
+        setTotalPages(totalPagesCalc);
+      }
+
+      setPage(0);
+    }
+  }, [filteredResources]);
 
   return (
     <>
@@ -990,16 +1003,18 @@ function StemBegroot({
               typeSelector={typeSelector}
               hideTagsForResources={hideTagsForResources}
               hideReadMore={hideReadMore}
+              currentPage={page}
+              pageSize={itemsPerPage}
             />
             <Spacer size={3} />
 
             {props.displayPagination && (
               <div className="osc-stem-begroot-paginator">
                 <Paginator
-                  page={resources?.metadata?.page || 0}
-                  totalPages={resources?.metadata?.pageCount || 1}
-                  onPageChange={(page) => {
-                    setPage(page);
+                  page={page || 0}
+                  totalPages={totalPages || 1}
+                  onPageChange={(newPage) => {
+                    setPage(newPage);
                     scrollToTop();
                   }}
                 />

--- a/packages/stem-begroot/src/step-1/begroot-detail-dialog/stem-begroot-detail-dialog.tsx
+++ b/packages/stem-begroot/src/step-1/begroot-detail-dialog/stem-begroot-detail-dialog.tsx
@@ -43,6 +43,8 @@ export const StemBegrootResourceDetailDialog = ({
   typeSelector = 'tag',
   setFilteredResources,
   filteredResources = [],
+  currentPage = 0,
+  pageSize = 999,
 }: {
   openDetailDialog: boolean;
   setOpenDetailDialog: (condition: boolean) => void;
@@ -69,6 +71,8 @@ export const StemBegrootResourceDetailDialog = ({
   voteType?: string;
   setFilteredResources?: (resources: Array<any>) => void;
   filteredResources?: Array<any>;
+  currentPage: number;
+  pageSize: number;
 }) => {
   // @ts-ignore
   const intTags = tags.map(tag => parseInt(tag, 10));
@@ -131,10 +135,8 @@ export const StemBegrootResourceDetailDialog = ({
       return 0;
     });
 
-  if ( (voteType === 'countPerTag' || voteType === 'budgetingPerTag') && setFilteredResources) {
-    if (JSON.stringify(filtered) !== JSON.stringify(filteredResources)) {
-      setFilteredResources(filtered);
-    }
+  if ( (JSON.stringify(filtered) !== JSON.stringify(filteredResources)) && setFilteredResources ) {
+    setFilteredResources(filtered);
   }
 
   const handleBeforeIndexChange = () => {
@@ -152,7 +154,9 @@ export const StemBegrootResourceDetailDialog = ({
         <Carousel
           startIndex={resourceDetailIndex}
           buttonText={{next: 'Volgende inzending', previous: 'Vorige inzending'}}
-          items={filtered || []}
+          items={
+            (filtered || [])?.slice(currentPage * pageSize, (currentPage + 1) * pageSize)
+          }
           beforeIndexChange={handleBeforeIndexChange}
           itemRenderer={(resource) => {
             const canUseButton = resourceBtnEnabled(resource);

--- a/packages/stem-begroot/src/step-1/begroot-resource-list/stem-begroot-resource-list.tsx
+++ b/packages/stem-begroot/src/step-1/begroot-resource-list/stem-begroot-resource-list.tsx
@@ -129,7 +129,7 @@ export const StemBegrootResourceList = ({
       return 0;
     });
 
-    if (JSON.stringify(filtered) !== JSON.stringify(filteredResources)) {
+    if ((JSON.stringify(filtered) !== JSON.stringify(filteredResources)) && setFilteredResources) {
       setFilteredResources(filtered);
     }
 

--- a/packages/stem-begroot/src/step-1/begroot-resource-list/stem-begroot-resource-list.tsx
+++ b/packages/stem-begroot/src/step-1/begroot-resource-list/stem-begroot-resource-list.tsx
@@ -36,6 +36,8 @@ export const StemBegrootResourceList = ({
   filteredResources = [],
   hideTagsForResources = false,
   hideReadMore = false,
+  currentPage = 0,
+  pageSize = 999,
   header
 }: {
   resourceListColumns?: number;
@@ -64,6 +66,8 @@ export const StemBegrootResourceList = ({
   filteredResources?: Array<any>;
   hideTagsForResources?: boolean;
   hideReadMore?: boolean;
+  currentPage: number;
+  pageSize: number;
 }) => {
   // @ts-ignore
   const intTags = tags.map(tag => parseInt(tag, 10));
@@ -125,17 +129,17 @@ export const StemBegrootResourceList = ({
       return 0;
     });
 
-  if ( (voteType === 'countPerTag' || voteType === 'budgetingPerTag') && setFilteredResources) {
     if (JSON.stringify(filtered) !== JSON.stringify(filteredResources)) {
       setFilteredResources(filtered);
     }
-  }
 
   return (
     <List
       id='stem-begroot-resource-selections-list'
       columns={resourceListColumns}
-      items={filtered || []}
+      items={
+        (filtered || [])?.slice(currentPage * pageSize, (currentPage + 1) * pageSize)
+      }
       renderHeader={() => header || <></>}
       renderItem={(resource, index) => {
         const primaryBtnText = resourceBtnTextHandler(resource);


### PR DESCRIPTION
This pull request introduces pagination functionality to the `StemBegroot` component and its related `StemBegrootResourceList` component. The changes include adding state management for pagination, calculating the total number of pages, and slicing the displayed resources based on the current page and page size.

### Pagination functionality:

* **State and logic for pagination in `StemBegroot`:**
  - Added a new `totalPages` state to track the total number of pages. The state is updated whenever the filtered resources change.
  - Updated the `Paginator` component to use the new `page` and `totalPages` states, replacing the metadata from `resources`. The `onPageChange` handler now updates the `page` state.

* **Pagination support in `StemBegrootResourceList`:**
  - Introduced `currentPage` and `pageSize` props to control which resources are displayed. 
  - Modified the `items` prop of the `List` component to slice the `filtered` resources array based on the `currentPage` and `pageSize`.