### PR TITLE
fix: Delete unique id when duplicating project

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/duplicate.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/duplicate.tsx
@@ -137,6 +137,10 @@ export default function ProjectDuplicate() {
       skipDefaultStatuses: true,
     };
 
+    if ( duplicateData.config && duplicateData.config.uniqueId ) {
+      delete duplicateData.config.uniqueId;
+    }
+
     const widgets = await fetchData(`/api/openstad/api/project/${data.id}/widgets`);
     duplicateData.widgets = widgets;
 


### PR DESCRIPTION
This pull request introduces a small change to the `ProjectDuplicate` function in `apps/admin-server/src/pages/projects/[project]/duplicate.tsx`. The change ensures that the `uniqueId` property is removed from the `duplicateData.config` object if it exists.