### PR TITLE
Feat/bulk duplicate delete

### DIFF
--- a/apps/admin-server/src/components/dialog-confirm-action.tsx
+++ b/apps/admin-server/src/components/dialog-confirm-action.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import { DialogClose } from '@radix-ui/react-dialog';
+import { MoreHorizontal, Trash } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Heading, Paragraph } from '@/components/ui/typography';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+} from '@/components/ui/dialog';
+
+type Props = {
+  buttonText: string;
+  header: string;
+  message: string;
+  confirmButtonText?: string;
+  cancelButtonText?: string;
+  confirmButtonVariant?: "link" | "default" | "destructive" | "outline" | "secondary" | "ghost" | null | undefined;
+  onConfirmAccepted: () => void;
+};
+
+export function ConfirmActionDialog({
+  buttonText,
+  header,
+  message,
+  confirmButtonText = 'Verwijderen',
+  cancelButtonText = 'Annuleren',
+  confirmButtonVariant = 'default',
+  onConfirmAccepted,
+}: Props) {
+  const [open, setOpen] = useState<boolean>(false);
+
+  return (
+    <Dialog open={open} modal={true} onOpenChange={setOpen}>
+      <div className="flex items-center" onClick={(e) => {
+        e.preventDefault();
+        setOpen(true);
+      }}>
+        {buttonText}
+      </div>
+      <DialogContent
+        onEscapeKeyDown={(e: KeyboardEvent) => {
+          e.stopPropagation();
+        }}
+        onInteractOutside={(e: Event) => {
+          e.stopPropagation();
+          setOpen(false);
+        }}>
+        <div>
+          <Heading size={'lg'}>{header}</Heading>
+          <Paragraph className="mb-8">{message}</Paragraph>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button
+                onClick={(e) => {
+                  e.preventDefault();
+                  setOpen(false);
+                }}
+                type="button"
+                variant="ghost">
+                {cancelButtonText}
+              </Button>
+            </DialogClose>
+
+            <Button
+              type="button"
+              variant={confirmButtonVariant}
+              onClick={(e) => {
+                e.preventDefault();
+                onConfirmAccepted && onConfirmAccepted();
+                setOpen(false);
+              }}>
+              {confirmButtonText}
+            </Button>
+          </DialogFooter>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin-server/src/hooks/use-resources.tsx
+++ b/apps/admin-server/src/hooks/use-resources.tsx
@@ -53,14 +53,17 @@ export default function useResources(projectId?: string, includeGlobalTags?: boo
     }
   }
 
-  async function remove(id: number) {
-    const deleteUrl = `/api/openstad/api/project/${projectNumber}/resource/${id}?includeUserVote=1`;
+  async function remove(id: number, multiple?: boolean, ids?: number[]) {
+    const deleteUrl = multiple
+      ? `/api/openstad/api/project/${projectNumber}/resource/delete`
+      : `/api/openstad/api/project/${projectNumber}/resource/${id}?includeUserVote=1`;
 
     const res = await fetch(deleteUrl, {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',
       },
+      body: multiple ? JSON.stringify({ ids }) : undefined,
     });
 
     if (res.ok) {
@@ -72,5 +75,27 @@ export default function useResources(projectId?: string, includeGlobalTags?: boo
       throw new Error('Could not remove the plan');
     }
   }
-  return { ...resourcesListSwr, create, update, remove };
+
+  async function duplicate(ids: number[]) {
+    const duplicateUrl = `/api/openstad/api/project/${projectNumber}/resource/duplicate`;
+
+    const res = await fetch(duplicateUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ ids }),
+    });
+
+    if (res.ok) {
+      const data = await res.json();
+
+      resourcesListSwr.mutate([...resourcesListSwr.data, ...data]);
+      return data;
+    } else {
+      throw new Error('Could not duplicate the widgets');
+    }
+  }
+
+  return { ...resourcesListSwr, create, update, remove, duplicate };
 }

--- a/apps/admin-server/src/hooks/use-widgets.tsx
+++ b/apps/admin-server/src/hooks/use-widgets.tsx
@@ -24,14 +24,17 @@ export function useWidgetsHook(projectId?: string) {
     return data;
   }
 
-  async function remove(id: number) {
-    const deleteUrl = `/api/openstad/api/project/${projectNumber}/widgets/${id}`;
+  async function remove(id: number, multiple?: boolean, ids?: number[]) {
+    const deleteUrl = multiple
+      ? `/api/openstad/api/project/${projectNumber}/widgets/delete`
+      : `/api/openstad/api/project/${projectNumber}/widgets/${id}`;
 
     const res = await fetch(deleteUrl, {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',
       },
+      body: multiple ? JSON.stringify({ ids }) : undefined,
     });
 
     if (res.ok) {
@@ -71,8 +74,29 @@ export function useWidgetsHook(projectId?: string) {
 
   }
 
+  async function duplicate(ids: number[]) {
+    const duplicateUrl = `/api/openstad/api/project/${projectNumber}/widgets/duplicate`;
 
-  return { ...widgetsSwr, createWidget, updateWidget, remove };
+    const res = await fetch(duplicateUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ ids }),
+    });
+
+    if (res.ok) {
+      const data = await res.json();
+
+      widgetsSwr.mutate([...widgetsSwr.data, ...data]);
+      return data;
+    } else {
+      throw new Error('Could not duplicate the widgets');
+    }
+  }
+
+
+  return { ...widgetsSwr, createWidget, updateWidget, remove, duplicate };
 }
 
 export type Widget = {

--- a/apps/admin-server/src/pages/projects/[project]/widgets/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/index.tsx
@@ -12,19 +12,23 @@ import toast from 'react-hot-toast';
 
 import { sortTable, searchTable } from '@/components/ui/sortTable';
 import { Button } from '@/components/ui/button';
+import {Checkbox} from "@/components/ui/checkbox";
+import {ConfirmActionDialog} from "@/components/dialog-confirm-action";
 
 export default function ProjectWidgets() {
   const router = useRouter();
   const { project } = router.query;
 
 
-  const { data: widgets, isLoading: isLoadingWidgets, remove } = useWidgetsHook(
+  const { data: widgets, isLoading: isLoadingWidgets, remove, duplicate } = useWidgetsHook(
     project as string
   );
 
   const [data, setData] = useState(widgets);
   const [filterSearchType, setFilterSearchType] = useState<string>('');
   const debouncedSearchTable = searchTable(setData, filterSearchType);
+  const [bulkSelectActive, setBulkSelectActive] = useState<boolean>(false);
+  const [selectedWidgets, setSelectedWidgets] = useState<number[]>([]);
 
   useEffect(() => {
     if (widgets) {
@@ -56,31 +60,104 @@ export default function ProjectWidgets() {
         }>
         <div className="container py-6">
 
-
-          <div className="float-right mb-4 flex gap-4">
-
-            <p className="text-xs font-medium text-muted-foreground self-center">Filter op:</p>
-            <select
-              className="p-2 rounded"
-              onChange={(e) => setFilterSearchType(e.target.value)}
+          <div className="float-left mb-4 flex gap-4">
+            <Button
+              variant={'outline'}
+              className="flex items-center gap-2 float-left"
+              onClick={() => {
+                setSelectedWidgets([])
+                setBulkSelectActive(!bulkSelectActive)
+              }}
             >
-              <option value="">Alles</option>
-              <option value="id">ID</option>
-              <option value="type">Widget</option>
-              <option value="createdAt">Toegevoegd op</option>
-              <option value="updatedAt">Gewijzigd op</option>
-            </select>
+              {bulkSelectActive ? 'Bulk selecteren stoppen' : 'Bulk selecteren'}
+            </Button>
 
-            <input
-              type="text"
-              className='p-2 rounded'
-              placeholder="Zoeken..."
-              onChange={(e) => debouncedSearchTable(e.target.value, data, widgets)}
-            />
-          </div>
+            {bulkSelectActive && (
+              <>
+                <Button
+                  variant={'default'}
+                  className="flex items-center gap-2 float-left"
+                  onClick={(e) => e.preventDefault()}
+                  disabled={ selectedWidgets.length === 0 }
+                >
+                  <ConfirmActionDialog
+                    buttonText="Dupliceren"
+                    header="Widgets Dupliceren"
+                    message="Weet je zeker dat je de geselecteerde widgets wilt dupliceren?"
+                    confirmButtonText="Dupliceren"
+                    cancelButtonText="Annuleren"
+                    onConfirmAccepted={() => {
+                      duplicate(selectedWidgets)
+                        .then(() => {
+                          toast.success('Widgets successvol gedupliceerd');
+                          setSelectedWidgets([]);
+                          setBulkSelectActive(false);
+                        })
+                        .catch((e) =>
+                          toast.error('Widgets konden (gedeeltelijk) niet worden gedupliceerd')
+                        )
+                    }}
+                    confirmButtonVariant="default"
+                  />
+                </Button>
+                <Button
+                  variant={'destructive'}
+                  className="flex items-center gap-2 float-left"
+                  onClick={(e) => e.preventDefault()}
+                  disabled={ selectedWidgets.length === 0 }
+                >
+                  <ConfirmActionDialog
+                    buttonText="Verwijderen"
+                    header="Widgets Verwijderen"
+                    message="Weet je zeker dat je de geselecteerde widgets wilt verwijderen?"
+                    confirmButtonText="Verwijderen"
+                    cancelButtonText="Annuleren"
+                    onConfirmAccepted={() => {
+                      remove(0, true, selectedWidgets)
+                        .then(() => {
+                          toast.success('Widgets successvol verwijderd');
+                          setSelectedWidgets([]);
+                          setBulkSelectActive(false);
+                        })
+                        .catch((e) =>
+                          toast.error('Widgets konden (gedeeltelijk) niet worden verwijderd')
+                        )
+                    }}
+                    confirmButtonVariant="destructive"
+                  />
+                </Button>
+              </>
+            )}
+            </div>
+
+            <div className="float-right mb-4 flex gap-4">
+
+              <p className="text-xs font-medium text-muted-foreground self-center">Filter op:</p>
+              <select
+                className="p-2 rounded"
+                onChange={(e) => setFilterSearchType(e.target.value)}
+              >
+                <option value="">Alles</option>
+                <option value="id">ID</option>
+                <option value="type">Widget</option>
+                <option value="createdAt">Toegevoegd op</option>
+                <option value="updatedAt">Gewijzigd op</option>
+              </select>
+
+              <input
+                type="text"
+                className='p-2 rounded'
+                placeholder="Zoeken..."
+                onChange={(e) => debouncedSearchTable(e.target.value, data, widgets)}
+              />
+            </div>
 
           <div className="p-6 bg-white rounded-md clear-right">
-            <div className="grid grid-cols-2 lg:grid-cols-[40px_repeat(5,1fr)_60px] items-left py-2 px-2 border-b border-border">
+            <div
+              className={`grid grid-cols-2 items-left py-2 px-2 border-b border-border`}
+              style={{ gridTemplateColumns: `repeat(${bulkSelectActive ? 2 : 1}, 40px) repeat(5, 1fr) 60px` }}
+            >
+              {bulkSelectActive && (<ListHeading />)}
               <ListHeading className="hidden lg:flex">
                 <button className="filter-button" onClick={(e) => setData(sortTable('id', e, data))}>
                   ID
@@ -108,8 +185,26 @@ export default function ProjectWidgets() {
                 return (
                   <Link
                     key={widget.id}
-                    href={`/projects/${project}/widgets/${widget.type}/${widget.id}`}>
-                    <li className="grid grid-cols-2 lg:grid-cols-[40px_repeat(5,1fr)_60px] py-3 px-2 hover:bg-muted hover:cursor-pointer transition-all duration-200 border-b">
+                    href={ bulkSelectActive ? `/projects/${project}/widgets/` : `/projects/${project}/widgets/${widget.type}/${widget.id}`}
+                    scroll={ !bulkSelectActive }
+                  >
+                    <li
+                      className="grid grid-cols-2 py-3 px-2 hover:bg-muted hover:cursor-pointer transition-all duration-200 border-b"
+                      style={{ gridTemplateColumns: `repeat(${bulkSelectActive ? 2 : 1}, 40px) repeat(5, 1fr) 60px` }}
+                    >
+                      {bulkSelectActive && (
+                        <Checkbox
+                          className="my-auto"
+                          onCheckedChange={(checked) => {
+                            if (checked) {
+                              setSelectedWidgets((prev) => [...prev, widget.id]);
+                            } else {
+                              setSelectedWidgets((prev) => prev.filter(id => id !== widget.id));
+                            }
+                          }}
+                        />
+                      )}
+
                       <Paragraph className="my-auto -mr-16 lg:mr-0">{widget.id}</Paragraph>
                       <div className="">
                         <strong className="">

--- a/apps/api-server/src/routes/api/resource.js
+++ b/apps/api-server/src/routes/api/resource.js
@@ -652,10 +652,15 @@ router
     .route ('/delete')
     .delete(auth.useReqUser)
     .delete( rateLimiter(), async function (req, res, next)  {
-      const ids = req.body.ids;
+      let ids = req.body.ids;
 
       if (!ids || !Array.isArray(ids)) {
         return next(new Error('Invalid request: ids must be an array'));
+      }
+
+      ids = ids.filter((id) => Number.isInteger(id));
+      if (ids.length === 0) {
+        return next(new Error('Invalid request: no valid ids provided'));
       }
 
       try {
@@ -688,11 +693,16 @@ router
     .route('/duplicate')
     .post(auth.useReqUser)
     .post(rateLimiter(), async function (req, res, next) {
-      const ids = req.body.ids;
+      let ids = req.body.ids;
       const projectId = req.params.projectId;
 
       if (!ids || !Array.isArray(ids)) {
         return next(new Error('Invalid request: ids must be an array'));
+      }
+
+      ids = ids.filter((id) => Number.isInteger(id));
+      if (ids.length === 0) {
+        return next(new Error('Invalid request: no valid ids provided'));
       }
 
       try {

--- a/apps/api-server/src/routes/api/widget.js
+++ b/apps/api-server/src/routes/api/widget.js
@@ -60,10 +60,15 @@ router
     .route ('/delete')
     .delete(auth.useReqUser)
     .delete( rateLimiter(), async function (req, res, next)  {
-        const ids = req.body.ids;
+        let ids = req.body.ids;
 
         if (!ids || !Array.isArray(ids)) {
             return next(new Error('Invalid request: ids must be an array'));
+        }
+
+        ids = ids.filter((id) => Number.isInteger(id));
+        if (ids.length === 0) {
+            return next(new Error('Invalid request: no valid ids provided'));
         }
 
         try {
@@ -96,11 +101,16 @@ router
     .route('/duplicate')
     .post(auth.useReqUser)
     .post(rateLimiter(), async function (req, res, next) {
-        const ids = req.body.ids;
+        let ids = req.body.ids;
         const projectId = req.params.projectId;
 
         if (!ids || !Array.isArray(ids)) {
             return next(new Error('Invalid request: ids must be an array'));
+        }
+
+        ids = ids.filter((id) => Number.isInteger(id));
+        if (ids.length === 0) {
+            return next(new Error('Invalid request: no valid ids provided'));
         }
 
         try {


### PR DESCRIPTION
This pull request introduces bulk selection and bulk actions (duplicate and delete) for both resources and widgets in the admin interface. It adds UI components and updates hooks to support selecting multiple items and performing actions on them.

**Bulk Actions Functionality**

* Added support for bulk selection of resources and widgets, allowing users to select multiple items and perform bulk duplicate or delete actions from the UI.
* Introduced a reusable `ConfirmActionDialog` component for confirming destructive or duplicative actions, which is now used for both single and bulk actions.

**API and Hook Enhancements**

* Extended the `useResources` and `useWidgetsHook` hooks to support bulk deletion and duplication via new endpoints. The `remove` functions now accept multiple IDs, and new `duplicate` functions are added.
* Extended the `resource` and `widget` API endpoints to perform the duplicate and delete actions when called