### PR TITLE
Fix/create ingress order

### DIFF
--- a/apps/api-server/src/services/checkHostStatus.js
+++ b/apps/api-server/src/services/checkHostStatus.js
@@ -19,7 +19,10 @@ const lookupPromise = async (domain) => {
 
 const getIngress = async (k8sApi, name, namespace) => {
   try {
-    return await k8sApi.readNamespacedIngress({name, namespace});
+    return await k8sApi.readNamespacedIngress({
+      name,
+      namespace
+    });
   } catch(error) {
     //Todo: log something
     console.log(error);
@@ -57,7 +60,11 @@ const updateIngress = async (ingress, k8sApi, name, domain, namespace) => {
     }
   }
   
-  return k8sApi.replaceNamespacedIngress({name, namespace, ingress});
+  return k8sApi.replaceNamespacedIngress({
+    name,
+    namespace,
+    body: ingress
+  });
 }
 
 const createIngress = async (k8sApi, name, domain, namespace) => {

--- a/apps/api-server/src/services/checkHostStatus.js
+++ b/apps/api-server/src/services/checkHostStatus.js
@@ -1,6 +1,5 @@
 const dns = require('dns');
 const db = require('../db');
-const k8s = require('@kubernetes/client-node');
 
 const getK8sApi = async () => {
   const k8s = await import('@kubernetes/client-node');

--- a/apps/api-server/src/services/checkHostStatus.js
+++ b/apps/api-server/src/services/checkHostStatus.js
@@ -2,7 +2,8 @@ const dns = require('dns');
 const db = require('../db');
 const k8s = require('@kubernetes/client-node');
 
-const getK8sApi = () => {
+const getK8sApi = async () => {
+  const k8s = await import('@kubernetes/client-node');
   const kc = new k8s.KubeConfig();
   kc.loadFromCluster();
   return kc.makeApiClient(k8s.NetworkingV1Api);

--- a/apps/api-server/src/services/checkHostStatus.js
+++ b/apps/api-server/src/services/checkHostStatus.js
@@ -19,7 +19,7 @@ const lookupPromise = async (domain) => {
 
 const getIngress = async (k8sApi, name, namespace) => {
   try {
-    return await k8sApi.readNamespacedIngress(name, namespace);
+    return await k8sApi.readNamespacedIngress({name, namespace});
   } catch(error) {
     //Todo: log something
     console.log(error);
@@ -57,7 +57,7 @@ const updateIngress = async (ingress, k8sApi, name, domain, namespace) => {
     }
   }
   
-  return k8sApi.replaceNamespacedIngress(name, namespace, ingress);
+  return k8sApi.replaceNamespacedIngress({name, namespace, ingress});
 }
 
 const createIngress = async (k8sApi, name, domain, namespace) => {


### PR DESCRIPTION
### fix: update Kubernetes API calls to comply with `@kubernetes/client-node v1.1.2`
**Summary**
This PR updates all Kubernetes NetworkingV1Api method calls to match the new method signature introduced in `@kubernetes/client-node v1.1.2`.
Since this version, Kubernetes client methods no longer accept positional parameters but instead require all arguments to be passed inside a single options object.

This change affects:

- `createNamespacedIngress`
- `readNamespacedIngress`
- `replaceNamespacedIngress`

Reference: [@kubernetes/client-node commit 34c6010](https://github.com/kubernetes-client/javascript/commit/34c6010896251443fd59baede4b42b03e21c9462#diff-67c33e6f7d4b5cd4063fdb45d10f369a9d19f664964b691010a711d85ac0663b)