### PR TITLE
fix: Correctly handle file removal by normalizing file names

### DIFF
--- a/packages/ui/src/form-elements/image-upload/index.tsx
+++ b/packages/ui/src/form-elements/image-upload/index.tsx
@@ -207,9 +207,18 @@ const ImageUploadField: FC<ImageUploadProps> = ({
                     }}
                     onremovefile={(error: FilePondErrorDescription | null, file: FilePondFile) => {
                         const fileName = file?.file?.name;
+
                         if (!!fileName) {
-                            const updatedImages = uploadedImages.filter(item => item.name !== fileName);
-                            setUploadedImages(updatedImages);
+                           const uploadImageFileName = fileName.replace(/\./g, '_');
+                           const fileIsInUploadedImages = uploadedImages.find(item => item.name === uploadImageFileName);
+
+                           if (!fileIsInUploadedImages) return;
+
+                           const updatedImages = uploadedImages.filter(item => item.name !== uploadImageFileName);
+                           setUploadedImages(updatedImages);
+
+                           const updatedFiles = files.filter(item => item.file.name !== fileName);
+                           setImages(updatedFiles);
                         }
                     }}
                     id={randomId}


### PR DESCRIPTION
This pull request updates the image removal logic in the `ImageUploadField` component to ensure that images are properly removed from both the uploaded images and the files lists. 

### Image removal logic improvements:

* Normalized file names by replacing periods with underscores before checking and removing from the `uploadedImages` list, ensuring consistency and preventing mismatches.
* Added a guard to only proceed with removal if the normalized file name exists in `uploadedImages`.
* Updated both `uploadedImages` and `files` state after removal to keep the UI in sync.