### PR TITLE
fix(counter): rename widgetId to widgetToFetchId

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/counter/[id]/general.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/counter/[id]/general.tsx
@@ -46,7 +46,7 @@ const formSchema = z.object({
   opinion: z.string().optional(),
   amount: z.coerce.number().optional(),
   id: z.string().optional(),
-  widgetId: z.string().optional(),
+  widgetToFetchId: z.string().optional(),
   resourceId: z.string().optional(),
   includeOrExclude: z.string().optional(),
   onlyIncludeOrExcludeTagIds: z.string().optional()
@@ -83,7 +83,7 @@ export default function CounterDisplay(
       label: props?.label || 'Hoeveelheid',
       url: props?.url || '',
       opinion: props?.opinion || '',
-      widgetId: props?.widgetId,
+      widgetToFetchId: props?.widgetToFetchId,
       resourceId: props?.resourceId,
       includeOrExclude: props?.includeOrExclude || 'include',
       onlyIncludeOrExcludeTagIds: props?.onlyIncludeOrExcludeTagIds || '',
@@ -242,7 +242,7 @@ export default function CounterDisplay(
         {props.counterType === 'choiceGuideResults' ? (
           <FormObjectSelectField
             form={form}
-            fieldName="widgetId"
+            fieldName="widgetToFetchId"
             fieldLabel="Gewenste keuzewijzer"
             items={choiceGuides}
             keyForValue="id"

--- a/packages/counter/src/counter.tsx
+++ b/packages/counter/src/counter.tsx
@@ -25,7 +25,7 @@ export type CounterProps = {
   url?: string;
   opinion?: string;
   amount?: number;
-  widgetId?: string;
+  widgetToFetchId?: string;
   includeOrExclude?: string;
   onlyIncludeOrExcludeTagIds?: string;
 };
@@ -113,14 +113,16 @@ function Counter({
     sentiment: opinion,
   });
 
+  console.log ({props});
+
   const {
     data: results,
     error,
     isLoading,
   } = datastore.useChoiceGuideResultCount({
     projectId: props.projectId,
-    widgetId:
-      counterType === 'choiceGuideResults' ? props.widgetId : undefined,
+    widgetToFetchId:
+      counterType === 'choiceGuideResults' ? props.widgetToFetchId : undefined,
   });
 
   if (counterType === 'resource') {

--- a/packages/counter/src/main.tsx
+++ b/packages/counter/src/main.tsx
@@ -4,7 +4,7 @@ import { CounterWidgetProps, Counter } from './counter.js';
 
 const config: CounterWidgetProps = {
   counterType: 'choiceGuideResults',
-  widgetId: '6',
+  widgetToFetchId: '6',
   label: 'Hoeveelheid',
   url: 'https://www.google.com',
   opinion: '',

--- a/packages/data-store/src/api/choiceGuideResultCount.js
+++ b/packages/data-store/src/api/choiceGuideResultCount.js
@@ -1,7 +1,7 @@
 export default {
-  fetch: async function({ projectId, widgetId }) {
+  fetch: async function({ projectId, widgetToFetchId }) {
   
-    let url = `/api/project/${projectId}/choicesguide/widgets/${widgetId}/count`;
+    let url = `/api/project/${projectId}/choicesguide/widgets/${widgetToFetchId}/count`;
     return this.fetch(url);
   
   }

--- a/packages/data-store/src/hooks/use-choiceguide-result-count.js
+++ b/packages/data-store/src/hooks/use-choiceguide-result-count.js
@@ -1,16 +1,16 @@
 export default function useChoiceGuideResultCount({
   projectId,
-  widgetId,
+  widgetToFetchId,
 }) {
   let self = this;
 
-  if (!widgetId) {
+  if (!widgetToFetchId) {
     return { data: 0, error: 'No widgetId given', isLoading: false };
   }
 
   try {
     const { data, error, isLoading } = self.useSWR(
-      { projectId, widgetId },
+      { projectId, widgetToFetchId },
       'choiceGuideResultCount.fetch'
     );
 


### PR DESCRIPTION
This fixes a bug where the API would overwrite the `widgetId` prop to
 the ID of the current widget - no bueno.