### PR TITLE
fix: Optimize polyline updates to prevent unnecessary re-renders

### DIFF
--- a/packages/leaflet-map/src/base-map.tsx
+++ b/packages/leaflet-map/src/base-map.tsx
@@ -569,7 +569,16 @@ const BaseMap = ({
       setCurrentMarkers(newMarkers);
     }
 
-    if (newPolyLines.length > 0) {
+    // Only update polyLines if there are actual changes
+    const polyLinesChanged = newPolyLines.length !== currentPolyLines.length ||
+      newPolyLines.some((polyLine, index) =>
+        polyLine.positions.length !== currentPolyLines[index]?.positions.length ||
+        polyLine.style.color !== currentPolyLines[index]?.style.color ||
+        polyLine.style.weight !== currentPolyLines[index]?.style.weight ||
+        polyLine.style.opacity !== currentPolyLines[index]?.style.opacity
+      );
+
+    if (polyLinesChanged) {
       setPolyLines(newPolyLines);
     }
   }, [markers, visibleMapDataLayers, iconCreateFunction, defaultIcon, categorize, clustering, onMarkerClick]);


### PR DESCRIPTION
* Added a check (`polyLinesChanged`) to determine if the polyline data (`newPolyLines`) has meaningful differences from the current polyline data (`currentPolyLines`) before updating. This ensures `setPolyLines` is only called when necessary, preventing redundant re-renders.