### PR TITLE
Add choiceguide result count to counter widget

### DIFF
--- a/apps/admin-server/src/components/ui/form-object-select-field.tsx
+++ b/apps/admin-server/src/components/ui/form-object-select-field.tsx
@@ -19,7 +19,7 @@ type Props<T> = {
   items: Array<T>;
   keyForValue: keyof T;
   onFieldChanged?: (key: string, value: keyof T) => void;
-  label?: (item: T) => string;
+  label?: (item: T & Record<string, any>) => string;
   noSelection?: string;
 };
 
@@ -34,7 +34,7 @@ export const FormObjectSelectField = <T extends { [key: string]: any }>({
       render={({ field }) => (
         <FormItem>
           <FormLabel>
-            {props.fieldLabel} 
+            {props.fieldLabel}
             {props.fieldInfo && <InfoDialog content={props.fieldInfo} />}
           </FormLabel>
           {ObjectListSelect<T>({

--- a/apps/admin-server/src/hooks/use-choice-guide-widgets.tsx
+++ b/apps/admin-server/src/hooks/use-choice-guide-widgets.tsx
@@ -1,7 +1,7 @@
 import useSWR from 'swr';
 import {validateProjectNumber} from "@/lib/validateProjectNumber";
 
-export default function useChoiceGuides(projectId?: string) {
+export default function useChoiceGuideWidgets(projectId?: string) {
   const projectNumber: number | undefined = validateProjectNumber(projectId);
 
   const url = `/api/openstad/api/project/${projectNumber}/choicesguide/widgets`;

--- a/apps/admin-server/src/hooks/use-choiceguides.tsx
+++ b/apps/admin-server/src/hooks/use-choiceguides.tsx
@@ -4,7 +4,7 @@ import {validateProjectNumber} from "@/lib/validateProjectNumber";
 export default function useChoiceGuides(projectId?: string) {
   const projectNumber: number | undefined = validateProjectNumber(projectId);
 
-  const url = `/api/openstad/api/project/${projectNumber}/choicesguide/`;
+  const url = `/api/openstad/api/project/${projectNumber}/choicesguide/widgets`;
 
   const choiceGuidesSwr = useSWR(projectNumber ? url : null);
 

--- a/apps/admin-server/src/pages/projects/[project]/widgets/activity/[id]/general.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/activity/[id]/general.tsx
@@ -25,7 +25,6 @@ import { ActivityWidgetProps } from '@openstad-headless/activity/src/activity';
 import { EditFieldProps } from '@/lib/form-widget-helpers/EditFieldProps';
 import { useFieldDebounce } from '@/hooks/useFieldDebounce';
 import { useRouter } from 'next/router';
-import useChoiceGuides from '@/hooks/use-choiceguides';
 import useResources from '@/hooks/use-resources';
 
 const formSchema = z.object({
@@ -112,7 +111,7 @@ export default function ActivityDisplay(
             </FormItem>
           )}
         />
-        
+
         <hr />
 
         <FormField

--- a/apps/admin-server/src/pages/projects/[project]/widgets/counter/[id]/general.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/counter/[id]/general.tsx
@@ -41,7 +41,7 @@ const formSchema = z.object({
     'votedUsers',
     'static',
     'argument',
-    'choiceguideresults',
+    'choiceGuideResults',
   ]),
   opinion: z.string().optional(),
   amount: z.coerce.number().optional(),
@@ -165,7 +165,7 @@ export default function CounterDisplay(
                   </SelectItem>
                   <SelectItem value="static">Vaste waarde</SelectItem>
                   <SelectItem value="argument">Aantal reacties</SelectItem>
-                  <SelectItem value="choiceguideresults">
+                  <SelectItem value="choiceGuideResults">
                     Aantal inzendingen keuzewijzer
                   </SelectItem>
                 </SelectContent>
@@ -239,7 +239,7 @@ export default function CounterDisplay(
           />
         ) : null}
 
-        {props.counterType === 'choiceguideresults' ? (
+        {props.counterType === 'choiceGuideResults' ? (
           <FormObjectSelectField
             form={form}
             fieldName="widgetId"

--- a/apps/admin-server/src/pages/projects/[project]/widgets/counter/[id]/general.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/counter/[id]/general.tsx
@@ -41,7 +41,6 @@ const formSchema = z.object({
     'votedUsers',
     'static',
     'argument',
-    'submission',
     'choiceguideresults',
   ]),
   opinion: z.string().optional(),

--- a/apps/admin-server/src/pages/projects/[project]/widgets/counter/[id]/general.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/counter/[id]/general.tsx
@@ -25,7 +25,7 @@ import { CounterWidgetProps } from '@openstad-headless/counter/src/counter';
 import { EditFieldProps } from '@/lib/form-widget-helpers/EditFieldProps';
 import { useFieldDebounce } from '@/hooks/useFieldDebounce';
 import { useRouter } from 'next/router';
-import useChoiceGuides from '@/hooks/use-choiceguides';
+import useChoiceGuideWidgets from '@/hooks/use-choice-guide-widgets';
 import useResources from '@/hooks/use-resources';
 import { FormObjectSelectField } from '@/components/ui/form-object-select-field';
 import useTags from "@/hooks/use-tags";
@@ -62,7 +62,7 @@ export default function CounterDisplay(
   const router = useRouter();
 
   const projectId = router.query.project as string;
-  const { data: choiceGuides } = useChoiceGuides(projectId as string);
+  const { data: choiceGuides } = useChoiceGuideWidgets(projectId as string);
   const { data: resourceList } = useResources(projectId as string);
   const resources = resourceList as { id: string; title: string }[];
 

--- a/apps/admin-server/src/pages/projects/[project]/widgets/counter/[id]/general.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/counter/[id]/general.tsx
@@ -42,11 +42,12 @@ const formSchema = z.object({
     'static',
     'argument',
     'submission',
+    'choiceguideresults',
   ]),
   opinion: z.string().optional(),
   amount: z.coerce.number().optional(),
   id: z.string().optional(),
-  choiceGuideId: z.string().optional(),
+  widgetId: z.string().optional(),
   resourceId: z.string().optional(),
   includeOrExclude: z.string().optional(),
   onlyIncludeOrExcludeTagIds: z.string().optional()
@@ -83,7 +84,7 @@ export default function CounterDisplay(
       label: props?.label || 'Hoeveelheid',
       url: props?.url || '',
       opinion: props?.opinion || '',
-      choiceGuideId: props?.choiceGuideId,
+      widgetId: props?.widgetId,
       resourceId: props?.resourceId,
       includeOrExclude: props?.includeOrExclude || 'include',
       onlyIncludeOrExcludeTagIds: props?.onlyIncludeOrExcludeTagIds || '',
@@ -165,7 +166,7 @@ export default function CounterDisplay(
                   </SelectItem>
                   <SelectItem value="static">Vaste waarde</SelectItem>
                   <SelectItem value="argument">Aantal reacties</SelectItem>
-                  <SelectItem value="submission">
+                  <SelectItem value="choiceguideresults">
                     Aantal inzendingen keuzewijzer
                   </SelectItem>
                 </SelectContent>
@@ -239,14 +240,14 @@ export default function CounterDisplay(
           />
         ) : null}
 
-        {props.counterType === 'submission' ? (
+        {props.counterType === 'choiceguideresults' ? (
           <FormObjectSelectField
             form={form}
-            fieldName="choiceGuideId"
+            fieldName="widgetId"
             fieldLabel="Gewenste keuzewijzer"
             items={choiceGuides}
             keyForValue="id"
-            label={(ch) => `${ch.id}`}
+            label={(ch) => `${ch.description} (Widget ID ${ch.id})`}
             onFieldChanged={props.onFieldChanged}
             noSelection="Selecteer uw gewenste keuzewijzer"
           />

--- a/apps/api-server/src/routes/api/choicesguide.js
+++ b/apps/api-server/src/routes/api/choicesguide.js
@@ -67,6 +67,43 @@ router.route('/:choicesGuideId(\\d+)(/questiongroup/:questionGroupId(\\d+))?/res
 			.catch(next);
 	});
 
+router.route('/widgets')
+	.get(auth.can('ChoicesGuide', 'list'))
+	.get(function (req, res, next){
+		db.Widget
+			.findAll({
+				attributes: ['id', 'description'],
+				where: {
+					projectId: req.params.projectId,
+					type: 'choiceguide',
+				}
+			})
+			.then((found) => {
+				res.json(found);
+			}).catch(next);
+	});
+
+router.route('/widgets/:widgetId(\\d+)/count')
+	.get(auth.can('ChoicesGuide', 'list'))
+	.get(function (req, res, next) {
+		const widgetId = parseInt(req.params.widgetId);
+		if (!widgetId) return next(createError(404, 'Widget not found'));
+
+		db.ChoicesGuideResult
+			.count({
+				where: {
+					widgetId,
+					projectId: req.params.projectId
+				}
+			})
+			.then((count) => {
+				res.json({ count });
+			})
+			.catch(next);
+	});
+
+
+
 router.route('/')
 	// list choicesguide result
 	// --------------

--- a/packages/counter/src/counter.tsx
+++ b/packages/counter/src/counter.tsx
@@ -20,12 +20,13 @@ export type CounterProps = {
   | 'votedUsers'
   | 'static'
   | 'argument'
-  | 'submission';
+  | 'submission'
+  | 'choiceguideresults';
   label?: string;
   url?: string;
   opinion?: string;
   amount?: number;
-  choiceGuideId?: string;
+  widgetId?: string;
   includeOrExclude?: string;
   onlyIncludeOrExcludeTagIds?: string;
 };
@@ -117,10 +118,10 @@ function Counter({
     data: results,
     error,
     isLoading,
-  } = datastore.useChoiceGuideResults({
+  } = datastore.useChoiceGuideResultCount({
     projectId: props.projectId,
-    choiceGuideId:
-      counterType === 'submission' ? props.choiceGuideId : undefined,
+    widgetId:
+      counterType === 'choiceguideresults' ? props.widgetId : undefined,
   });
 
   if (counterType === 'resource') {
@@ -149,8 +150,8 @@ function Counter({
     amountDisplayed = comments?.length || 0;
   }
 
-  if (counterType === 'submission') {
-    amountDisplayed = results?.length || 0;
+  if (counterType === 'choiceguideresults') {
+    amountDisplayed = results || 0;
   }
 
   const content = () => {

--- a/packages/counter/src/counter.tsx
+++ b/packages/counter/src/counter.tsx
@@ -20,7 +20,7 @@ export type CounterProps = {
   | 'votedUsers'
   | 'static'
   | 'argument'
-  | 'choiceguideresults';
+  | 'choiceGuideResults';
   label?: string;
   url?: string;
   opinion?: string;
@@ -120,7 +120,7 @@ function Counter({
   } = datastore.useChoiceGuideResultCount({
     projectId: props.projectId,
     widgetId:
-      counterType === 'choiceguideresults' ? props.widgetId : undefined,
+      counterType === 'choiceGuideResults' ? props.widgetId : undefined,
   });
 
   if (counterType === 'resource') {
@@ -149,7 +149,7 @@ function Counter({
     amountDisplayed = comments?.length || 0;
   }
 
-  if (counterType === 'choiceguideresults') {
+  if (counterType === 'choiceGuideResults') {
     amountDisplayed = results || 0;
   }
 

--- a/packages/counter/src/counter.tsx
+++ b/packages/counter/src/counter.tsx
@@ -20,7 +20,6 @@ export type CounterProps = {
   | 'votedUsers'
   | 'static'
   | 'argument'
-  | 'submission'
   | 'choiceguideresults';
   label?: string;
   url?: string;

--- a/packages/counter/src/main.tsx
+++ b/packages/counter/src/main.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { CounterWidgetProps, Counter } from './counter.js';
 
 const config: CounterWidgetProps = {
-  counterType: 'choiceguideresults',
+  counterType: 'choiceGuideResults',
   widgetId: '6',
   label: 'Hoeveelheid',
   url: 'https://www.google.com',

--- a/packages/counter/src/main.tsx
+++ b/packages/counter/src/main.tsx
@@ -3,10 +3,15 @@ import ReactDOM from 'react-dom/client';
 import { CounterWidgetProps, Counter } from './counter.js';
 
 const config: CounterWidgetProps = {
-  counterType: 'resource',
+  counterType: 'choiceguideresults',
+  widgetId: '6',
   label: 'Hoeveelheid',
   url: 'https://www.google.com',
   opinion: '',
+  api: {
+    url: 'http://localhost:31410',
+  },
+  projectId: '2'
 };
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/packages/data-store/src/api/choiceGuideResultCount.js
+++ b/packages/data-store/src/api/choiceGuideResultCount.js
@@ -1,0 +1,8 @@
+export default {
+  fetch: async function({ projectId, widgetId }) {
+  
+    let url = `/api/project/${projectId}/choicesguide/widgets/${widgetId}/count`;
+    return this.fetch(url);
+  
+  }
+}

--- a/packages/data-store/src/api/index.js
+++ b/packages/data-store/src/api/index.js
@@ -14,6 +14,7 @@ import submissions from './submissions';
 import commentsByProject from './commentsByProject';
 import choiceGuideResults from './choiceGuideResults';
 import userActivity from './user-activity';
+import choiceGuideResultCount from './choiceGuideResultCount';
 
 const windowGlobal = typeof window !== "undefined" ? window : {};
 
@@ -46,6 +47,10 @@ function API(props = {}) {
 
   self.choiceGuideResults = {
     fetch: choiceGuideResults.fetch.bind(self)
+  }
+  
+  self.choiceGuideResultCount = {
+    fetch: choiceGuideResultCount.fetch.bind(self)
   }
 
   self.comments = {

--- a/packages/data-store/src/hooks/use-choiceguide-result-count.js
+++ b/packages/data-store/src/hooks/use-choiceguide-result-count.js
@@ -5,7 +5,7 @@ export default function useChoiceGuideResultCount({
   let self = this;
 
   if (!widgetId) {
-    return { data: [], error: 'No widgetId given', isLoading: false };
+    return { data: 0, error: 'No widgetId given', isLoading: false };
   }
 
   try {
@@ -20,7 +20,7 @@ export default function useChoiceGuideResultCount({
       document.dispatchEvent(event);
     }
     
-    return { data: data?.count || [], error, isLoading };
+    return { data: data?.count || 0, error, isLoading };
   } catch (e) {
     return {
       data: [],

--- a/packages/data-store/src/hooks/use-choiceguide-result-count.js
+++ b/packages/data-store/src/hooks/use-choiceguide-result-count.js
@@ -23,7 +23,7 @@ export default function useChoiceGuideResultCount({
     return { data: data?.count || 0, error, isLoading };
   } catch (e) {
     return {
-      data: [],
+      data: 0,
       error:
         'Er ging iets mis bij het ophalen van de resultaten, waarschijnlijk ontbreken er een aantal rechten',
       isLoading: false,

--- a/packages/data-store/src/hooks/use-choiceguide-result-count.js
+++ b/packages/data-store/src/hooks/use-choiceguide-result-count.js
@@ -15,8 +15,8 @@ export default function useChoiceGuideResultCount({
     );
 
     if (error) {
-      let error = new Error(error);
-      let event = new window.CustomEvent('osc-error', { detail: error });
+      let newError = new Error(error);
+      let event = new window.CustomEvent('osc-error', { detail: newError });
       document.dispatchEvent(event);
     }
     

--- a/packages/data-store/src/hooks/use-choiceguide-result-count.js
+++ b/packages/data-store/src/hooks/use-choiceguide-result-count.js
@@ -1,0 +1,32 @@
+export default function useChoiceGuideResultCount({
+  projectId,
+  widgetId,
+}) {
+  let self = this;
+
+  if (!widgetId) {
+    return { data: [], error: 'No widgetId given', isLoading: false };
+  }
+
+  try {
+    const { data, error, isLoading } = self.useSWR(
+      { projectId, widgetId },
+      'choiceGuideResultCount.fetch'
+    );
+
+    if (error) {
+      let error = new Error(error);
+      let event = new window.CustomEvent('osc-error', { detail: error });
+      document.dispatchEvent(event);
+    }
+    
+    return { data: data?.count || [], error, isLoading };
+  } catch (e) {
+    return {
+      data: [],
+      error:
+        'Er ging iets mis bij het ophalen van de resultaten, waarschijnlijk ontbreken er een aantal rechten',
+      isLoading: false,
+    };
+  }
+}

--- a/packages/data-store/src/index.js
+++ b/packages/data-store/src/index.js
@@ -17,6 +17,7 @@ import useCommentsByProject from './hooks/use-comments-by-project';
 import useChoiceGuideResults from './hooks/use-choiceguide-results';
 import useUserActivity from './hooks/use-user-activity';
 import useWidget from "./hooks/use-widget";
+import useChoiceGuideResultCount from './hooks/use-choiceguide-result-count';
 
 const windowGlobal = typeof window !== 'undefined' ? window : {};
 
@@ -41,6 +42,7 @@ function DataStore(props = {}) {
   self.useSubmissions = useSubmissions.bind(self);
   self.useCommentsByProject = useCommentsByProject.bind(self);
   self.useChoiceGuideResults = useChoiceGuideResults.bind(self);
+  self.useChoiceGuideResultCount = useChoiceGuideResultCount.bind(self);
   self.useUserActivity = useUserActivity.bind(self);
   self.useWidget = useWidget.bind(self);
 


### PR DESCRIPTION
This PR adds the Choiceguide result count to the counter widget -- the old method did not work in the headless environment, as we have to fetch it through a widget ID.