### PR TITLE
Add a reset 2FA button

### DIFF
--- a/apps/admin-server/src/components/dialog-resource-reset.tsx
+++ b/apps/admin-server/src/components/dialog-resource-reset.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { DialogClose } from '@radix-ui/react-dialog';
+
+import { Button } from '@/components/ui/button';
+import { Heading, Paragraph } from '@/components/ui/typography';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+} from '@/components/ui/dialog';
+
+type Props = {
+  header: string;
+  message: string;
+  resetButtonText?: string;
+  confirmButtonText?: string;
+  cancelButtonText?: string;
+  onResetAccepted: () => void;
+};
+
+export function ResetResourceDialog({
+  header,
+  message,
+  resetButtonText = 'Reset',
+  confirmButtonText = 'Bevestig',
+  cancelButtonText = 'Annuleren',
+  onResetAccepted,
+}: Props) {
+  const [open, setOpen] = useState<boolean>(false);
+
+  return (
+    <Dialog open={open} modal={true} onOpenChange={setOpen}>
+      <div className="flex items-center">
+        <Button
+          onClick={(e) => {
+            e.preventDefault();
+            setOpen(true);
+          }}
+          className="mt-4"
+          type="button"
+          variant="destructive">
+          {resetButtonText}
+        </Button>
+      </div>
+      <DialogContent
+        onEscapeKeyDown={(e: KeyboardEvent) => {
+          e.stopPropagation();
+        }}
+        onInteractOutside={(e: Event) => {
+          e.stopPropagation();
+          setOpen(false);
+        }}>
+        <div>
+          <Heading size={'lg'}>{header}</Heading>
+          <Paragraph className="mb-8">{message}</Paragraph>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button
+                onClick={(e) => {
+                  e.preventDefault();
+                  setOpen(false);
+                }}
+                type="button"
+                variant="ghost">
+                {cancelButtonText}
+              </Button>
+            </DialogClose>
+
+            <Button
+              type="button"
+              variant={'destructive'}
+              onClick={(e) => {
+                e.preventDefault();
+                onResetAccepted && onResetAccepted();
+                setOpen(false);
+              }}>
+              {confirmButtonText}
+            </Button>
+          </DialogFooter>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin-server/src/pages/users/[user]/general.tsx
+++ b/apps/admin-server/src/pages/users/[user]/general.tsx
@@ -1,5 +1,4 @@
-
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { useForm } from 'react-hook-form';
@@ -42,6 +41,7 @@ export default function CreateUserGeneral() {
    */
 
   const { data, updateUser } = useUser();
+  const [isTwoFactorEnabled, setIsTwoFactorEnabled] = useState(false);
 
   let user = data;
   if (Array.isArray(data)) user = data[0];
@@ -70,6 +70,23 @@ export default function CreateUserGeneral() {
     form.reset(defaults());
   }, [form, defaults]);
 
+  // Fetch two-factor status
+  useEffect(() => {
+    async function fetchTwoFactorStatus() {
+      try {
+        const response = await fetch(`/api/openstad/api/project/${user.projectId}/user/${user.id}/two-factor-status`);
+        const data = await response.json();
+        setIsTwoFactorEnabled(data.twoFactorEnabled);
+      } catch (error) {
+        toast.error('Failed to fetch two-factor status');
+      }
+    }
+
+    if (user?.id) {
+      fetchTwoFactorStatus();
+    }
+  }, [user]);
+
   async function onSubmit(values: z.infer<typeof formSchema>) {
     try {
       await updateUser({ ...values, id: user.id, projectId: user.projectId });
@@ -87,6 +104,7 @@ export default function CreateUserGeneral() {
         twoFactorConfigured: null, 
       });
 
+      setIsTwoFactorEnabled(false);
       toast.success('Two-factor authentication reset succesvol');
     } catch (error) {
       toast.error('Two-factor authenticatie kon niet worden gereset');
@@ -240,13 +258,19 @@ export default function CreateUserGeneral() {
       <Separator className="my-4" />
 
       <div>
-        {/* <Heading size="lg">Two-Factor Authenticatie</Heading> */}
-        <ResetResourceDialog
-          header="Two-Factor Authenticatie Reset"
-          message="Weet je zeker dat je de two-factor authentication wilt resetten voor deze gebruiker?"
-          resetButtonText='Reset Two-Factor Authenticatie'
-          onResetAccepted={handleResetTwoFactor}
-        />
+        <p>
+          {isTwoFactorEnabled
+            ? 'Two-factor authenticatie is ingeschakeld.'
+            : 'Deze gebruiker heeft nog geen two-factor authenticatie ingesteld.'}
+        </p>
+        {isTwoFactorEnabled && (
+          <ResetResourceDialog
+            header="Two-Factor Authenticatie Reset"
+            message="Weet je zeker dat je de two-factor authentication wilt resetten voor deze gebruiker?"
+            resetButtonText="Reset Two-Factor Authenticatie"
+            onResetAccepted={handleResetTwoFactor}
+          />
+        )}
       </div>
     </div>
   );

--- a/apps/admin-server/src/pages/users/[user]/general.tsx
+++ b/apps/admin-server/src/pages/users/[user]/general.tsx
@@ -15,6 +15,7 @@ import { Heading } from '@/components/ui/typography';
 import { Separator } from '@/components/ui/separator';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
+import { ResetResourceDialog } from '@/components/dialog-resource-reset';
 import useUser from '@/hooks/use-user';
 import { toast } from 'react-hot-toast';
 
@@ -75,6 +76,20 @@ export default function CreateUserGeneral() {
       toast.success('User is bijgewerkt')
     } catch(err:any) {
       toast.error(err.message || 'User kon niet worden bijgewerkt')
+    }
+  }
+
+  async function handleResetTwoFactor() {
+    try {
+      await updateUser({
+        ...user, // Include all existing user data
+        twoFactorToken: null, 
+        twoFactorConfigured: null, 
+      });
+
+      toast.success('Two-factor authentication reset succesvol');
+    } catch (error) {
+      toast.error('Two-factor authenticatie kon niet worden gereset');
     }
   }
 
@@ -221,6 +236,18 @@ export default function CreateUserGeneral() {
           </Button>
         </form>
       </Form>
+
+      <Separator className="my-4" />
+
+      <div>
+        {/* <Heading size="lg">Two-Factor Authenticatie</Heading> */}
+        <ResetResourceDialog
+          header="Two-Factor Authenticatie Reset"
+          message="Weet je zeker dat je de two-factor authentication wilt resetten voor deze gebruiker?"
+          resetButtonText='Reset Two-Factor Authenticatie'
+          onResetAccepted={handleResetTwoFactor}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/api-server/src/util/map-user-data.js
+++ b/apps/api-server/src/util/map-user-data.js
@@ -33,7 +33,7 @@ module.exports = function mapUserData({ map = {}, user = {} }) {
   }
 
   // do mapping
-  let keys = [ 'email', 'nickName', 'name', 'phoneNumber', 'address', 'postcode', 'city' ];
+  let keys = [ 'email', 'nickName', 'name', 'phoneNumber', 'address', 'postcode', 'city', 'twoFactorConfigured' ];
   for (let key of keys) {
     result[ key ] = mapKey( key );
   }


### PR DESCRIPTION
(Extra) Vragen bij deze PR:

**Endpoint voor 2FA-status**
Ik heb een endpoint gemaakt in de API server om te controleren of een gebruiker 2FA heeft ingesteld. Is dit de beste manier om dit te implementeren?
Ik heb geen ander endpoint kunnen vinden om deze informatie van de gebruiker op te halen, aangezien deze in de auth database staat. Ik zag wel een `/api/admin/user/:userId-endpoint` in de auth server, maar requests naar dit endpoint waren unauthorized.

**Controle op 2FA-status**
Om te bepalen of een gebruiker 2FA heeft ingesteld, controleren we nu of `authUser?.twoFactorConfigured === 1`. Is dit voldoende informatie om te kunnen zeggen dat een user 2FA ingesteld heeft?