### PR TITLE
Feat/multi project overview widget fixes

### DIFF
--- a/apps/admin-server/src/components/ui/tabs.tsx
+++ b/apps/admin-server/src/components/ui/tabs.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as TabsPrimitive from '@radix-ui/react-tabs';
 
-import { cn } from '@/lib/utils';
+import { cn } from '../../lib/utils';
 
 const Tabs = TabsPrimitive.Root;
 

--- a/apps/admin-server/src/pages/projects/[project]/widgets/multiprojectresourceoverview/[id]/settings.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/multiprojectresourceoverview/[id]/settings.tsx
@@ -35,11 +35,15 @@ const formSchema = z.object({
       overviewSummary: z.string().optional(),
       overviewDescription: z.string().optional(),
       overviewImage: z.string().optional(),
+      overviewMarkerIcon: z.string().optional(),
       overviewUrl: z.string().optional(),
+      projectLat: z.string().optional(),
+      projectLng: z.string().optional(),
     })
   ).optional(),
   includeProjectsInOverview: z.boolean().optional(),
   imageProjectUpload: z.string().optional(),
+  markerIconProjectUpload: z.string().optional(),
 });
 
 export default function WidgetMultiProjectSettings(
@@ -250,11 +254,69 @@ export default function WidgetMultiProjectSettings(
                             )}
                           />
 
+                          <FormField
+                            control={form.control}
+                            name={`selectedProjects.${field.value?.findIndex(p => p.id === project.id) ?? 0}.projectLat`}
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormLabel>
+                                  Latitude voor project marker
+                                </FormLabel>
+                                <FormDescription>
+                                  Dit veld is optioneel en wordt gebruikt voor een marker op de kaart. Voor hulp bij het vinden van de juiste coördinaten kun je bijvoorbeeld <a href="https://www.latlong.net/" target="_blank" rel="noopener noreferrer" style={{textDecoration: "underline"}}>deze website</a> gebruiken.
+                                </FormDescription>
+                                <FormControl>
+                                  <Input
+                                    {...field}
+                                    type="text"
+                                  />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
+
+                          <FormField
+                            control={form.control}
+                            name={`selectedProjects.${field.value?.findIndex(p => p.id === project.id) ?? 0}.projectLng`}
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormLabel>
+                                  Longitude voor project marker
+                                </FormLabel>
+                                <FormDescription>
+                                  Dit veld is optioneel en wordt gebruikt voor een marker op de kaart. Voor hulp bij het vinden van de juiste coördinaten kun je bijvoorbeeld <a href="https://www.latlong.net/" target="_blank" rel="noopener noreferrer" style={{textDecoration: "underline"}}>deze website</a> gebruiken.
+                                </FormDescription>
+                                <FormControl>
+                                  <Input
+                                    {...field}
+                                    type="text"
+                                  />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
+
+                          <ImageUploader
+                            form={form}
+                            project={props?.projectId}
+                            fieldName="markerIconProjectUpload"
+                            imageLabel="Upload een marker icoon voor het project"
+                            allowedTypes={["image/*"]}
+                            onImageUploaded={(imageResult) => {
+                              const image = imageResult ? imageResult.url : '';
+
+                              form.setValue(`selectedProjects.${field.value?.findIndex(p => p.id === project.id) ?? 0}.overviewMarkerIcon`, image);
+                              form.resetField('markerIconProjectUpload');
+                            }}
+                          />
+
                           <ImageUploader
                             form={form}
                             project={props?.projectId}
                             fieldName="imageProjectUpload"
-                            imageLabel="Upload een afbeelding voor de project tegel"
+                            imageLabel="Upload een afbeelding voor de project tegel in het overzicht"
                             allowedTypes={["image/*"]}
                             onImageUploaded={(imageResult) => {
                               const image = imageResult ? imageResult.url : '';
@@ -263,6 +325,26 @@ export default function WidgetMultiProjectSettings(
                               form.resetField('imageProjectUpload');
                             }}
                           />
+
+                          {!!form.getValues(`selectedProjects.${field.value?.findIndex(p => p.id === project.id) ?? 0}.overviewMarkerIcon`) ? (
+                            <div style={{ position: 'relative', height: '140px' }}>
+                              <img
+                                src={form.getValues(`selectedProjects.${field.value?.findIndex(p => p.id === project.id) ?? 0}.overviewMarkerIcon`)}
+                                style={{position: "relative", width: "auto", height: "auto", maxHeight: "100%"}}
+                              />
+                              <Button
+                                color="red"
+                                onClick={() => {
+                                  form.setValue(`selectedProjects.${field.value?.findIndex(p => p.id === project.id) ?? 0}.overviewMarkerIcon`, '');
+                                  form.resetField('markerIconProjectUpload');
+                                }}
+                                className="absolute left-0 top-0 p-1">
+                                <X size={24} />
+                              </Button>
+                            </div>
+                          ) : (
+                            <div></div>
+                          )}
 
                           {!!form.getValues(`selectedProjects.${field.value?.findIndex(p => p.id === project.id) ?? 0}.overviewImage`) && (
                             <div style={{ position: 'relative', height: '140px' }}>

--- a/apps/admin-server/src/pages/projects/[project]/widgets/multiprojectresourceoverview/[id]/settings.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/multiprojectresourceoverview/[id]/settings.tsx
@@ -42,6 +42,7 @@ const formSchema = z.object({
     })
   ).optional(),
   includeProjectsInOverview: z.boolean().optional(),
+  excludeResourcesInOverview: z.boolean().optional(),
   imageProjectUpload: z.string().optional(),
   markerIconProjectUpload: z.string().optional(),
 });
@@ -55,7 +56,8 @@ export default function WidgetMultiProjectSettings(
   const { data: projects } = useProjectList();
   const defaultValues = {
     selectedProjects: props.selectedProjects || [],
-    includeProjectsInOverview: props.includeProjectsInOverview || false
+    includeProjectsInOverview: props.includeProjectsInOverview || false,
+    excludeResourcesInOverview: props?.excludeResourcesInOverview || false
   }
 
   const form = useForm<FormData>({
@@ -99,6 +101,28 @@ export default function WidgetMultiProjectSettings(
             </FormItem>
           )}
         />
+
+        {form.watch("includeProjectsInOverview") === true && (
+          <>
+            <Spacer />
+            <FormField
+              control={form.control}
+              name="excludeResourcesInOverview"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Toon geen inzendingen in het overzicht
+                  </FormLabel>
+                  <FormDescription>
+                    Als je deze optie aanzet, worden alleen de projecten zelf getoond als tegels in het overzicht, zonder de inzendingen.
+                  </FormDescription>
+                  {YesNoSelect(field, props)}
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </>
+        )}
         <Separator className="my-4" />
         <form
           onSubmit={form.handleSubmit(onSubmit)}

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourceoverview/[id]/display.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourceoverview/[id]/display.tsx
@@ -28,6 +28,7 @@ import {
 const formSchema = z.object({
   displayBanner: z.boolean(),
   displayMap: z.boolean(),
+  displayAsTabs: z.boolean(),
   displayTitle: z.boolean(),
   titleMaxLength: z.coerce.number(),
   displayDescription: z.boolean(),
@@ -49,6 +50,8 @@ const formSchema = z.object({
   displayBudget: z.boolean(),
   displayTags: z.boolean(),
   displayLocationFilter: z.boolean(),
+  listTabTitle: z.string().optional(),
+  mapTabTitle: z.string().optional(),
   // displayRanking: z.boolean(),
   // displayLabel: z.boolean(),
   // displayShareButtons: z.boolean(),
@@ -72,6 +75,7 @@ export default function WidgetResourceOverviewDisplay(
     defaultValues: {
       displayBanner: props?.displayBanner || false,
       displayMap: props?.displayMap || false,
+      displayAsTabs: props?.displayAsTabs || false,
       displayTitle: props?.displayTitle || false,
       bannerText: props?.bannerText,
       titleMaxLength: props?.titleMaxLength || 20,
@@ -93,6 +97,8 @@ export default function WidgetResourceOverviewDisplay(
       displayBudget: props?.displayBudget !== false,
       displayTags: props?.displayTags !== false,
       displayLocationFilter: props?.displayLocationFilter === true,
+      listTabTitle: typeof (props?.listTabTitle) === 'undefined' ? 'Lijst' : props.listTabTitle,
+      mapTabTitle: typeof (props?.mapTabTitle) === 'undefined' ? 'Kaart' : props.mapTabTitle,
       // displayRanking: props?.displayRanking || false,
       // displayLabel: props?.displayLabel || false,
       // displayShareButtons: props?.displayShareButtons || false,
@@ -104,37 +110,38 @@ export default function WidgetResourceOverviewDisplay(
   const { watch } = form;
   const displayBanner = watch('displayBanner');
   const displayMap = watch('displayMap');
+  const displayDocuments = watch('displayDocuments');
+  const displayAsTabs = watch('displayAsTabs');
 
   return (
     <div className="p-6 bg-white rounded-md">
       <Form {...form}>
-        <Heading size="xl">Weergave</Heading>
-        <Separator className="my-4" />
         <form
           onSubmit={form.handleSubmit(onSubmit)}
           className="lg:w-3/4 grid grid-cols-1 lg:grid-cols-2 gap-x-4 gap-y-8">
 
-          <div className='col-span-2 grid grid-cols-1 lg:grid-cols-2 gap-x-4 gap-y-8 w-full'>
+            <Heading size="xl">Algemeen</Heading>
+            <Separator style={{margin: "-10px 0 0"}} className="my-4 col-span-full" />
+
             <FormField
               control={form.control}
               name="displayBanner"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Titel weergeven</FormLabel>
+                  <FormLabel>Titel boven het overzicht weergeven?</FormLabel>
                   {YesNoSelect(field, props)}
                   <FormMessage />
                 </FormItem>
               )}
             />
+
             {displayBanner && (
               <FormField
                 control={form.control}
                 name="bannerText"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>
-                      Titel
-                    </FormLabel>
+                    <FormLabel>Titel boven het overzicht</FormLabel>
                     <FormControl>
                       <Input
                         type="text"
@@ -150,9 +157,53 @@ export default function WidgetResourceOverviewDisplay(
                 )}
               />
             )}
-          </div>
 
-          <div className='col-span-2 grid grid-cols-1 lg:grid-cols-2 gap-x-4 gap-y-8 w-full'>
+            <FormField
+              control={form.control}
+              name="applyText"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Tekst voor het toepassen van de filters
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      type="text"
+                      {...field}
+                      onChange={(e) => {
+                        onFieldChange(field.name, e.target.value);
+                        field.onChange(e);
+                      }}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="resetText"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Tekst voor het resetten van de filters
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      type="text"
+                      {...field}
+                      onChange={(e) => {
+                        onFieldChange(field.name, e.target.value);
+                        field.onChange(e);
+                      }}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
             <FormField
               control={form.control}
               name="displayMap"
@@ -164,7 +215,79 @@ export default function WidgetResourceOverviewDisplay(
                 </FormItem>
               )}
             />
-          </div>
+
+          {displayMap && (
+            <FormField
+              control={form.control}
+              name="displayAsTabs"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Moet de kaart en de lijst als tabs worden weergegeven?
+                  </FormLabel>
+                  <FormDescription>
+                    De huidige weergave is een lijst met de kaart erboven.
+                    Als je dit aanvinkt, worden de kaart en de lijst als tabs weergegeven.
+                  </FormDescription>
+                  {YesNoSelect(field, props)}
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          )}
+
+          { (displayMap && displayAsTabs) && (
+            <>
+              <FormField
+                control={form.control}
+                name="listTabTitle"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Titel van de lijst tab
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        type="text"
+                        {...field}
+                        onChange={(e) => {
+                          onFieldChange(field.name, e.target.value);
+                          field.onChange(e);
+                        }}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="mapTabTitle"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Titel van de map tab
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        type="text"
+                        {...field}
+                        onChange={(e) => {
+                          onFieldChange(field.name, e.target.value);
+                          field.onChange(e);
+                        }}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </>
+          )}
+
+
+          <Heading size="xl" className="col-span-full mt-6">Tegels</Heading>
+          <Separator style={{margin: "-10px 0 0"}} className="my-4 col-span-full" />
 
           <FormField
             control={form.control}
@@ -249,11 +372,11 @@ export default function WidgetResourceOverviewDisplay(
 
           <FormField
             control={form.control}
-            name="descriptionMaxLength"
+            name="summaryMaxLength"
             render={({ field }) => (
               <FormItem>
                 <FormLabel>
-                  Hoeveelheid karakters van de beschrijving die getoond wordt
+                  Hoeveelheid karakters van de samenvatting die getoond wordt
                 </FormLabel>
                 <FormControl>
                   <Input
@@ -282,14 +405,13 @@ export default function WidgetResourceOverviewDisplay(
             )}
           />
 
-
           <FormField
             control={form.control}
-            name="summaryMaxLength"
+            name="descriptionMaxLength"
             render={({ field }) => (
               <FormItem>
                 <FormLabel>
-                  Hoeveelheid karakters van de samenvatting die getoond wordt
+                  Hoeveelheid karakters van de beschrijving die getoond wordt
                 </FormLabel>
                 <FormControl>
                   <Input
@@ -345,111 +467,7 @@ export default function WidgetResourceOverviewDisplay(
             )}
           />
 
-          <FormField
-            control={form.control}
-            name="displayBudget"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>
-                  Budget in dialog weergeven
-                </FormLabel>
-                {YesNoSelect(field, props)}
-                <FormMessage />
-              </FormItem>
-            )}
-          />
 
-          <FormField
-            control={form.control}
-            name="displayTags"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>
-                  Tags in dialog weergeven
-                </FormLabel>
-                {YesNoSelect(field, props)}
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name="displayLocationFilter"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>
-                  Locatie filter weergeven
-                </FormLabel>
-                {YesNoSelect(field, props)}
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name="displayDocuments"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>
-                  Geüploade documenten weergeven
-                </FormLabel>
-                {YesNoSelect(field, props)}
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          {form.watch("displayDocuments") && (
-            <>
-              <FormField
-                control={form.control}
-                name="documentsTitle"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>
-                      Welke titel moet er boven de download knop(pen) komen?
-                    </FormLabel>
-                    <FormControl>
-                      <Input
-                        type="text"
-                        {...field}
-                        onChange={(e) => {
-                          onFieldChange(field.name, e.target.value);
-                          field.onChange(e);
-                        }}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              <FormField
-                control={form.control}
-                name="documentsDesc"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>
-                      Welke beschrijving moet er boven de download knop(pen) komen?
-                    </FormLabel>
-                    <FormControl>
-                      <Input
-                        type="text"
-                        {...field}
-                        onChange={(e) => {
-                          onFieldChange(field.name, e.target.value);
-                          field.onChange(e);
-                        }}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </>
-          )}
           {/* <FormField
             control={form.control}
             name="displayShareButtons"
@@ -505,53 +523,9 @@ export default function WidgetResourceOverviewDisplay(
               </FormItem>
             )}
           />
-          <div></div>
 
-          <FormField
-            control={form.control}
-            name="applyText"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>
-                  Tekst voor het toepassen van de filters
-                </FormLabel>
-                <FormControl>
-                  <Input
-                    type="text"
-                    {...field}
-                    onChange={(e) => {
-                      onFieldChange(field.name, e.target.value);
-                      field.onChange(e);
-                    }}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name="resetText"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>
-                  Tekst voor het resetten van de filters
-                </FormLabel>
-                <FormControl>
-                  <Input
-                    type="text"
-                    {...field}
-                    onChange={(e) => {
-                      onFieldChange(field.name, e.target.value);
-                      field.onChange(e);
-                    }}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+          <Heading size="xl" className="col-span-full mt-6">Dialog</Heading>
+          <Separator style={{margin: "-10px 0 0"}} className="my-4 col-span-full" />
 
           <FormField
             control={form.control}
@@ -560,6 +534,48 @@ export default function WidgetResourceOverviewDisplay(
               <FormItem>
                 <FormLabel>
                   Like button weergeven in de dialog
+                </FormLabel>
+                {YesNoSelect(field, props)}
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="displayBudget"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Budget in dialog weergeven
+                </FormLabel>
+                {YesNoSelect(field, props)}
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="displayTags"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Tags in dialog weergeven
+                </FormLabel>
+                {YesNoSelect(field, props)}
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="displayLocationFilter"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Locatie filter weergeven
                 </FormLabel>
                 {YesNoSelect(field, props)}
                 <FormMessage />
@@ -583,6 +599,70 @@ export default function WidgetResourceOverviewDisplay(
               </FormItem>
             )}
           />
+
+          <FormField
+            control={form.control}
+            name="displayDocuments"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Geüploade documenten weergeven
+                </FormLabel>
+                {YesNoSelect(field, props)}
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {displayDocuments && (
+            <>
+            <FormField
+              control={form.control}
+              name="documentsTitle"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Welke titel moet er boven de download knop(pen) komen?
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      type="text"
+                      {...field}
+                      onChange={(e) => {
+                        onFieldChange(field.name, e.target.value);
+                        field.onChange(e);
+                      }}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="documentsDesc"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Welke beschrijving moet er boven de download knop(pen) komen?
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      type="text"
+                      {...field}
+                      onChange={(e) => {
+                        onFieldChange(field.name, e.target.value);
+                        field.onChange(e);
+                      }}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </>
+        )}
 
           <Button className="w-fit col-span-full" type="submit">
             Opslaan

--- a/apps/cms-server/views/partials/header.html
+++ b/apps/cms-server/views/partials/header.html
@@ -116,11 +116,13 @@
             {% set menuData = data.home._children | json | replace("'", "&#39;") %}
             <div id="navbar"
               class="--compact"
-              data-home='
-              [{
-                "_url": "{{ data.home._url }}",
-                "title": "{{ data.home.title }}"
-              }]'
+                 {% if not data.home.orphan %}
+                 data-home='
+                    [{
+                      "_url": "{{ data.home._url }}",
+                      "title": "{{ data.home.title }}"
+                    }]'
+                 {% endif %}
               data-content='{{ menuData }}'
              data-prefix='{{ data.prefix }}'
             ></div>

--- a/apps/cms-server/views/partials/navbar.html
+++ b/apps/cms-server/views/partials/navbar.html
@@ -12,11 +12,13 @@
 {% set menuData = data.home._children | json | replace("'", "&#39;") %}
 
   <div id="navbar"
-    data-home='
-    [{
-      "_url": "{{ data.home._url }}",
-      "title": "{{ data.home.title }}"
-    }]'
+       {% if not data.home.orphan %}
+       data-home='
+        [{
+          "_url": "{{ data.home._url }}",
+          "title": "{{ data.home.title }}"
+        }]'
+       {% endif %}
     data-content='{{ menuData }}'
     data-prefix='{{ data.prefix }}'
   ></div>

--- a/packages/leaflet-map/src/resource-overview-map.tsx
+++ b/packages/leaflet-map/src/resource-overview-map.tsx
@@ -192,6 +192,30 @@ const ResourceOverviewMap = ({
       return marker;
     }) || [];
 
+  const projectMarkers = selectedProjects.map((project) => {
+    const marker: MarkerProps = {
+      lat: project.projectLat ? parseFloat(project.projectLat) : undefined,
+      lng: project.projectLng ? parseFloat(project.projectLng) : undefined,
+      href: project.overviewUrl || '',
+      title: project.overviewTitle || project.name || '',
+      icon: project.overviewMarkerIcon
+        ? L.icon({
+          iconUrl: project.overviewMarkerIcon,
+          iconSize: [30, 40],
+          iconAnchor: [15, 40],
+          className: 'custom-image-icon',
+        })
+        : undefined,
+    };
+
+    if (marker.lat && marker.lng) {
+      return marker;
+    }
+    return null;
+  }).filter(marker => marker !== null);
+
+  currentMarkers = currentMarkers.concat(projectMarkers);
+
   if (givenResources) {
     resources.metadata.totalCount = givenResources.length;
   }

--- a/packages/multi-project-resource-overview/src/multi-project-resource-overview.tsx
+++ b/packages/multi-project-resource-overview/src/multi-project-resource-overview.tsx
@@ -16,6 +16,9 @@ export type MultiProjectResourceOverviewProps = ResourceOverviewWidgetProps & {
     overviewDescription?: string;
     overviewImage?: string;
     overviewUrl?: string;
+    overviewMarkerIcon?: string;
+    projectLat?: string;
+    projectLng?: string;
   }[];
   includeProjectsInOverview?: boolean;
 };

--- a/packages/multi-project-resource-overview/src/multi-project-resource-overview.tsx
+++ b/packages/multi-project-resource-overview/src/multi-project-resource-overview.tsx
@@ -21,6 +21,7 @@ export type MultiProjectResourceOverviewProps = ResourceOverviewWidgetProps & {
     projectLng?: string;
   }[];
   includeProjectsInOverview?: boolean;
+  excludeResourcesInOverview?: boolean;
 };
 
 function MultiProjectResourceOverview({

--- a/packages/multi-project-resource-overview/vite.config.ts
+++ b/packages/multi-project-resource-overview/vite.config.ts
@@ -1,21 +1,28 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import {prefix} from '../lib/prefix';
+import path from 'path';
 
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command }) => {
+  const alias = {
+    '@': path.resolve(__dirname, '../../apps/admin-server/src'),
+  };
+
   // When running in dev mode, use the React plugin
   if (command === 'serve') {
     return {
       plugins: [react()],
-      css: prefix()
+      css: prefix(),
+      resolve: { alias },
     };
     // During build, use the classic runtime and build as an IIFE so we can deliver it to the browser
   } else {
     return {
       plugins: [react({ jsxRuntime: 'classic' })],
       css: prefix(),
+      resolve: { alias },
       build: {
         lib: {
           formats: ['iife'],

--- a/packages/multi-project-resource-overview/vite.config.ts
+++ b/packages/multi-project-resource-overview/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig(({ command }) => {
   if (command === 'serve') {
     return {
       plugins: [react()],
-      css: prefix(),
+      css: prefix()
     };
     // During build, use the classic runtime and build as an IIFE so we can deliver it to the browser
   } else {

--- a/packages/multi-project-resource-overview/vite.config.ts
+++ b/packages/multi-project-resource-overview/vite.config.ts
@@ -1,28 +1,21 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import {prefix} from '../lib/prefix';
-import path from 'path';
 
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command }) => {
-  const alias = {
-    '@': path.resolve(__dirname, '../../apps/admin-server/src'),
-  };
-
   // When running in dev mode, use the React plugin
   if (command === 'serve') {
     return {
       plugins: [react()],
       css: prefix(),
-      resolve: { alias },
     };
     // During build, use the classic runtime and build as an IIFE so we can deliver it to the browser
   } else {
     return {
       plugins: [react({ jsxRuntime: 'classic' })],
       css: prefix(),
-      resolve: { alias },
       build: {
         lib: {
           formats: ['iife'],

--- a/packages/resource-overview/src/resource-overview.css
+++ b/packages/resource-overview/src/resource-overview.css
@@ -254,6 +254,20 @@ p.osc-searchtext {
   display: none;
 }
 
+.osc-resource-overview-tabs-container {
+  display: flex;
+  flex-direction: column;
+  grid-column: 1 / -1;
+}
+
+.osc-resource-overview-tabs-container > div[role="tablist"] {
+  margin-bottom: 20px;
+}
+
+.osc-resource-overview-tabs-container > div[role="tablist"] > button[type="button"]{
+  gap: 2px;
+}
+
 /* Text Colors */
 .color-FFFFFF { color: #FFFFFF; }
 .color-000000 { color: #000000; }

--- a/packages/resource-overview/src/resource-overview.tsx
+++ b/packages/resource-overview/src/resource-overview.tsx
@@ -146,6 +146,7 @@ export type ResourceOverviewWidgetProps = BaseProps &
     includeOrExcludeStatusIds?: string;
     includeProjectsInOverview?: boolean;
     displayLocationFilter?: boolean;
+    excludeResourcesInOverview?: boolean;
   };
 
 //Temp: Header can only be made when the map works so for now a banner
@@ -438,6 +439,7 @@ function ResourceOverviewInner({
   displayAsTabs = false,
   listTabTitle = 'Lijst',
   mapTabTitle = 'Kaart',
+  excludeResourcesInOverview = false,
   ...props
 }: ResourceOverviewWidgetProps) {
   const datastore = new DataStore({
@@ -564,6 +566,8 @@ function ResourceOverviewInner({
   const [resourceDetailIndex, setResourceDetailIndex] = useState<number>(0);
 
   useEffect(() => {
+    if (includeProjectsInOverview && excludeResourcesInOverview) return;
+
     if (resourcesWithPagination) {
       setResources(resourcesWithPagination.records || []);
     }

--- a/packages/resource-overview/src/resource-overview.tsx
+++ b/packages/resource-overview/src/resource-overview.tsx
@@ -137,6 +137,9 @@ export type ResourceOverviewWidgetProps = BaseProps &
       overviewDescription?: string;
       overviewImage?: string;
       overviewUrl?: string;
+      overviewMarkerIcon?: string;
+      projectLat?: string;
+      projectLng?: string;
     }[];
     multiProjectResources?: any[];
     includeOrExcludeTagIds?: string;

--- a/packages/resource-overview/src/resource-overview.tsx
+++ b/packages/resource-overview/src/resource-overview.tsx
@@ -23,6 +23,8 @@ import {
 } from '@utrecht/component-library-react';
 import { ResourceOverviewMapWidgetProps, dataLayerArray } from '@openstad-headless/leaflet-map/src/types/resource-overview-map-widget-props';
 import { renderRawTemplate } from '@openstad-headless/raw-resource/includes/template-render';
+import { Tabs } from '@/components/ui/tabs';
+import {TabsContent, TabsList, TabsTrigger} from "@openstad-headless/admin-server/src/components/ui/tabs";
 
 // This function takes in latitude and longitude of two locations
 // and returns the distance between them as the crow flies (in kilometers)
@@ -63,7 +65,8 @@ export type ResourceOverviewWidgetProps = BaseProps &
       displayHeader?: boolean,
       displayMap?: boolean,
       selectedProjects?: any[],
-      location?: PostcodeAutoFillLocation
+      location?: PostcodeAutoFillLocation,
+      displayAsTabs?: boolean,
     ) => React.JSX.Element; renderItem?: (
       resource: any,
       props: ResourceOverviewWidgetProps,
@@ -101,6 +104,9 @@ export type ResourceOverviewWidgetProps = BaseProps &
     displayTagGroupName?: boolean;
     displayBanner?: boolean;
     displayMap?: boolean;
+    displayAsTabs?: boolean;
+    listTabTitle?: string;
+    mapTabTitle?: string;
     itemsPerPage?: number;
     textResults?: string;
     onlyIncludeTagIds?: string;
@@ -400,7 +406,7 @@ const defaultItemRenderer = (
   );
 };
 
-function ResourceOverview({
+function ResourceOverviewInner({
   renderItem = defaultItemRenderer,
   allowFiltering = true,
   displayType = 'cardrow',
@@ -427,6 +433,9 @@ function ResourceOverview({
   includeOrExcludeTagIds = 'include',
   includeOrExcludeStatusIds = 'include',
   includeProjectsInOverview = false,
+  displayAsTabs = false,
+  listTabTitle = 'Lijst',
+  mapTabTitle = 'Kaart',
   ...props
 }: ResourceOverviewWidgetProps) {
   const datastore = new DataStore({
@@ -777,6 +786,24 @@ function ResourceOverview({
     }, 200);
   }
 
+  const overviewSection = (
+    <section className="osc-resource-overview-resource-collection" id={randomId}>
+      {filteredResources &&
+        filteredResources
+          ?.slice(page * pageSize, (page + 1) * pageSize)
+          ?.map((resource: any, index: number) => {
+            return (
+              <React.Fragment key={`resource-item-${resource?.id || resource?.uniqueId}`}>
+                {renderItem(resource, { ...props, displayType, selectedProjects }, () => {
+                  onResourceClick(resource, index);
+                })}
+              </React.Fragment>
+            );
+          })
+      }
+    </section>
+  );
+
   return (
     <>
       <Dialog
@@ -818,7 +845,7 @@ function ResourceOverview({
 
       <div className={`osc ${getDisplayVariant(displayVariant)}`}>
 
-        {displayBanner || displayMap ? renderHeader(props, (filteredResources || []), bannerText, displayBanner, displayMap, selectedProjects, location) : null}
+        {displayBanner || displayMap ? renderHeader(props, (filteredResources || []), bannerText, displayBanner, (displayMap && !displayAsTabs), selectedProjects, location) : null}
 
         <section
           className={`osc-resource-overview-content ${!filterNeccesary ? 'full' : ''
@@ -870,21 +897,23 @@ function ResourceOverview({
             />
           ) : null}
 
-          <section className="osc-resource-overview-resource-collection" id={randomId}>
-            {filteredResources &&
-              filteredResources
-                ?.slice(page * pageSize, (page + 1) * pageSize)
-                ?.map((resource: any, index: number) => {
-                  return (
-                    <React.Fragment key={`resource-item-${resource?.id || resource?.uniqueId}`}>
-                      {renderItem(resource, { ...props, displayType, selectedProjects }, () => {
-                        onResourceClick(resource, index);
-                      })}
-                    </React.Fragment>
-                  );
-                })
-            }
-          </section>
+          { displayAsTabs ? (
+            <div className="osc-resource-overview-tabs-container">
+              <TabsList>
+                <TabsTrigger value="list"><Icon icon="ri-list-unordered" />{listTabTitle}</TabsTrigger>
+                <TabsTrigger value="map"><Icon icon="ri-map-pin-line" />{mapTabTitle}</TabsTrigger>
+              </TabsList>
+              <TabsContent value="list">
+                {overviewSection}
+              </TabsContent>
+              <TabsContent value="map">
+                {renderHeader(props, (filteredResources || []), bannerText, false, true, selectedProjects, location)}
+              </TabsContent>
+            </div>
+          ) : (
+            overviewSection
+          )}
+
         </section>
         {props.displayPagination && (
           <>
@@ -903,6 +932,18 @@ function ResourceOverview({
         )}
       </div>
     </>
+  );
+}
+
+function ResourceOverview(props: ResourceOverviewWidgetProps) {
+  const { displayAsTabs } = props;
+
+  return displayAsTabs ? (
+    <Tabs defaultValue="list">
+      <ResourceOverviewInner {...props} />
+    </Tabs>
+    ) : (
+    <ResourceOverviewInner {...props} />
   );
 }
 

--- a/packages/resource-overview/src/resource-overview.tsx
+++ b/packages/resource-overview/src/resource-overview.tsx
@@ -23,8 +23,7 @@ import {
 } from '@utrecht/component-library-react';
 import { ResourceOverviewMapWidgetProps, dataLayerArray } from '@openstad-headless/leaflet-map/src/types/resource-overview-map-widget-props';
 import { renderRawTemplate } from '@openstad-headless/raw-resource/includes/template-render';
-import { Tabs } from '@/components/ui/tabs';
-import {TabsContent, TabsList, TabsTrigger} from "@openstad-headless/admin-server/src/components/ui/tabs";
+import {TabsContent, TabsList, TabsTrigger, Tabs} from "@openstad-headless/admin-server/src/components/ui/tabs";
 
 // This function takes in latitude and longitude of two locations
 // and returns the distance between them as the crow flies (in kilometers)


### PR DESCRIPTION
This pull request introduces several enhancements and fixes across multiple files, primarily focusing on adding new configuration options for multi project overview widget, refining the user interface for project and resource overview widgets. Below is a summary of the most important changes:

### Form Enhancements and Additional Configuration Options:
* Added new fields in `WidgetMultiProjectSettings` to support `overviewMarkerIcon`, `projectLat`, and `projectLng` for better map marker configuration. Also included `excludeResourcesInOverview` as a boolean option. 
* Added support for displaying the map and list as tabs with configurable tab titles (`listTabTitle` and `mapTabTitle`). Updated the form to include these options along with a toggle for switching between the default layout and tabbed layout.
* Reordered admin fields in tab `Display` to ensure better readability. Also grouped them by category.

### Bug Fixes and Code Refinements:
* Fixed a relative import path in `tabs.tsx` to ensure proper module resolution. 
* Corrected swapped field names for `summaryMaxLength` and `descriptionMaxLength` in the multi project overview widget widget form, aligning the labels with their intended purposes. 