### PR TITLE
fix(auth): add phone hash salt to secrets

### DIFF
--- a/charts/openstad-headless/templates/auth/deployment.yaml
+++ b/charts/openstad-headless/templates/auth/deployment.yaml
@@ -154,7 +154,10 @@ spec:
             value: "{{ .Values.auth.cookie.secureOff | default "no" }}"
 
           - name: PHONE_HASH_SALT
-            value: {{ .Values.auth.phoneHashSalt | default ( randAlphaNum 12 | quote ) }}
+            valueFrom:
+              secretKeyRef:
+                key: phone_hash_salt
+                name: {{ template "openstad.auth.secret.fullname" . }}
 
           - name: API_URL
             value: https://{{ template "openstad.api.url" . }}

--- a/charts/openstad-headless/templates/secrets/auth-secret.yaml
+++ b/charts/openstad-headless/templates/secrets/auth-secret.yaml
@@ -13,3 +13,4 @@ data:
   fixed_token: {{ .Values.secrets.database.auth.credentials.fixedToken | default ( randAlphaNum 20  ) | b64enc }}
   admin_client_id: {{ .Values.secrets.database.auth.credentials.adminClientId | default ( randAlphaNum 20  ) | b64enc }}
   admin_client_secret: {{ .Values.secrets.database.auth.credentials.adminClientSecret | default ( randAlphaNum 20 ) | b64enc }}
+  phone_hash_salt: {{ .Values.secrets.auth.phoneHashSalt | default ( randAlphaNum 12 | quote ) }}

--- a/charts/openstad-headless/values.yaml
+++ b/charts/openstad-headless/values.yaml
@@ -258,9 +258,6 @@ auth:
   fromName:
   fromEmail:
 
-  # Salt settings
-  phoneHashSalt:
-
   # Cookie settings
   cookie:
     secureOff:
@@ -377,7 +374,7 @@ image:
     ccPrefetcher: 20
     # Number of concurrent http requests. Anything to exceed this value will result in a 503 (too busy), to avoid an indefinite pileup
     ccRequests: 100
-  
+
   hqOriginalMaxPixels: 160000
 
   # Inject extra environment variables
@@ -491,6 +488,7 @@ secrets:
 
   auth:
     sessionSecret:
+    phoneHashSalt:
 
   cms:
     apiKey:


### PR DESCRIPTION
This fixes an issue where the `PHONE_HASH_SALT` would be randomized for every deployment, if it was not set in the values.