### PR TITLE
fix: Update submission API URL construction for consistency

### DIFF
--- a/apps/admin-server/src/hooks/use-submission.tsx
+++ b/apps/admin-server/src/hooks/use-submission.tsx
@@ -4,12 +4,13 @@ import {validateProjectNumber} from "@/lib/validateProjectNumber";
 export default function useSubmissions(projectId?: string) {
   const projectNumber: number | undefined = validateProjectNumber(projectId);
 
-  const url = `/api/openstad/api/project/${projectNumber}/submission?includeUser=1`;
+  const baseUrl = `/api/openstad/api/project/${projectNumber}/submission`;
+  const url = `${baseUrl}?includeUser=1`;
 
   const { data, isLoading, error, mutate } = useSWR(projectNumber ? url : null);
 
   async function remove(id: string|number) {
-    const res = await fetch(`${url}/${id}`, {
+    const res = await fetch(`${baseUrl}/${id}`, {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',


### PR DESCRIPTION
This pull request refactors the URL construction logic in the `useSubmissions` hook to fix the url for API delete call