### PR TITLE
Fix/image quality

### DIFF
--- a/apps/admin-server/src/components/resource-form.tsx
+++ b/apps/admin-server/src/components/resource-form.tsx
@@ -652,7 +652,7 @@ export default function ResourceForm({ onFormSubmit }: Props) {
               items={loadedTags}
               layout="vertical"
               selectedPredicate={(t) =>
-                form.getValues('tags').findIndex((tg) => tg === t.id) > -1
+                form.getValues('tags')?.findIndex((tg) => tg === t.id) > -1
               }
               onValueChange={(tag, checked) => {
                 const values = form.getValues('tags');
@@ -674,7 +674,7 @@ export default function ResourceForm({ onFormSubmit }: Props) {
               keyPerItem={(t) => `${t.id}`}
               items={loadedStatuses}
               selectedPredicate={(t) =>
-                form.getValues('statuses').findIndex((tg) => tg === t.id) > -1
+                form.getValues('statuses')?.findIndex((tg) => tg === t.id) > -1
               }
               onValueChange={(status, checked) => {
                 const values = form.getValues('statuses');

--- a/apps/api-server/src/routes/api/upload.js
+++ b/apps/api-server/src/routes/api/upload.js
@@ -9,7 +9,7 @@ if (!imageAppUrl.startsWith('http')) {
   imageAppUrl = (process.env.FORCE_HTTP ? 'http://' : 'https://') + imageAppUrl;
 }
 
-let proxySettings = {
+const imageProxyMw = createProxyMiddleware({
   target: imageAppUrl,
   changeOrigin: true,
   pathRewrite: {
@@ -18,16 +18,18 @@ let proxySettings = {
   headers: {
     'image-token': process.env.IMAGE_VERIFICATION_TOKEN,
   },
-}
+});
 
 router
     .route('/images|/image|/document|/documents')
     .post((req, res, next) => {
-        if (req.user && req.user?.role) {
-          proxySettings.headers["x-user-role"] = req.user.role;
-        }
+        // check if req.user is set
+        // if (!req.user || !req.user?.id) {
+        //   console.log ('upload path: no user found', req.user);
+        //   return res.status(401).send('Unauthorized');
+        // }
         next();
     })
-    .post(createProxyMiddleware(proxySettings))
+    .post(imageProxyMw)
 
 module.exports = router;

--- a/apps/image-server/server.js
+++ b/apps/image-server/server.js
@@ -66,6 +66,7 @@ const imageSteamConfig = {
         enabled: 'false',
       },
     },
+    hqOriginalMaxPixels: 5120 * 5120
   },
 };
 
@@ -127,19 +128,11 @@ app.get('/health', (req, res) => {
 app.get('/image/*',
   function (req, res, next) {
     req.url = req.url.replace('/image', '');
-    const userRole = req.headers['x-user-role'] || 'member';
-
-    if (userRole === 'admin') {
-      imageSteamConfig.router.hqOriginalMaxPixels = 10240 * 10240;
-    }
-
-    const dynamicImageServer = new imgSteam.http.Connect(imageSteamConfig);
-    const dynamicImageHandler = dynamicImageServer.getHandler();
 
     /**
      * Pass request en response to the imageserver
      */
-    dynamicImageHandler(req, res, next);
+    imageHandler(req, res);
   });
 
 const documentMulterConfig = {


### PR DESCRIPTION
### fix: set global image quality and minor admin resource fix
**Summary**

- Reverted earlier code changes related to image upload behavior as they did not work reliably in practice.
- `hqOriginalMaxPixels` has been added to the default image-steam configuration to ensure better image quality by default.
- Applied a minor fix to prevent occasional errors in admin resources.