### PR TITLE
fix: Weights for radio buttons shouldn't stack

### DIFF
--- a/packages/choiceguide/src/parts/scoreUtils.tsx
+++ b/packages/choiceguide/src/parts/scoreUtils.tsx
@@ -39,14 +39,28 @@ export const calculateScoreForItem = (
                 }
             });
 
+            const tempScores: Record<'x' | 'y' | 'z', number> = { x: 0, y: 0, z: 0 };
+
             Object.keys(optionWeights).forEach((optionId) => {
                 const secondOptionWeights = optionWeights[optionId];
 
+                const isRadioBox = answerKey.startsWith('radiobox');
+
                 ['x', 'y', 'z'].forEach((secondDimension) => {
-                    if (typeof secondOptionWeights[secondDimension] === 'number' && secondOptionWeights[secondDimension] !== 0) {
-                        countScores[secondDimension] += Number(secondOptionWeights[secondDimension]);
+                    const optionValue = secondOptionWeights[secondDimension];
+
+                    if (typeof optionValue === 'number' && optionValue !== 0) {
+                        if (isRadioBox) {
+                            tempScores[secondDimension] = Math.max(tempScores[secondDimension], optionValue);
+                        } else {
+                            tempScores[secondDimension] += optionValue;
+                        }
                     }
                 });
+            });
+
+            ['x', 'y', 'z'].forEach((sixthDimension) => {
+                countScores[sixthDimension] += tempScores[sixthDimension];
             });
         });
 


### PR DESCRIPTION
This pull request refines the scoring logic in the `calculateScoreForItem` function within `scoreUtils.tsx`. The update introduces a temporary score tracker and adjusts the handling of input type radiobox to ensure accurate score calculation.

### Scoring logic improvements:

* Introduced a `tempScores` object to temporarily store scores for dimensions `'x'`, `'y'`, and `'z'`, ensuring intermediate calculations are isolated.
* Added a check for `radiobox` input types (`isRadioBox`) to handle their scoring differently by using the maximum value instead of summing.