### PR TITLE
fix: New id when adding multiple didn't add up

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/choiceOptions.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/choiceOptions.tsx
@@ -119,8 +119,13 @@ export default function WidgetChoiceGuideChoiceOptions(props: ChoiceOptions) {
   }
 
   const handleAddGroup = () => {
-    append({ id: nextIdRef.current, title: '', description: '' });
-    nextIdRef.current += 1;
+    const choiceOptions = form.getValues('choiceOptions') || [];
+    const newId = choiceOptions.length
+      ? Math.max(...choiceOptions.map((group: ChoiceOptions) => Number(group.id))) + 1
+      : nextIdRef.current;
+
+    append({ id: newId, title: '', description: '' });
+    nextIdRef.current = newId;
   };
 
   // const typeWithoutDimension = ['none', 'map', 'imageUpload', 'documentUpload', 'text'];


### PR DESCRIPTION
This pull request updates the logic for generating unique IDs when adding new choice groups in the `WidgetChoiceGuideChoiceOptions` component. The changes ensure that the ID generation accounts for existing groups, improving robustness.

### Key Change in ID Generation Logic:

* Updated the `handleAddGroup` function in `choiceOptions.tsx` to calculate the new ID based on the maximum existing ID in `choiceOptions`, falling back to `nextIdRef` if no groups exist. This prevents potential ID conflicts when groups are dynamically added.