### PR TITLE
feat: Improve comments export

### DIFF
--- a/apps/admin-server/src/lib/export-helpers/comments-export.tsx
+++ b/apps/admin-server/src/lib/export-helpers/comments-export.tsx
@@ -1,0 +1,78 @@
+import flattenObject from "@/lib/export-helpers/flattenObject";
+import * as XLSX from "xlsx";
+
+const keyMap: Record<string, string> = {
+  'resourceId'            : 'Inzending ID',
+  'resource.title'        : 'Inzending titel',
+  'userId'                : 'Gebruiker ID',
+  'user.role'             : 'Gebruiker rol',
+  'user.displayName'      : 'Gebruiker weergavenaam',
+  'user.name'             : 'Gebruiker naam',
+  'user.email'            : 'Gebruiker e-mailadres',
+  'id'                    : 'Reactie ID',
+  'parentId'              : 'Reactie op ID',
+  'sentiment'             : 'Sentiment',
+  'description'           : 'Reactie',
+  'location.lat'          : 'Locatie (lat)',
+  'location.lng'          : 'Locatie (lng)',
+  'createDateHumanized'   : 'Datum (leesbaar)',
+  'updatedAt'             : 'Laatst bijgewerkt',
+};
+
+const cleanCommentsData = (allComments: any[]) => {
+  return allComments.map(original => {
+    const cleaned: Record<string, any> = {};
+
+    Object.entries(keyMap).forEach(([key, label]) => {
+      if (original.hasOwnProperty(key)) {
+        cleaned[label] = original[key];
+      }
+    });
+
+    Object.keys(original).forEach((key) => {
+      if (key.startsWith('tags.')) {
+        const label = key.replace('tags.', 'Tag ');
+
+        const fullTagsString = typeof cleaned[label] === 'undefined'
+          ? original[key]
+          : cleaned[label] + ', ' + original[key];
+
+        cleaned[label] = JSON.parse( `[${fullTagsString}]` )?.filter(Boolean).join(', ');
+      }
+    });
+
+    return cleaned;
+  });
+}
+
+export const exportComments = (data: any[], fileName: string) => {
+  const allComments: any[] = [];
+
+  const flattenedData = data.map(item => flattenObject(item));
+
+  flattenedData.forEach((comment) => {
+    allComments.push(comment);
+
+    let replies = [];
+    if (typeof comment.replies === 'string') {
+      try {
+        replies = JSON.parse( `[${comment.replies}]` );
+
+        replies?.forEach((reply: any) => {
+          reply.parentId = comment.id;
+          reply.description = `└ ${reply.description || ''}`;
+
+          const flattenedReply = flattenObject(reply);
+          allComments.push(flattenedReply);
+        });
+      } catch (e) {}
+    }
+  });
+
+  const cleanedComments = cleanCommentsData(allComments);
+
+  const workbook = XLSX.utils.book_new();
+  const worksheet = XLSX.utils.json_to_sheet(cleanedComments);
+  XLSX.utils.book_append_sheet(workbook, worksheet, 'Reacties');
+  XLSX.writeFile(workbook, fileName);
+};

--- a/apps/admin-server/src/pages/projects/[project]/comments/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/comments/index.tsx
@@ -8,34 +8,22 @@ import { RemoveResourceDialog } from '@/components/dialog-resource-remove';
 import toast from 'react-hot-toast';
 import { sortTable, searchTable } from '@/components/ui/sortTable';
 import { Button } from '../../../../components/ui/button';
-import * as XLSX from 'xlsx';
-import flattenObject from "@/lib/export-helpers/flattenObject";
 import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from "@/components/ui/select";
 import useResources from "@/hooks/use-resources";
-
+import { exportComments } from '@/lib/export-helpers/comments-export';
 
 export default function ProjectComments() {
   const router = useRouter();
   const { project } = router.query;
   const { data, removeComment } = useComments(project as string, '?includeAllComments=1&includeTags', true);
   const { data: resources } = useResources(project as string);
-  const [comments, setComments] = useState<any[]>([])
+  const [comments, setComments] = useState<any[]>([]);
 
-  const exportData = (data: any[], fileName: string) => {
-  
-    const flattenedData = data.map(item => flattenObject(item));
-  
-    const workbook = XLSX.utils.book_new();
-    const worksheet = XLSX.utils.json_to_sheet(flattenedData);
-    XLSX.utils.book_append_sheet(workbook, worksheet, 'Sheet1');
-  
-    XLSX.writeFile(workbook, fileName);
-  };
   function transform() {
     const today = new Date();
     const projectId = router.query.project;
     const formattedDate = today.toISOString().split('T')[0].replace(/-/g, '');
-    exportData(filterData, `${projectId}_reacties_${formattedDate}.xlsx`);
+    exportComments(filterData, `${projectId}_reacties_${formattedDate}.xlsx`);
   }
 
   function categorizeTags(tags: { type: string, name: string }[] ) {


### PR DESCRIPTION
This pull request refactors the comments export functionality in the admin server. It introduces a new helper function for exporting comments and improving the exported output.

### Refactoring and modularization:

* `apps/admin-server/src/lib/export-helpers/comments-export.tsx`: Added a new `exportComments` function that includes logic for cleaning, flattening, and exporting comments data to an Excel file. This function also handles nested replies.

### Component updates:

* `apps/admin-server/src/pages/projects/[project]/comments/index.tsx`: Replaced the inline export logic with the newly created `exportComments` helper function.