### PR TITLE
Hotfix (CMS-server): basic auth would block

### DIFF
--- a/apps/cms-server/app.js
+++ b/apps/cms-server/app.js
@@ -400,7 +400,7 @@ app.use((req, res, next) => {
     return basicAuth({
         users: { [req.site.config.basicAuth.username]: req.site.config.basicAuth.password },
         challenge: true
-    });
+    })(req, res, next);
   }
 
   next();


### PR DESCRIPTION
Basic auth was not invoked correctly, and the resulting method was missing the `req`, `res` and `next` parameters.