### PR TITLE
Fix/allow maps init without polygon

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/settings/map.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/settings/map.tsx
@@ -213,7 +213,7 @@ export default function ProjectSettingsMap() {
                 )}
               />
 
-              {form.watch('tilesVariant') !== 'nlmaps' && (
+              {(!!form.watch('tilesVariant') && form.watch('tilesVariant') !== 'nlmaps') && (
                 <p
                   style={{
                     backgroundColor: '#d69e2e',

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourcesmap/[id]/map.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourcesmap/[id]/map.tsx
@@ -255,7 +255,7 @@ export default function WidgetResourcesMapMap(
             )}
           />
 
-          {form.watch('tilesVariant') !== 'nlmaps' && (
+          {(!!form.watch('tilesVariant') && form.watch('tilesVariant') !== 'nlmaps') && (
             <p
               style={{
                 backgroundColor: '#d69e2e',

--- a/packages/leaflet-map/src/lib/leaflet-extensions.d.ts
+++ b/packages/leaflet-map/src/lib/leaflet-extensions.d.ts
@@ -1,0 +1,6 @@
+import * as L from 'leaflet';
+
+declare module 'leaflet' {
+  // Add the mapInteraction function to the L namespace
+  function mapInteraction(map: L.Map, options?: any): any;
+}

--- a/packages/leaflet-map/src/lib/leaflet-extensions.d.ts
+++ b/packages/leaflet-map/src/lib/leaflet-extensions.d.ts
@@ -1,6 +1,5 @@
 import * as L from 'leaflet';
 
 declare module 'leaflet' {
-  // Add the mapInteraction function to the L namespace
   function mapInteraction(map: L.Map, options?: any): any;
 }

--- a/packages/leaflet-map/src/resource-overview-map.tsx
+++ b/packages/leaflet-map/src/resource-overview-map.tsx
@@ -329,7 +329,7 @@ const ResourceOverviewMap = ({
     }
   }
 
-  return ((polygon && center) || !areaId) ? (
+  return ((polygon && center) || !Number(areaId)) ? (
     <div className='map-container--buttons'>
       <Button appearance='primary-action-button' className='skip-link' onClick={skipMarkers}>Sla kaart over</Button>
       { mapDataLayers.length > 0 && (

--- a/packages/ui/src/form-elements/map/index.tsx
+++ b/packages/ui/src/form-elements/map/index.tsx
@@ -146,7 +146,7 @@ const MapField: FC<MapProps> = ({
             className="form-field-map-container"
             id={`map`}
           >
-            {((areaId && polygon.length) || !areaId) && (
+            {((areaId && polygon.length) || !Number(areaId)) && (
               <EditorMap
                   {...props}
                   fieldName={fieldKey}


### PR DESCRIPTION
This pull request introduces several small updates across multiple files. Below is a summary of the most important changes:

### Warning Rendering Improvements:
* Updated conditional checks in `ProjectSettingsMap` and `WidgetResourcesMapMap` components to ensure `tilesVariant` is truthy before showing the CSP warning.

### Map Functionality Enhancements:
* Enhanced the `BaseMap` component to handle scenarios where `area` is undefined or empty by calculating bounds based on `mapDataLayers` features (e.g., `LineString` and `Point` geometries). This ensures proper auto-zoom and centering behavior.

### Map initialisation Improvements:
* Improved type safety in `ResourceOverviewMap` and `MapField` components by explicitly converting `areaId` to a number before performing logical operations. This prevents the map showing when no areaId is present. 