### PR TITLE
fix: set default page size for resource overview map

### DIFF
--- a/packages/leaflet-map/src/resource-overview-map.tsx
+++ b/packages/leaflet-map/src/resource-overview-map.tsx
@@ -99,6 +99,7 @@ const ResourceOverviewMap = ({
   const { data: resources } = datastore.useResources(
     {
       projectId: props.projectId,
+      pageSize: 99999,
     },
     { suspense: !!givenResources }
   );


### PR DESCRIPTION
This pull request includes a small change to the `ResourceOverviewMap` component in the `resource-overview-map.tsx` file. The change increases the `pageSize` parameter in the `useResources` hook to a very high value (`99999`) to ensure all resources are fetched in a single request.