### PR TITLE
Fix helm values and add helm linter to CI

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -2,8 +2,6 @@ name: Release Helm Charts
 
 on:
   push:
-    branches:
-      - main
     paths:
       - 'charts/**'
 
@@ -31,6 +29,7 @@ jobs:
 
   release:
     needs: lint
+    if: github.ref == 'refs/heads/main'
     # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
     # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
     permissions:

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -8,7 +8,29 @@ on:
       - 'charts/**'
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.5.4
+
+      - name: Lint Charts
+        run: |
+          for dir in $(ls -d charts/*/); do
+          # remove trailing slash from dir
+            dir=$(echo $dir | sed 's:/*$::')
+            helm lint $dir -f $dir/values.yaml --strict || exit 1
+          done
+
   release:
+    needs: lint
     # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
     # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
     permissions:

--- a/charts/openstad-headless/Chart.yaml
+++ b/charts/openstad-headless/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.24
+version: 0.0.25
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/openstad-headless/values.yaml
+++ b/charts/openstad-headless/values.yaml
@@ -114,6 +114,12 @@ persistence:
   #configure the cloud-specific storageClassName, will use the clouds default if not specified
   storageClassName:
   annotations: {}
+  image:
+    size: 1Gi
+  docs:
+    size: 1Gi
+  cms:
+    size: 1Gi
 
 admin:
   # Configure how many replicas exists of this service


### PR DESCRIPTION
This PR ensure the sizes for image, docs and cms PVCs are defined in the default values.yaml.

A helm linting job is added to the CI for every branch, but releases will only happen on the `main` branch still.