### PR TITLE
feat: Implement filter behavior options for tag filtering

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/begrootmodule/[id]/tags.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/begrootmodule/[id]/tags.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@/components/ui/button';
 import {
   Form,
-  FormControl,
+  FormControl, FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -18,12 +18,13 @@ import { EditFieldProps } from '@/lib/form-widget-helpers/EditFieldProps';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import _ from 'lodash';
 import { StemBegrootWidgetProps } from '@openstad-headless/stem-begroot/src/stem-begroot';
 import { handleTagCheckboxGroupChange } from '@/lib/form-widget-helpers/TagGroupHelper';
 
 import * as Switch from '@radix-ui/react-switch';
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from "@/components/ui/select";
 
 const formSchema = z.object({
   displayTagFilters: z.boolean(),
@@ -39,6 +40,7 @@ const formSchema = z.object({
       message: 'You have to select at least one item.',
     }),
   displayTagGroupName: z.boolean(),
+  filterBehavior: z.string().optional(),
 });
 
 type Tag = {
@@ -73,6 +75,7 @@ export default function WidgetStemBegrootOverviewTags(
       displayTagFilters: props?.displayTagFilters || false,
       tagGroups: props.tagGroups || [],
       displayTagGroupName: props?.displayTagGroupName || false,
+      filterBehavior: props?.filterBehavior || 'or',
     },
   });
 
@@ -95,6 +98,38 @@ export default function WidgetStemBegrootOverviewTags(
               </FormItem>
             )}
           />
+
+          <FormField
+            control={form.control}
+            name="filterBehavior"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Kies de manier waarop je de filters wilt combineren
+                </FormLabel>
+                <FormDescription>
+                  <strong>Of</strong>: Als er meerdere filters actief zijn, wordt alleen één van de filters toegepast. Bijvoorbeeld, als je zoekt op meerdere eigenschappen, wordt er een resultaat getoond als één van die eigenschappen overeenkomt.<br />
+                  <strong>En</strong>: Als er meerdere filters actief zijn, moeten alle filters tegelijkertijd van toepassing zijn. Alleen resultaten die aan alle geselecteerde criteria voldoen, worden getoond.
+                </FormDescription>
+                <Select
+                  onValueChange={field.onChange}
+                  value={field.value || 'or'}
+                >
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Of" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="or">Of</SelectItem>
+                    <SelectItem value="and">En</SelectItem>
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
           <Separator className="my-4" />
 
           <FormField

--- a/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/filters.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/filters.tsx
@@ -23,6 +23,7 @@ import _ from 'lodash';
 import { handleTagCheckboxGroupChange } from '@/lib/form-widget-helpers/TagGroupHelper';
 import { useFieldDebounce } from '@/hooks/useFieldDebounce';
 import { DocumentMapProps } from '@openstad-headless/document-map/src/document-map';
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from "@/components/ui/select";
 
 const formSchema = z.object({
   tagGroups: z
@@ -35,7 +36,8 @@ const formSchema = z.object({
     )
     .refine((value) => value.some((item) => item), {
       message: 'You have to select at least one item.',
-    })
+    }),
+  filterBehavior: z.string().optional(),
 });
 
 type Tag = {
@@ -71,6 +73,7 @@ export default function DocumentFilters(
     resolver: zodResolver<any>(formSchema),
     defaultValues: {
       tagGroups: props.tagGroups || [],
+      filterBehavior: props?.filterBehavior || 'or',
     },
   });
 
@@ -82,6 +85,37 @@ export default function DocumentFilters(
         <form
           onSubmit={form.handleSubmit(onSubmit)}
           className="lg:w-full grid grid-cols-1 gap-4">
+
+          <FormField
+            control={form.control}
+            name="filterBehavior"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Kies de manier waarop je de filters wilt combineren
+                </FormLabel>
+                <FormDescription>
+                  <strong>Of</strong>: Als er meerdere filters actief zijn, wordt alleen één van de filters toegepast. Bijvoorbeeld, als je zoekt op meerdere eigenschappen, wordt er een resultaat getoond als één van die eigenschappen overeenkomt.<br />
+                  <strong>En</strong>: Als er meerdere filters actief zijn, moeten alle filters tegelijkertijd van toepassing zijn. Alleen resultaten die aan alle geselecteerde criteria voldoen, worden getoond.
+                </FormDescription>
+                <Select
+                  onValueChange={field.onChange}
+                  value={field.value || 'or'}
+                >
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Of" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="or">Of</SelectItem>
+                    <SelectItem value="and">En</SelectItem>
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
           <FormField
             control={form.control}

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourceoverview/[id]/tags.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourceoverview/[id]/tags.tsx
@@ -19,11 +19,12 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { ResourceOverviewWidgetProps } from '@openstad-headless/resource-overview/src/resource-overview';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import _ from 'lodash';
 import { handleTagCheckboxGroupChange } from '@/lib/form-widget-helpers/TagGroupHelper';
 import { useFieldDebounce } from '@/hooks/useFieldDebounce';
 import InfoDialog from "@/components/ui/info-hover";
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from "@/components/ui/select";
 
 const formSchema = z.object({
   displayTagFilters: z.boolean(),
@@ -41,6 +42,7 @@ const formSchema = z.object({
       message: 'You have to select at least one item.',
     }),
   displayTagGroupName: z.boolean(),
+  filterBehavior: z.string().optional(),
 });
 
 type Tag = {
@@ -76,6 +78,7 @@ export default function WidgetResourceOverviewTags(
     defaultValues: {
       displayTagFilters: props?.displayTagFilters || false,
       showActiveTags: props?.showActiveTags || false,
+      filterBehavior: props?.filterBehavior || 'or',
       tagGroups: props.tagGroups || [],
       displayTagGroupName: props?.displayTagGroupName || false,
     },
@@ -88,7 +91,7 @@ export default function WidgetResourceOverviewTags(
         <Separator className="my-4" />
         <form
           onSubmit={form.handleSubmit(onSubmit)}
-          className="lg:w-1/3 grid grid-cols-1 gap-4">
+          className="lg:w-2/3 grid grid-cols-1 gap-4">
           <FormField
             control={form.control}
             name="displayTagFilters"
@@ -108,6 +111,37 @@ export default function WidgetResourceOverviewTags(
               <FormItem>
                 <FormLabel style={{display: 'flex'}}>Wil je onder de filters de actieve tags zien waar op is gefilterd? <InfoDialog content={"Dit geeft je de mogelijkheid om de actieve tags te zien waarop momenteel is gefilterd. Dit is vooral handig bij filters waar je meerdere opties kunt selecteren binnen één dropdown. Zo kun je snel een overzicht krijgen van de geselecteerde tags en eenvoudig aanpassen of verwijderen. De actieve tags worden alleen weergegeven bij filteropties die het toestaan om meerdere keuzes tegelijk te selecteren."} /></FormLabel>
                 {YesNoSelect(field, props)}
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="filterBehavior"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Kies de manier waarop je de filters wilt combineren
+                </FormLabel>
+                <FormDescription>
+                  <strong>Of</strong>: Als er meerdere filters actief zijn, wordt alleen één van de filters toegepast. Bijvoorbeeld, als je zoekt op meerdere eigenschappen, wordt er een resultaat getoond als één van die eigenschappen overeenkomt.<br />
+                  <strong>En</strong>: Als er meerdere filters actief zijn, moeten alle filters tegelijkertijd van toepassing zijn. Alleen resultaten die aan alle geselecteerde criteria voldoen, worden getoond.
+                </FormDescription>
+                <Select
+                  onValueChange={field.onChange}
+                  value={field.value || 'or'}
+                >
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Of" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="or">Of</SelectItem>
+                    <SelectItem value="and">En</SelectItem>
+                  </SelectContent>
+                </Select>
                 <FormMessage />
               </FormItem>
             )}

--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -94,6 +94,7 @@ export type DocumentMapProps = BaseProps &
     maxCharactersWarning?: string;
     minCharactersError?: string;
     maxCharactersError?: string;
+    filterBehavior?: string;
   };
 
 
@@ -133,6 +134,7 @@ function DocumentMap({
   onlyAllowClickOnImage = false,
   popupNotLoggedInText = 'Om een reactie te plaatsen, moet je ingelogd zijn.',
   popupNotLoggedInButton = 'Inloggen',
+  filterBehavior = 'or',
   ...props
 }: DocumentMapProps) {
 
@@ -249,7 +251,15 @@ function DocumentMap({
           return false;
         }
 
-        return comment?.tags.some((tag: any) => finalAllTagsToFilter.includes(tag.id));
+        if (filterBehavior === 'and') {
+          return finalAllTagsToFilter.every(tagId =>
+            comment.tags?.some((tag: { id: number }) => tag.id === tagId)
+          );
+        } else {
+          return comment.tags?.some((tag: { id: number }) =>
+            finalAllTagsToFilter.includes(tag.id)
+          );
+        }
       });
 
     const tagsNewString = !!finalAllTagsToFilter ? finalAllTagsToFilter.join(',') : '';

--- a/packages/resource-overview/src/resource-overview.tsx
+++ b/packages/resource-overview/src/resource-overview.tsx
@@ -149,6 +149,7 @@ export type ResourceOverviewWidgetProps = BaseProps &
     includeProjectsInOverview?: boolean;
     displayLocationFilter?: boolean;
     excludeResourcesInOverview?: boolean;
+    filterBehavior?: string;
   };
 
 //Temp: Header can only be made when the map works so for now a banner
@@ -442,6 +443,7 @@ function ResourceOverviewInner({
   displayAsTabs = false,
   listTabTitle = 'Lijst',
   mapTabTitle = 'Kaart',
+  filterBehavior = 'or',
   ...props
 }: ResourceOverviewWidgetProps) {
   const datastore = new DataStore({
@@ -654,10 +656,15 @@ function ResourceOverviewInner({
           if (hasExcludedTag) return false;
 
           if (includeTags.length > 0) {
-            const hasIncludedTag = resource.tags?.some((tag: { id: number }) =>
-              includeTags.includes(tag.id)
-            );
-            return hasIncludedTag;
+            if (filterBehavior === 'and') {
+              return includeTags.every(tagId =>
+                resource.tags?.some((tag: { id: number }) => tag.id === tagId)
+              );
+            } else {
+              return resource.tags?.some((tag: { id: number }) =>
+                includeTags.includes(tag.id)
+              );
+            }
           }
 
           return true;

--- a/packages/stem-begroot/src/stem-begroot.tsx
+++ b/packages/stem-begroot/src/stem-begroot.tsx
@@ -95,6 +95,7 @@ export type StemBegrootWidgetProps = BaseProps &
     step1Delete?: string;
     step1Add?: string;
     step1MaxText?: string;
+    filterBehavior?: string;
   };
 
 function StemBegroot({
@@ -115,6 +116,7 @@ function StemBegroot({
   step1Delete = 'Verwijder',
   step1Add = 'Voeg toe',
   step1MaxText = '',
+  filterBehavior = 'or',
   ...props
 }: StemBegrootWidgetProps) {
   const datastore = new DataStore({
@@ -1022,6 +1024,7 @@ function StemBegroot({
               hideReadMore={hideReadMore}
               currentPage={page}
               pageSize={itemsPerPage}
+              filterBehavior={filterBehavior}
             />
             <Spacer size={3} />
 

--- a/packages/stem-begroot/src/step-1/begroot-resource-list/stem-begroot-resource-list.tsx
+++ b/packages/stem-begroot/src/step-1/begroot-resource-list/stem-begroot-resource-list.tsx
@@ -38,6 +38,7 @@ export const StemBegrootResourceList = ({
   hideReadMore = false,
   currentPage = 0,
   pageSize = 999,
+  filterBehavior = 'or',
   header
 }: {
   resourceListColumns?: number;
@@ -68,6 +69,7 @@ export const StemBegrootResourceList = ({
   hideReadMore?: boolean;
   currentPage: number;
   pageSize: number;
+  filterBehavior?: string;
 }) => {
   // @ts-ignore
   const intTags = tags.map(tag => parseInt(tag, 10));
@@ -90,11 +92,17 @@ export const StemBegrootResourceList = ({
     Object.keys(groupedTags).length === 0
       ? resources
       : resources.filter((resource: any) => {
-        return Object.keys(groupedTags).every(tagType => {
-          return groupedTags[tagType]?.some(tagId =>
-            resource.tags && Array.isArray(resource.tags) && resource.tags?.some((o: { id: number }) => o.id === tagId)
-          );
-        });
+        if (tags.length > 0) {
+          if (filterBehavior === 'and') {
+            return tags.every(tagId =>
+              resource.tags?.some((tag: { id: number }) => tag.id === tagId)
+            );
+          } else {
+            return resource.tags?.some((tag: { id: number }) =>
+              tags.includes(tag.id)
+            );
+          }
+        }
       })
   )
     ?.filter((resource: any) => {


### PR DESCRIPTION
This pull request introduces a new "filter behavior" option to the tag filtering functionality across three major admin widgets (`StemBegroot`, `ResourceOverview`, and `DocumentMap`). Users can now choose whether filters should be combined using "AND" (all selected tags must match) or "OR" (any selected tag matches).

**Filter Behavior Option**

* Added a `filterBehavior` field (with "or" as the default value) to the forms and schemas in the admin UI for `StemBegroot`, `ResourceOverview`, and `DocumentMap` widgets, allowing users to select between "AND" and "OR" filtering via a dropdown.

**Widget and Component Logic**

* Updated the filtering logic in `StemBegrootResourceList`, `DocumentMap`, and `ResourceOverviewInner` to apply the correct "AND"/"OR" logic when filtering resources or comments by tags, based on the selected filter behavior. 