### PR TITLE
Fix/TwoFactorRoles op kunnen slaan

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/authentication/2fa.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/authentication/2fa.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
-import * as z from 'zod';
+import { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { useState, useCallback, useEffect } from 'react';
+import * as z from 'zod';
 import { useProject } from '../../../../hooks/use-project';
 
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   Form,
   FormControl,
@@ -14,13 +14,12 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/ui/form';
-import toast from 'react-hot-toast';
 import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
 import { PageLayout } from '@/components/ui/page-layout';
-import { Heading } from '@/components/ui/typography';
 import { Separator } from '@/components/ui/separator';
-import { Checkbox } from '@/components/ui/checkbox';
+import { Textarea } from '@/components/ui/textarea';
+import { Heading } from '@/components/ui/typography';
+import toast from 'react-hot-toast';
 
 
 const twoFactorRoles = [
@@ -30,7 +29,7 @@ const twoFactorRoles = [
   },
   {
     id: 'member',
-    label: 'lid',
+    label: 'Lid',
   },
   {
     id: 'moderator',

--- a/apps/api-server/src/adapter/openstad/service.js
+++ b/apps/api-server/src/adapter/openstad/service.js
@@ -277,8 +277,7 @@ service.createClient = async function({ authConfig, project }) {
       throw new Error('OpenStad.service.createClient: create client failed')
     }
 
-    let client = response.json();
-    return client;
+    return await response.json();
 
   } catch(err) {
     throw new Error('Cannot connect to auth server');

--- a/apps/api-server/src/routes/api/project.js
+++ b/apps/api-server/src/routes/api/project.js
@@ -605,6 +605,7 @@ router.route('/:projectId') //(\\d+)
       let providers = await authSettings.providers({ project });
       const configData = req.body.config?.auth?.provider?.openstad?.config || {};
       const allowedDomains = req.body.config?.allowedDomains || false;
+      const twoFactorRoles = req.body.config?.auth?.provider?.openstad?.twoFactorRoles;
 
       for (let provider of providers) {
         if (
@@ -620,9 +621,12 @@ router.route('/:projectId') //(\\d+)
         if (!!allowedDomains) {
           authConfig.allowedDomains = allowedDomains;
         }
-
+        
         if (adapter.service.updateClient) {
-          let merged = merge.recursive({}, authConfig, {config: configData});
+          let merged = merge.recursive({}, authConfig, {
+            config: configData,
+            twoFactorRoles: twoFactorRoles || authConfig.twoFactorRoles
+          });
           await adapter.service.updateClient({ authConfig: merged, project });
           // delete req.body.config?.auth?.provider?.[authConfig.provider]?.authTypes;
           // delete req.body.config?.auth?.provider?.[authConfig.provider]?.twoFactorRoles;


### PR DESCRIPTION
When updating project settings through the API, changes to two-factor authentication (2FA) are not being persisted.

**for testers**
try saving "moderator" and "lid" a couple of times with different values and you'll see its nog being saved properly