### PR TITLE
feat: Add include/exclude options per project in multi resource overview

### DIFF
--- a/apps/api-server/src/routes/api/resource.js
+++ b/apps/api-server/src/routes/api/resource.js
@@ -106,11 +106,12 @@ router.all('*', function (req, res, next) {
     req.scope.push('includeUser');
   }
 
-  if (req?.query?.projectIds && typeof req?.query?.projectIds === "object") {
+  if (req?.query?.projectIds && (typeof req?.query?.projectIds === "object" || typeof req?.query?.projectIds === "string")) {
     let projectIds = req.query.projectIds;
 
     if (!Array.isArray(projectIds)) projectIds = [projectIds];
     req.scope.push({ method: ['selectProjectIds', projectIds] });
+    req.query.projectIds = projectIds;
   }
 
   if (req.canIncludeVoteCount) req.scope.push('includeVoteCount');

--- a/packages/multi-project-resource-overview/src/multi-project-resource-overview.tsx
+++ b/packages/multi-project-resource-overview/src/multi-project-resource-overview.tsx
@@ -19,6 +19,8 @@ export type MultiProjectResourceOverviewProps = ResourceOverviewWidgetProps & {
     overviewMarkerIcon?: string;
     projectLat?: string;
     projectLng?: string;
+    includeProjectsInOverview?: boolean;
+    excludeResourcesInOverview?: boolean;
   }[];
   includeProjectsInOverview?: boolean;
   excludeResourcesInOverview?: boolean;
@@ -66,6 +68,7 @@ function MultiProjectResourceOverview({
       {...props}
       selectedProjects={selectedProjectsState}
       includeProjectsInOverview={props.includeProjectsInOverview}
+      excludeResourcesInOverview={props.excludeResourcesInOverview}
     />
   );
 }


### PR DESCRIPTION
This pull request introduces enhancements to the handling of project-specific settings in the multi-project resource overview widget.

### Updates to form logic and settings:

* Adjusted the `formSchema` in `settings.tsx` to ensure optional fields are correctly structured for `includeProjectsInOverview` and `excludeResourcesInOverview` settings. 
* Refactored the `defaultValues` and `onSubmit` logic in `settings.tsx` to handle project-specific settings (`includeProjectsInOverview` and `excludeResourcesInOverview`) at the project level for backward compatibility. 
* Removed global form fields for `includeProjectsInOverview` and `excludeResourcesInOverview` in favor of project-specific controls within the settings form.
* Added project-specific toggles for `includeProjectsInOverview` and `excludeResourcesInOverview` in the UI, allowing more granular control over project display settings.

### Backend and data handling adjustments:

* Enhanced the API route in `resource.js` to handle `projectIds` as either a string or an array, ensuring compatibility with different input formats.

### Changes to resource overview logic:

* Refined filtering logic in `resource-overview.tsx` to exclude resources based on `excludeResourcesInOverview` and ensure only projects marked with `includeProjectsInOverview` are displayed. 