### PR TITLE
CMS: Make apostrophe preview configurable

### DIFF
--- a/apps/cms-server/modules/base-widget/index.js
+++ b/apps/cms-server/modules/base-widget/index.js
@@ -1,0 +1,11 @@
+/**
+ * A widget for display a title with static content
+ */
+const previewEnabled = process.env?.DISABLE_WIDGET_PREVIEW !== 'true';
+
+module.exports = {
+  extend: '@apostrophecms/widget-type',
+  options: {
+    preview: previewEnabled,
+  }
+};

--- a/apps/cms-server/modules/openstad-accordion-widget/index.js
+++ b/apps/cms-server/modules/openstad-accordion-widget/index.js
@@ -29,7 +29,7 @@ const contentWidgets = {
 };
 
 module.exports = {
-  extend: '@apostrophecms/widget-type',
+  extend: 'base-widget',
   options: {
     label: 'Accordion',
   },

--- a/apps/cms-server/modules/openstad-alertBox-widget/index.js
+++ b/apps/cms-server/modules/openstad-alertBox-widget/index.js
@@ -3,7 +3,7 @@
  */
 
 module.exports = {
-  extend: '@apostrophecms/widget-type',
+  extend: 'base-widget',
   options: {
     label: 'Alert Box'
   },

--- a/apps/cms-server/modules/openstad-button-widget/index.js
+++ b/apps/cms-server/modules/openstad-button-widget/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extend: '@apostrophecms/widget-type',
+  extend: 'base-widget',
   options: {
     label: 'Button'
   },

--- a/apps/cms-server/modules/openstad-carousel-widget/index.js
+++ b/apps/cms-server/modules/openstad-carousel-widget/index.js
@@ -3,7 +3,7 @@
  */
 
 module.exports = {
-  extend: '@apostrophecms/widget-type',
+  extend: 'base-widget',
   options: {
     label: 'Carousel',
   },

--- a/apps/cms-server/modules/openstad-component-widget/index.js
+++ b/apps/cms-server/modules/openstad-component-widget/index.js
@@ -1,7 +1,7 @@
 // const styleSchema = require('../../../config/styleSchema.js').default;
 
 module.exports = {
-  extend: '@apostrophecms/widget-type',
+  extend: 'base-widget',
   options: {
     label: 'Openstad Component'
   },

--- a/apps/cms-server/modules/openstad-iconSection-widget/index.js
+++ b/apps/cms-server/modules/openstad-iconSection-widget/index.js
@@ -3,7 +3,7 @@
  */
 
 module.exports = {
-  extend: '@apostrophecms/widget-type',
+  extend: 'base-widget',
   options: {
     label: 'Icon Section'
   },

--- a/apps/cms-server/modules/openstad-image-widget/index.js
+++ b/apps/cms-server/modules/openstad-image-widget/index.js
@@ -1,7 +1,7 @@
 // const styleSchema = require('../../../config/styleSchema.js').default;
 
 module.exports = {
-  extend: '@apostrophecms/widget-type',
+  extend: 'base-widget',
   options: {
     label: 'Afbeelding',
   },

--- a/apps/cms-server/modules/openstad-rte-widget/index.js
+++ b/apps/cms-server/modules/openstad-rte-widget/index.js
@@ -37,7 +37,7 @@ const contentWidgets = {
 };
 
 module.exports = {
-  extend: '@apostrophecms/widget-type',
+  extend: 'base-widget',
   options: {
     label: 'Rich Text Editor',
   },

--- a/apps/cms-server/modules/openstad-section-widget/index.js
+++ b/apps/cms-server/modules/openstad-section-widget/index.js
@@ -14,7 +14,7 @@ const contentWidgets = {
 };
 
 module.exports = {
-  extend: '@apostrophecms/widget-type',
+  extend: 'base-widget',
   options: {
     label: 'Sectie'
   },

--- a/apps/cms-server/modules/openstad-shareLinks-widget/index.js
+++ b/apps/cms-server/modules/openstad-shareLinks-widget/index.js
@@ -3,7 +3,7 @@
  */
 
 module.exports = {
-  extend: '@apostrophecms/widget-type',
+  extend: 'base-widget',
   options: {
     label: 'Share Links'
   },

--- a/apps/cms-server/modules/openstad-timeline-widget/index.js
+++ b/apps/cms-server/modules/openstad-timeline-widget/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extend: '@apostrophecms/widget-type',
+  extend: 'base-widget',
   options: { label: 'Tijdlijn' },
   fields: {
     add: {

--- a/apps/cms-server/modules/openstad-title-widget/index.js
+++ b/apps/cms-server/modules/openstad-title-widget/index.js
@@ -3,7 +3,7 @@
  */
 
 module.exports = {
-  extend: '@apostrophecms/widget-type',
+  extend: 'base-widget',
   options: {
     label: 'Titel'
   },

--- a/charts/openstad-headless/templates/cms/deployment.yaml
+++ b/charts/openstad-headless/templates/cms/deployment.yaml
@@ -67,6 +67,9 @@ spec:
           - name: DISABLE_RATE_LIMITER
             value: {{ .Values.cms.disableRateLimiter | default "false" | quote }}
 
+          - name: DISABLE_WIDGET_PREVIEW
+            value: {{ .Values.cms.disableWidgetPreview | default "false" | quote }}
+
           # Inject extra environment variables
           {{- if .Values.cms.extraEnvVars }}
           {{- include "common.tplvalues.render" (dict "value" .Values.cms.extraEnvVars "context" $) | nindent 10 }}

--- a/charts/openstad-headless/values.yaml
+++ b/charts/openstad-headless/values.yaml
@@ -441,6 +441,8 @@ cms:
       secretName: openstad-tls-cms
       hosts: []
 
+  disableWidgetPreview: "false"
+
   # Inject extra environment variables
   extraEnvVars: []
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -296,6 +296,7 @@ services:
       - APOS_RELEASE_ID=${APOS_RELEASE_ID}
       - REACT_CDN=${REACT_CDN}
       - REACT_DOM_CDN=${REACT_DOM_CDN}
+      - DISABLE_WIDGET_PREVIEW=${CMS_DISABLE_WIDGET_PREVIEW:-false}
     ports:
       - '${CMS_PORT}:${CMS_PORT}'
     volumes:

--- a/scripts/create-docker-config.js
+++ b/scripts/create-docker-config.js
@@ -115,6 +115,7 @@ CMS_PORT=${process.env.CMS_PORT}
 CMS_OVERWRITE_URL=${process.env.CMS_OVERWRITE_URL}
 CMS_MONGODB_URI=${process.env.CMS_MONGODB_URI || 'mongodb://openstad-mongo:27017/{database}'}
 CMS_DEFAULT_SETTINGS=${process.env.CMS_DEFAULT_SETTINGS}
+CMS_DISABLE_WIDGET_PREVIEW=${process.env.CMS_DISABLE_WIDGET_PREVIEW || 'false'}
 `;
 
     await fs.writeFile('./.env', configfile);


### PR DESCRIPTION
The widgets now extend a new `base-widget`, which extends the old `@apostrophecms/widget-type`, but allows us to set the `preview` option for all widgets through a new ENV var `DISABLE_WIDGET_PREVIEW`. 
By default `preview` will be set to `true`, which is the default behavior for Apostrophe (since [4.16.0](https://github.com/apostrophecms/apostrophe/blob/main/CHANGELOG.md#4160-2025-05-14)).

Because this can lead to a lot of requests in a small timeframe, we want the option to disable the previews, so administrators will not be blocked by the WAF.