### PR TITLE
fix: Duplicated titles resulted in duplicate values

### DIFF
--- a/apps/admin-server/src/lib/export-helpers/csv-export.tsx
+++ b/apps/admin-server/src/lib/export-helpers/csv-export.tsx
@@ -1,27 +1,4 @@
 export const exportDataToCSV = (data: any, widgetName: string, selectedWidget: any) => {
-
-  if ( selectedWidget && selectedWidget?.config && selectedWidget?.config?.items ) {
-
-    const fieldKeyToTitleMap = selectedWidget?.config?.items.reduce((acc: any, item: any) => {
-      acc[item.fieldKey] = item.title;
-      return acc;
-    }, {});
-
-    data = data.map((row: any) => {
-      const updatedSubmittedData = Object.keys(row?.submittedData).reduce((acc: any, key: any) => {
-        const newKey = fieldKeyToTitleMap[key] || key;
-        acc[newKey] = row?.submittedData[key];
-        return acc;
-      }, {});
-
-      return {
-        ...row,
-        submittedData: updatedSubmittedData
-      };
-    });
-
-  }
-
   function transformString() {
     widgetName = widgetName.replace(/\s+/g, '-').toLowerCase();
     widgetName = widgetName.replace(/[^a-z0-9-]/g, '');
@@ -130,8 +107,7 @@ export const exportDataToCSV = (data: any, widgetName: string, selectedWidget: a
       widgetName || ' ',
       row.userId || ' ',
       ...Array.from(fieldKeyToTitleMap.entries()).map(([key, title]) => {
-        const keyToUse = key?.endsWith('_other') ? key : title;
-        const rawValue = row.submittedData?.[keyToUse];
+        const rawValue = row.submittedData?.[key];
         return normalizeData(rawValue);
       }),
     ];


### PR DESCRIPTION
This pull request simplifies the `exportDataToCSV` function in `apps/admin-server/src/lib/export-helpers/csv-export.tsx` by removing unnecessary logic for mapping field keys to titles and updating the handling of submitted data. The changes streamline the function and improve maintainability.

### Simplification of `exportDataToCSV` function:

* Removed the logic that mapped `fieldKey` values to titles (`fieldKeyToTitleMap`) and transformed the `submittedData` object accordingly. This eliminates redundant processing of data before exporting.
* Updated the data normalization step to directly use the `key` from `fieldKeyToTitleMap` instead of conditionally switching between `key` and `title`. This simplifies the code and avoids unnecessary complexity.