### PR TITLE
feat: Tag functionalities comments widget

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/comments/[id]/extraFields.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/comments/[id]/extraFields.tsx
@@ -1,0 +1,282 @@
+import { Button } from '@/components/ui/button';
+import {
+  Form,
+  FormControl, FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+
+import { Checkbox } from '@/components/ui/checkbox';
+import { Separator } from '@/components/ui/separator';
+import { Heading } from '@/components/ui/typography';
+import useTags from '@/hooks/use-tags';
+import { EditFieldProps } from '@/lib/form-widget-helpers/EditFieldProps';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import * as z from 'zod';
+import { useEffect, useState } from 'react';
+import _ from 'lodash';
+import { handleTagCheckboxGroupChange } from '@/lib/form-widget-helpers/TagGroupHelper';
+import { useFieldDebounce } from '@/hooks/useFieldDebounce';
+import { CheckboxList } from '@/components/checkbox-list';
+import {ArgumentWidgetTabProps} from "@/pages/projects/[project]/widgets/comments/[id]/index";
+
+const formSchema = z.object({
+  extraFieldsTagGroups: z
+    .array(
+      z.object({
+        type: z.string(),
+        label: z.string().optional(),
+        multiple: z.boolean().default(false),
+      })
+    )
+    .refine((value) => value.some((item) => item), {
+      message: 'You have to select at least one item.',
+    }),
+  defaultTags: z.string().optional()
+});
+
+type Tag = {
+  id: number;
+  name: string;
+  type: string;
+};
+
+export default function ArgumentsExtraFields(
+  props: ArgumentWidgetTabProps &
+    EditFieldProps<ArgumentWidgetTabProps>,
+) {
+  type FormData = z.infer<typeof formSchema>;
+  const { data: tags } = useTags(props.projectId);
+  const [tagGroupNames, setGroupedNames] = useState<string[]>([]);
+
+  const { onFieldChange } = useFieldDebounce(props.onFieldChanged);
+
+  useEffect(() => {
+    if (Array.isArray(tags)) {
+      const fetchedTags = tags as Array<Tag>;
+      const groupNames = _.chain(fetchedTags).map('type').uniq().value();
+      setGroupedNames(groupNames);
+    }
+  }, [tags]);
+
+  async function onSubmit(values: FormData) {
+    props.updateConfig({ ...props, ...values });
+  }
+
+  const form = useForm<FormData>({
+    resolver: zodResolver<any>(formSchema),
+    defaultValues: {
+      extraFieldsTagGroups: props.extraFieldsTagGroups || [],
+      defaultTags: props?.defaultTags || '',
+    },
+  });
+
+  return (
+    <div className="p-6 bg-white rounded-md">
+      <Form {...form}>
+        <Heading size="xl">Extra Velden</Heading>
+        <Separator className="my-4" />
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="lg:w-full grid grid-cols-1 gap-4">
+
+          <FormField
+            control={form.control}
+            name="extraFieldsTagGroups"
+            render={() => (
+              <FormItem className="col-span-full">
+                <div>
+                  <FormLabel>Selecteer de gewenste tag groepen</FormLabel>
+                  <FormDescription>
+                    Selecteer de gewenste tag groepen die als extra velden verschijnen.<br />
+                    Het label veld fungeert als een titel boven de dropdown van het extra veld.
+                  </FormDescription>
+                </div>
+                <div className="grid grid-cols-1 lg:grid-cols-1 lg:grid-cols-3 gap-x-4 gap-y-4">
+                  {(tagGroupNames || []).map((groupName, index) => (
+                    <>
+                      <FormField
+                        key={`parent${groupName}`}
+                        control={form.control}
+                        name="extraFieldsTagGroups"
+                        render={({ field }) => {
+                          return (
+                            <FormItem
+                              key={groupName}
+                              className="flex flex-row items-center space-x-3 space-y-0">
+                              <FormControl>
+                                <Checkbox
+                                  checked={
+                                    field.value?.findIndex(
+                                      (el) => el.type === groupName
+                                    ) > -1
+                                  }
+                                  onCheckedChange={(checked: any) => {
+                                    const updatedFields =
+                                      handleTagCheckboxGroupChange(
+                                        groupName,
+                                        checked,
+                                        field.value,
+                                        'type'
+                                      );
+
+                                    field.onChange(updatedFields);
+                                    props.onFieldChanged(
+                                      field.name,
+                                      updatedFields
+                                    );
+                                  }}
+                                />
+                              </FormControl>
+                              <FormLabel className="font-normal">
+                                {groupName}
+                              </FormLabel>
+                            </FormItem>
+                          );
+                        }}
+                      />
+
+                      <FormField
+                        key={`parent-label-input${groupName}`}
+                        control={form.control}
+                        name="extraFieldsTagGroups"
+                        render={({ field }) => {
+
+                          const defaultValue = field.value.find(
+                            (g) => g.type === groupName
+                          )?.label;
+
+                          return (
+                            <FormItem
+                              key={`${groupName}-label-input`}
+                              className="flex flex-row items-center space-x-3 space-y-0">
+                              <FormControl>
+                                <Input
+                                  placeholder="Groep label"
+                                  key={`${groupName}-label-input-field`}
+                                  defaultValue={defaultValue}
+                                  disabled={
+                                    field.value.find(
+                                      (g) => g.type === groupName
+                                    ) === undefined
+                                  }
+                                  onChange={(e) => {
+                                    const groups = field.value;
+
+                                    const groupIndex = groups.findIndex(
+                                      (g) => g.type === groupName
+                                    );
+
+                                    const existingGroup = groups[groupIndex];
+                                    existingGroup.label = e.target.value;
+                                    groups[groupIndex] = existingGroup;
+                                    field.onChange(groups);
+                                    onFieldChange(field.name, groups);
+                                  }}
+                                />
+                              </FormControl>
+                            </FormItem>
+                          );
+                        }}
+                      />
+
+                      <FormField
+                        key={`parent${groupName}-multiple`}
+                        control={form.control}
+                        name="extraFieldsTagGroups"
+                        render={({ field }) => {
+                          return (
+                            <FormItem
+                              key={groupName}
+                              className="flex flex-row items-center space-x-3 space-y-0">
+                              <FormControl>
+                                <Checkbox
+                                  disabled={
+                                    field.value.find(
+                                      (g) => g.type === groupName
+                                    ) === undefined
+                                  }
+                                  checked={
+                                    field.value?.findIndex(
+                                      (el) =>
+                                        el.type === groupName && el.multiple
+                                    ) > -1
+                                  }
+                                  onCheckedChange={(checked: any) => {
+                                    const groups = handleTagCheckboxGroupChange(
+                                      groupName,
+                                      checked,
+                                      field.value,
+                                      'multiple'
+                                    );
+                                    field.onChange(groups);
+                                    props.onFieldChanged(field.name, groups);
+                                  }}
+                                />
+                              </FormControl>
+                              <FormLabel className="font-normal">
+                                Mogen er meerdere tags geselecteerd worden?
+                              </FormLabel>
+                            </FormItem>
+                          );
+                        }}
+                      />
+                    </>
+                  ))}
+                </div>
+              </FormItem>
+            )}
+          />
+
+          <Separator className="my-4" />
+
+          <FormField
+            control={form.control}
+            name="defaultTags"
+            render={() => (
+              <FormItem className="col-span-full">
+                <FormLabel>Selecteer de standaard tags</FormLabel>
+                <FormDescription>
+                  Selecteer de standaard tags die aan reacties worden toegevoegd zonder dat de gebruiker dit ziet.
+                </FormDescription>
+                <CheckboxList
+                  form={form}
+                  fieldName="defaultTags"
+                  fieldLabel="Select default tags"
+                  label={(t: Tag) => t.name}
+                  keyForGrouping="type"
+                  keyPerItem={(t: Tag) => `${t.id}`}
+                  items={tags || []}
+                  layout="vertical"
+                  selectedPredicate={(t) =>
+                    // @ts-ignore
+                    form
+                      ?.getValues('defaultTags')
+                      ?.split(',')
+                      ?.findIndex((tg) => tg === `${t.id}`) > -1
+                  }
+                  onValueChange={(tag, checked) => {
+                    const ids = form.getValues('defaultTags')?.split(',') ?? [];
+                    const idsToSave = (checked
+                      ? [...ids, tag.id]
+                      : ids.filter((id) => id !== `${tag.id}`)).join(',');
+
+                    form.setValue('defaultTags', idsToSave);
+                    props.onFieldChanged("defaultTags", idsToSave);
+                  }}
+                />
+              </FormItem>
+            )}
+          />
+
+          <Button className="w-fit col-span-full" type="submit">
+            Opslaan
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/apps/admin-server/src/pages/projects/[project]/widgets/comments/[id]/include.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/comments/[id]/include.tsx
@@ -1,0 +1,132 @@
+import { CheckboxList } from '@/components/checkbox-list';
+import { Button } from '@/components/ui/button';
+import {
+  Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage
+} from '@/components/ui/form';
+import { Separator } from '@/components/ui/separator';
+import { Heading } from '@/components/ui/typography';
+import useTags from '@/hooks/use-tags';
+import { EditFieldProps } from '@/lib/form-widget-helpers/EditFieldProps';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import * as z from 'zod';
+import React from "react";
+import {Spacer} from "@/components/ui/spacer";
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from "@/components/ui/select";
+import {ArgumentWidgetTabProps} from "@/pages/projects/[project]/widgets/comments/[id]/index";
+
+const formSchema = z.object({
+  includeOrExclude: z.string().optional(),
+  onlyIncludeOrExcludeTagIds: z.string().optional()
+});
+
+export default function ArgumentsInclude(
+  props: ArgumentWidgetTabProps &
+  EditFieldProps<ArgumentWidgetTabProps>
+) {
+  type FormData = z.infer<typeof formSchema>;
+  async function onSubmit(values: FormData) {
+    props.updateConfig({ ...props, ...values });
+  }
+
+  const { data: loadedTags } = useTags(props.projectId);
+  const tags = (loadedTags || []) as Array<{
+    id: string;
+    name: string;
+    type?: string;
+  }>;
+
+  const form = useForm<FormData>({
+    resolver: zodResolver<any>(formSchema),
+    defaultValues: {
+      includeOrExclude: props?.includeOrExclude || 'include',
+      onlyIncludeOrExcludeTagIds: props?.onlyIncludeOrExcludeTagIds || '',
+    },
+  });
+
+  return (
+    <div className="p-6 bg-white rounded-md">
+      <Form {...form} className="p-6 bg-white rounded-md">
+        <Heading size="xl">Inclusief/Exclusief</Heading>
+        <Separator className="my-4" />
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="grid gap-4">
+
+          <FormField
+            control={form.control}
+            name="includeOrExclude"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Toon reacties gekoppeld aan onderstaande tags
+                </FormLabel>
+                <FormDescription>
+                  Gebruik het selectievakje om te kiezen hoe de geselecteerde tags de weergave van reacties
+                  beïnvloeden:
+                  <br/>
+                  <br/>
+                  Maak je keuze op basis van hoe je de reacties wilt filteren in relatie tot de geselecteerde tags.
+                  <br/>
+                  <br/>
+                </FormDescription>
+                <Select
+                  onValueChange={field.onChange}
+                  value={field.value || 'include'}
+                >
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Inclusief" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="include"><strong>Inclusief</strong>: Als je deze optie kiest, worden alleen de
+                      reacties getoond die gekoppeld zijn aan de
+                      geselecteerde tags.</SelectItem>
+                    <SelectItem value="exclude"><strong>Exclusief</strong>: Als je deze optie kiest, worden juist de
+                      reacties die gekoppeld zijn aan de
+                      geselecteerde tags niet getoond.</SelectItem>
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Spacer />
+
+          <CheckboxList
+            form={form}
+            fieldName="onlyIncludeOrExcludeTagIds"
+            fieldLabel="Geef enkel de resources met de volgende tags weer:"
+            label={(t) => t.name}
+            keyForGrouping="type"
+            keyPerItem={(t) => `${t.id}`}
+            items={tags}
+            selectedPredicate={(t) =>
+              // @ts-ignore
+              form
+                ?.getValues('onlyIncludeOrExcludeTagIds')
+                ?.split(',')
+                ?.findIndex((tg) => tg === `${t.id}`) > -1
+            }
+            onValueChange={(tag, checked) => {
+              const ids = form.getValues('onlyIncludeOrExcludeTagIds')?.split(',') ?? [];
+
+              const idsToSave = (checked
+                ? [...ids, tag.id]
+                : ids.filter((id) => id !== `${tag.id}`)).join(',');
+
+              form.setValue('onlyIncludeOrExcludeTagIds', idsToSave);
+              props.onFieldChanged("onlyIncludeOrExcludeTagIds", idsToSave);
+            }}
+          />
+
+          <Button className="w-fit col-span-full" type="submit">
+            Opslaan
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/apps/admin-server/src/pages/projects/[project]/widgets/comments/[id]/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/comments/[id]/index.tsx
@@ -21,6 +21,8 @@ import {
 import WidgetPublish from '@/components/widget-publish';
 import { BaseProps, ProjectSettingProps } from '@openstad-headless/types';
 import ArgumentsSorting from "@/pages/projects/[project]/widgets/comments/[id]/sorting";
+import ArgumentsExtraFields from "@/pages/projects/[project]/widgets/comments/[id]/extraFields";
+import ArgumentsInclude from "@/pages/projects/[project]/widgets/comments/[id]/include";
 export const getServerSideProps = withApiUrl;
 
 // Use these props in the widget tabs
@@ -64,6 +66,8 @@ export default function WidgetArguments({ apiUrl }: WithApiUrlProps) {
               <TabsTrigger value="general">Algemeen</TabsTrigger>
               <TabsTrigger value="list">Titel</TabsTrigger>
               <TabsTrigger value="form">Formulier</TabsTrigger>
+              <TabsTrigger value="extraFields">Extra velden</TabsTrigger>
+              <TabsTrigger value="include">Inclusief / exclusief</TabsTrigger>
               <TabsTrigger value="sorting">Sorteren</TabsTrigger>
               <TabsTrigger value="publish">Publiceren</TabsTrigger>
             </TabsList>
@@ -107,6 +111,42 @@ export default function WidgetArguments({ apiUrl }: WithApiUrlProps) {
             <TabsContent value="form" className="p-0">
               {previewConfig ? (
                 <ArgumentsForm
+                  {...previewConfig}
+                  updateConfig={(config) =>
+                    updateConfig({ ...widget.config, ...config })
+                  }
+                  onFieldChanged={(key, value) => {
+                    if (previewConfig) {
+                      updatePreview({
+                        ...previewConfig,
+                        [key]: value,
+                      });
+                    }
+                  }}
+                />
+              ) : null}
+            </TabsContent>
+            <TabsContent value="extraFields" className="p-0">
+              {previewConfig ? (
+                <ArgumentsExtraFields
+                  {...previewConfig}
+                  updateConfig={(config) =>
+                    updateConfig({ ...widget.config, ...config })
+                  }
+                  onFieldChanged={(key, value) => {
+                    if (previewConfig) {
+                      updatePreview({
+                        ...previewConfig,
+                        [key]: value,
+                      });
+                    }
+                  }}
+                />
+              ) : null}
+            </TabsContent>
+            <TabsContent value="include" className="p-0">
+              {previewConfig ? (
+                <ArgumentsInclude
                   {...previewConfig}
                   updateConfig={(config) =>
                     updateConfig({ ...widget.config, ...config })

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/index.tsx
@@ -26,6 +26,8 @@ import ArgumentsForm from '../../comments/[id]/form';
 import { LikeWidgetTabProps } from '../../likes/[id]';
 import { extractConfig } from '@/lib/sub-widget-helper';
 import WidgetResourceDetailDocumentMap from "@/pages/projects/[project]/widgets/resourcedetail/[id]/document-map";
+import ArgumentsExtraFields from "@/pages/projects/[project]/widgets/comments/[id]/extraFields";
+import ArgumentsInclude from "@/pages/projects/[project]/widgets/comments/[id]/include";
 export const getServerSideProps = withApiUrl;
 
 export default function WidgetResourceDetail({ apiUrl }: WithApiUrlProps) {
@@ -112,6 +114,8 @@ export default function WidgetResourceDetail({ apiUrl }: WithApiUrlProps) {
                     <TabsTrigger value="general">Algemeen</TabsTrigger>
                     <TabsTrigger value="list">Lijst</TabsTrigger>
                     <TabsTrigger value="form">Formulier</TabsTrigger>
+                    <TabsTrigger value="extraFields">Extra velden</TabsTrigger>
+                    <TabsTrigger value="include">Inclusief / exclusief</TabsTrigger>
                   </TabsList>
                   <TabsContent value="general" className="p-0">
                     <ArgumentsGeneral
@@ -192,8 +196,38 @@ export default function WidgetResourceDetail({ apiUrl }: WithApiUrlProps) {
                         })}
                       />
                     </div>
-
                   </TabsContent>
+
+                  <TabsContent value="extraFields" className="p-0">
+                    <ArgumentsExtraFields
+                      {...extractConfig<
+                        ResourceDetailWidgetProps,
+                        ArgumentWidgetTabProps
+                      >({
+                        subWidgetKey: 'commentsWidget',
+                        previewConfig: previewConfig,
+                        updateConfig,
+                        updatePreview,
+                      })}
+                      projectId={ projectId as string }
+                    />
+                  </TabsContent>
+
+                  <TabsContent value="include" className="p-0">
+                    <ArgumentsInclude
+                      {...extractConfig<
+                        ResourceDetailWidgetProps,
+                        ArgumentWidgetTabProps
+                      >({
+                        subWidgetKey: 'commentsWidget',
+                        previewConfig: previewConfig,
+                        updateConfig,
+                        updatePreview,
+                      })}
+                      projectId={ projectId as string }
+                    />
+                  </TabsContent>
+
                 </Tabs>
               )}
             </TabsContent>

--- a/apps/api-server/src/routes/api/comment.js
+++ b/apps/api-server/src/routes/api/comment.js
@@ -213,7 +213,16 @@ router.route('/:commentId(\\d+)')
     comment
       .authorizeData(req.body, 'update')
       .update(req.body)
-      .then(result => {
+      .then(async result => {
+        if ( !comment.location && !comment.parentId ) {
+            let tags = req.body.tags || [];
+            if (!Array.isArray(tags)) tags = [tags];
+            tags = tags.filter(tag => !Number.isNaN(parseInt(tag)));
+            tags = tags.map(tag => parseInt(tag));
+            tags = tags.filter((value, index) => tags.indexOf(value) === index);
+            await result.setTags(tags);
+        }
+
         res.json(result);
       })
       .catch(next);

--- a/packages/comments/src/types/comment-form-props.ts
+++ b/packages/comments/src/types/comment-form-props.ts
@@ -1,6 +1,6 @@
-import {Comment} from '@openstad-headless/types';
+import {BaseProps, Comment} from '@openstad-headless/types';
 
-export type CommentFormProps = {
+export type CommentFormProps = BaseProps & {
   activeMode?: 'edit' | 'reply' | '';
   comment?: Comment;
   descriptionMinLength?: number;
@@ -15,4 +15,5 @@ export type CommentFormProps = {
   maxCharactersWarning?: string;
   minCharactersError?: string;
   maxCharactersError?: string;
+  extraFieldsTagGroups?: Array<{ type: string; label?: string; multiple: boolean }>;
 };

--- a/packages/resource-detail/src/resource-detail.tsx
+++ b/packages/resource-detail/src/resource-detail.tsx
@@ -496,9 +496,14 @@ function ResourceDetail({
             closedText={props.commentsWidget?.closedText}
             itemsPerPage={props.commentsWidget?.itemsPerPage}
             displayPagination={props.commentsWidget?.displayPagination}
+            extraFieldsTagGroups={ props.commentsWidget?.extraFieldsTagGroups }
+            defaultTags={ props.commentsWidget?.defaultTags }
+            includeOrExclude={ props.commentsWidget?.includeOrExclude }
+            onlyIncludeOrExcludeTagIds={ props.commentsWidget?.onlyIncludeOrExcludeTagIds }
             sentiment={useSentiments[0]}
           />
-
+          includeOrExclude
+          onlyIncludeOrExcludeTagIds
           {useSentiments?.length > 1 && (
             <Comments
               {...props}
@@ -513,6 +518,10 @@ function ResourceDetail({
               closedText={props.commentsWidget_multiple?.closedText}
               itemsPerPage={props.commentsWidget?.itemsPerPage}
               displayPagination={props.commentsWidget?.displayPagination}
+              extraFieldsTagGroups={ props.commentsWidget?.extraFieldsTagGroups }
+              defaultTags={ props.commentsWidget?.defaultTags }
+              includeOrExclude={ props.commentsWidget?.includeOrExclude }
+              onlyIncludeOrExcludeTagIds={ props.commentsWidget?.onlyIncludeOrExcludeTagIds }
               sentiment={useSentiments[1]}
             />
           )}

--- a/packages/types/comment.ts
+++ b/packages/types/comment.ts
@@ -19,6 +19,12 @@ export type Comment = {
   user?: { displayName: string, role: string};
   submitLike: () => void;
 
+  tags?: Array<{
+    id: string;
+    name: string;
+    type: string;
+  }>;
+
   can?: {
     reply: boolean;
     delete: boolean;

--- a/packages/ui/src/form-elements/select/index.tsx
+++ b/packages/ui/src/form-elements/select/index.tsx
@@ -7,9 +7,9 @@ import {
     Select,
     SelectOption
 } from "@utrecht/component-library-react";
-import React from "react";
+import React, { useState } from "react";
 import {FC} from "react";
-import { Spacer } from '@openstad-headless/ui/src';
+import {MultiSelect, Spacer} from '@openstad-headless/ui/src';
 
 export type SelectFieldProps = {
     title?: string;
@@ -28,6 +28,8 @@ export type SelectFieldProps = {
     infoImage?: string;
     randomId?: string;
     fieldInvalid?: boolean;
+    multiple?: boolean;
+    defaultValue?: string | string[];
 }
 
 const SelectField: FC<SelectFieldProps> = ({
@@ -45,6 +47,8 @@ const SelectField: FC<SelectFieldProps> = ({
       infoImage = '',
       randomId = '',
       fieldInvalid = false,
+      multiple = false,
+      defaultValue = [],
 }) => {
     choices = choices.map((choice) => {
       if (typeof choice === 'string') {
@@ -60,6 +64,12 @@ const SelectField: FC<SelectFieldProps> = ({
             return <div dangerouslySetInnerHTML={{__html: html}}/>;
         }
     }
+
+    const initialSelected = multiple
+      ? defaultValue
+      : (Array.isArray(defaultValue) && defaultValue.length > 0 ? defaultValue[0] : '');
+
+    const [selected, setSelected] = useState<string | string[]>(initialSelected);
 
     return (
         <FormField type="select">
@@ -95,27 +105,62 @@ const SelectField: FC<SelectFieldProps> = ({
             )}
 
             <Paragraph className="utrecht-form-field__input">
+              { multiple ? (
+                  <MultiSelect
+                    label={defaultOption}
+                    options={choices.map(choice => ({
+                      value: choice.value,
+                      label: choice.label,
+                      checked: Array.isArray(selected) ? selected.includes(choice.value) : false,
+                    }))}
+                    onItemSelected={(optionValue: string) => {
+                      let newSelected = Array.isArray(selected) ? [...selected] : [];
+                      if (newSelected.includes(optionValue)) {
+                        newSelected = newSelected.filter(v => v !== optionValue);
+                      } else {
+                        newSelected.push(optionValue);
+                      }
+                      setSelected(newSelected);
+                      if (onChange) {
+                        onChange({
+                          name: fieldKey,
+                          value: newSelected?.join(","),
+                        });
+                      }
+                    }}
+                  />
+              ) : (
                 <Select
-                    className="form-item"
-                    name={fieldKey}
-                    required={fieldRequired}
-                    onChange={(e) => onChange ? onChange({
+                  className="form-item"
+                  name={fieldKey}
+                  required={fieldRequired}
+                  onChange={(e) => {
+                    setSelected(e.target.value);
+                    if (onChange) {
+                      onChange({
                         name: fieldKey,
                         value: e.target.value
-                    }) : null }
-                    disabled={disabled}
-                    aria-invalid={fieldInvalid}
-                    aria-describedby={`${randomId}_error`}
+                      })
+                    }
+                  }}
+                  disabled={disabled}
+                  aria-invalid={fieldInvalid}
+                  aria-describedby={`${randomId}_error`}
+                  value={ selected }
                 >
-                    <SelectOption value="">
-                        {defaultOption}
+                  <SelectOption value="">
+                    {defaultOption}
+                  </SelectOption>
+                  {choices?.map((value, index) => (
+                    <SelectOption
+                      key={index}
+                      value={value && value.value}
+                    >
+                      {value && value.label}
                     </SelectOption>
-                    {choices?.map((value, index) => (
-                        <SelectOption value={value && value.value} key={index}>
-                            {value && value.label}
-                        </SelectOption>
-                    ))}
+                  ))}
                 </Select>
+              ) }
             </Paragraph>
         </FormField>
     );

--- a/packages/ui/src/multiselect/index.css
+++ b/packages/ui/src/multiselect/index.css
@@ -69,3 +69,11 @@
     overflow: auto;
     box-shadow: 0 0 6px hsl(0deg 0% 0% / 16.08%);
 }
+
+.osc .multi-select .multiselect-container .utrecht-form-field__label--checkbox{
+    display: flex;
+}
+
+.osc .multi-select .multiselect-container .utrecht-checkbox.utrecht-checkbox--html-input.utrecht-checkbox--custom {
+    order: 0;
+}


### PR DESCRIPTION
### Tag support to the Comments widget

This PR adds support for assigning tags to reactions to the widgets 'comments' and 'resource detail'.

Key updates:
- **Admin UI**: Tags can now be configured in the admin interface for reactions (based on existing tag logic).
- **Frontend**: Reactions components now support tag selection via dropdowns. Selected tags are displayed and passed along when submitting a reaction.
- **Filtering**: Tag-based include and exclude filtering added.