### PR TITLE
Node 24 upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Image used for building dependencies
-FROM node:18-slim AS builder
+FROM node:24-slim AS builder
 ENV GITHUB_REPOSITORY=openstad/openstad-headless
 
 LABEL org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}
@@ -69,7 +69,7 @@ RUN npm run build --if-present -w $WORKSPACE
 RUN npm prune -ws --production
 
 # Release image
-FROM node:18-slim AS release
+FROM node:24-slim AS release
 ARG APP
 ARG PORT
 ARG NODE_ENV

--- a/apps/api-server/package.json
+++ b/apps/api-server/package.json
@@ -86,7 +86,6 @@
     "mjml": "^5.0.0-alpha.6",
     "morgan": "^1.10.0",
     "mysql2": "^3.9.7",
-    "node-fetch": "^2.6.7",
     "nodemailer": "^6.7.3",
     "nodemon": "^3.0.1",
     "nunjucks": "^3.2.3",

--- a/apps/api-server/src/adapter/oidc/router.js
+++ b/apps/api-server/src/adapter/oidc/router.js
@@ -1,7 +1,6 @@
 const config = require('config');
 const express = require('express');
 const createError = require('http-errors');
-const fetch = require('node-fetch');
 const jwt = require('jsonwebtoken');
 const Sequelize = require('sequelize');
 const db = require('../../db');

--- a/apps/api-server/src/adapter/oidc/service.js
+++ b/apps/api-server/src/adapter/oidc/service.js
@@ -1,4 +1,3 @@
-const fetch = require('node-fetch');
 const mapUserData = require('../../util/map-user-data');
 
 let service = {};

--- a/apps/api-server/src/adapter/openstad/router.js
+++ b/apps/api-server/src/adapter/openstad/router.js
@@ -1,7 +1,6 @@
 const config = require('config');
 const express = require('express');
 const createError = require('http-errors');
-const fetch = require('node-fetch');
 const jwt = require('jsonwebtoken');
 const Sequelize = require('sequelize');
 const db = require('../../db');

--- a/apps/api-server/src/adapter/openstad/service.js
+++ b/apps/api-server/src/adapter/openstad/service.js
@@ -1,4 +1,3 @@
-const fetch = require('node-fetch');
 const merge = require('merge');
 const mapUserData = require('../../util/map-user-data');
 const authSettings = require('../../util/auth-settings');

--- a/apps/api-server/src/middleware/user.js
+++ b/apps/api-server/src/middleware/user.js
@@ -1,7 +1,6 @@
 const config = require('config');
 const jwt = require('jsonwebtoken');
 const merge = require('merge');
-const fetch = require('node-fetch');
 const db = require('../db');
 const authSettings = require('../util/auth-settings');
 

--- a/apps/api-server/src/models/Resource.js
+++ b/apps/api-server/src/models/Resource.js
@@ -96,6 +96,7 @@ module.exports = function (db, sequelize, DataTypes) {
         type: DataTypes.ENUM(
           'superuser',
           'admin',
+          'moderator',
           'editor',
           'member',
           'anonymous',

--- a/apps/api-server/src/routes/api/image-verification-link.js
+++ b/apps/api-server/src/routes/api/image-verification-link.js
@@ -1,4 +1,3 @@
-const fetch = require('node-fetch');
 const createError = require('http-errors');
 const config = require('config');
 const db = require('../../db');

--- a/apps/api-server/src/routes/api/project.js
+++ b/apps/api-server/src/routes/api/project.js
@@ -1,6 +1,5 @@
 const express 				= require('express');
 const config 					= require('config');
-const fetch           = require('node-fetch');
 const merge           = require('merge');
 const Sequelize       = require('sequelize');
 const db      				= require('../../db');

--- a/apps/api-server/src/routes/api/template.js
+++ b/apps/api-server/src/routes/api/template.js
@@ -1,4 +1,3 @@
-const fetch = require('node-fetch');
 const createError = require('http-errors');
 const config = require('config');
 const db = require('../../db');

--- a/apps/api-server/src/routes/api/user.js
+++ b/apps/api-server/src/routes/api/user.js
@@ -7,7 +7,6 @@ const auth = require('../../middleware/sequelize-authorization-middleware');
 const pagination = require('../../middleware/pagination');
 const {Op} = require('sequelize');
 const searchInResults = require('../../middleware/search-in-results');
-const fetch = require('node-fetch');
 const merge = require('merge');
 const authSettings = require('../../util/auth-settings');
 const hasRole = require('../../lib/sequelize-authorization/lib/hasRole');

--- a/apps/auth-server/services/verificationService.js
+++ b/apps/auth-server/services/verificationService.js
@@ -1,5 +1,4 @@
 const emailProvider = require('./email');
-const fetch = require('node-fetch');
 const tokenUrl = require('./tokenUrl');
 const tokenSMS = require('./tokenSMS');
 

--- a/apps/cms-server/modules/openstad-auth/index.js
+++ b/apps/cms-server/modules/openstad-auth/index.js
@@ -3,7 +3,6 @@
  * and if valid fetches the user data
  */
 
-const fetch = require('node-fetch');
 const Url = require('url');
 const expressSession = require('express-session');
 

--- a/apps/cms-server/services/projects.js
+++ b/apps/cms-server/services/projects.js
@@ -1,4 +1,3 @@
-const fetch = require('node-fetch');
 const apiUrl = process.env.API_URL_INTERNAL || process.env.API_URL;
 
 const fetchAll = async () => {

--- a/apps/cms-server/vitest.config.ts
+++ b/apps/cms-server/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     exclude: [
         "modules/openstad-assets/ui/src/vendor/bootstrap/js/tests/*",
+        "apos-build/**"
     ]
   },
 })

--- a/apps/image-server/README.md
+++ b/apps/image-server/README.md
@@ -63,7 +63,6 @@ Example with node.js, using node-fetch & form-data. Notice dotenv is used for AP
 
 ```
 const FormData = require('form-data');
-const fetch = require('node-fetch');
 
 exports.upload = function (token, buffer, fileName) {
   const form = new FormData();

--- a/package-lock.json
+++ b/package-lock.json
@@ -287,7 +287,6 @@
         "mjml": "^5.0.0-alpha.6",
         "morgan": "^1.10.0",
         "mysql2": "^3.9.7",
-        "node-fetch": "^2.6.7",
         "nodemailer": "^6.7.3",
         "nodemon": "^3.0.1",
         "nunjucks": "^3.2.3",
@@ -3431,9 +3430,9 @@
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.3.tgz",
-      "integrity": "sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
+      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/core": "^1.7.3",
@@ -3441,12 +3440,12 @@
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.5.tgz",
-      "integrity": "sha512-HDO/1/1oH9fjj4eLgegrlH3dklZpHtUYYFiVwMUwfGvk9jWDRWqkklA2/NFScknrcNSspbV868WjXORvreDX+Q==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
+      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.7.3"
+        "@floating-ui/dom": "^1.7.4"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -9767,9 +9766,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.46.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.46.4.tgz",
-      "integrity": "sha512-B2wfzCJ+ps/OBzRjeds7DlJumCU3rXMxJJS1vzURyj7+KBHGONm7c9q1TfdBl4vCuNMkDvARn3PBl2wZzuR5mw==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.47.0.tgz",
+      "integrity": "sha512-Weap5hVbZs/yIvUZcFpAmIso8rLmwkO1LesddNjeX28tIhQkAKjRuVgAJ2xpj8wXTny7IZro9aBIgGov0qsL4A==",
       "cpu": [
         "arm"
       ],
@@ -9780,9 +9779,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.46.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.46.4.tgz",
-      "integrity": "sha512-FGJYXvYdn8Bs6lAlBZYT5n+4x0ciEp4cmttsvKAZc/c8/JiPaQK8u0c/86vKX8lA7OY/+37lIQSe0YoAImvBAA==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.47.0.tgz",
+      "integrity": "sha512-XcnlqvG5riTJByKX7bZ1ehe48GiF+eNkdnzV0ziLp85XyJ6tLPfhkXHv3e0h3cpZESTQa8IB+ZHhV/r02+8qKw==",
       "cpu": [
         "arm64"
       ],
@@ -9793,9 +9792,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.46.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.46.4.tgz",
-      "integrity": "sha512-/9qwE/BM7ATw/W/OFEMTm3dmywbJyLQb4f4v5nmOjgYxPIGpw7HaxRi6LnD4Pjn/q7k55FGeHe1/OD02w63apA==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.47.0.tgz",
+      "integrity": "sha512-kZzTIzmzAUOKteh688kN88HNaL7wxwTz9XB5dDK94AQdf9nD+lxm/H5uPKQaawUFS+klBEowqPMUPjBRKGbo/g==",
       "cpu": [
         "arm64"
       ],
@@ -9806,9 +9805,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.46.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.46.4.tgz",
-      "integrity": "sha512-QkWfNbeRuzFnv2d0aPlrzcA3Ebq2mE8kX/5Pl7VdRShbPBjSnom7dbT8E3Jmhxo2RL784hyqGvR5KHavCJQciw==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.47.0.tgz",
+      "integrity": "sha512-WaMrgHRbFspYjvycbsbqheBmlsQBLwfZVWv/KFsT212Yz/RjEQ/9KEp1/p0Ef3ZNwbWsylmgf69St66D9NQNHw==",
       "cpu": [
         "x64"
       ],
@@ -9819,9 +9818,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.46.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.46.4.tgz",
-      "integrity": "sha512-+ToyOMYnSfV8D+ckxO6NthPln/PDNp1P6INcNypfZ7muLmEvPKXqduUiD8DlJpMMT8LxHcE5W0dK9kXfJke9Zw==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.47.0.tgz",
+      "integrity": "sha512-umfYslurvSmAK5MEyOcOGooQ6EBB2pYePQaTVlrOkIfG6uuwu9egYOlxr35lwsp6XG0NzmXW0/5o150LUioMkQ==",
       "cpu": [
         "arm64"
       ],
@@ -9832,9 +9831,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.46.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.46.4.tgz",
-      "integrity": "sha512-cGT6ey/W+sje6zywbLiqmkfkO210FgRz7tepWAzzEVgQU8Hn91JJmQWNqs55IuglG8sJdzk7XfNgmGRtcYlo1w==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.47.0.tgz",
+      "integrity": "sha512-EFXhIykAl8//4ihOjGNirF89HEUbOB8ev2aiw8ST8wFGwDdIPARh3enDlbp8aFnScl4CDK4DZLQYXaM6qpxzZw==",
       "cpu": [
         "x64"
       ],
@@ -9845,9 +9844,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.46.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.46.4.tgz",
-      "integrity": "sha512-9fhTJyOb275w5RofPSl8lpr4jFowd+H4oQKJ9XTYzD1JWgxdZKE8bA6d4npuiMemkecQOcigX01FNZNCYnQBdA==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.47.0.tgz",
+      "integrity": "sha512-EwkC5N61ptruQ9wNkYfLgUWEGh+F3JZSGHkUWhaK2ISAK0d0xmiMKF0trFhRqPQFov5d9DmFiFIhWB5IC79OUA==",
       "cpu": [
         "arm"
       ],
@@ -9858,9 +9857,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.46.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.46.4.tgz",
-      "integrity": "sha512-+6kCIM5Zjvz2HwPl/udgVs07tPMIp1VU2Y0c72ezjOvSvEfAIWsUgpcSDvnC7g9NrjYR6X9bZT92mZZ90TfvXw==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.47.0.tgz",
+      "integrity": "sha512-Iz/g1X94vIjppA4H9hN3VEedw4ObC+u+aua2J/VPJnENEJ0GeCAPBN15nJc5pS5M8JPlUhOd3oqhOWX6Un4RHA==",
       "cpu": [
         "arm"
       ],
@@ -9871,9 +9870,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.46.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.46.4.tgz",
-      "integrity": "sha512-SWuXdnsayCZL4lXoo6jn0yyAj7TTjWE4NwDVt9s7cmu6poMhtiras5c8h6Ih6Y0Zk6Z+8t/mLumvpdSPTWub2Q==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.47.0.tgz",
+      "integrity": "sha512-eYEYHYjFo/vb6k1l5uq5+Af9yuo9WaST/z+/8T5gkee+A0Sfx1NIPZtKMEQOLjm/oaeHFGpWaAO97gTPhouIfQ==",
       "cpu": [
         "arm64"
       ],
@@ -9884,9 +9883,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.46.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.46.4.tgz",
-      "integrity": "sha512-vDknMDqtMhrrroa5kyX6tuC0aRZZlQ+ipDfbXd2YGz5HeV2t8HOl/FDAd2ynhs7Ki5VooWiiZcCtxiZ4IjqZwQ==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.47.0.tgz",
+      "integrity": "sha512-LX2x0/RszFEmDfjzL6kG/vihD5CkpJ+0K6lcbqX0jAopkkXeY2ZjStngdFMFW+BK7pyrqryJgy6Jt3+oyDxrSA==",
       "cpu": [
         "arm64"
       ],
@@ -9897,9 +9896,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.46.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.46.4.tgz",
-      "integrity": "sha512-mCBkjRZWhvjtl/x+Bd4fQkWZT8canStKDxGrHlBiTnZmJnWygGcvBylzLVCZXka4dco5ymkWhZlLwKCGFF4ivw==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.47.0.tgz",
+      "integrity": "sha512-0U+56rJmJvqBCwlPFz/BcxkvdiRdNPamBfuFHrOGQtGajSMJ2OqzlvOgwj5vReRQnSA6XMKw/JL1DaBhceil+g==",
       "cpu": [
         "loong64"
       ],
@@ -9910,9 +9909,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.46.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.46.4.tgz",
-      "integrity": "sha512-YMdz2phOTFF+Z66dQfGf0gmeDSi5DJzY5bpZyeg9CPBkV9QDzJ1yFRlmi/j7WWRf3hYIWrOaJj5jsfwgc8GTHQ==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.47.0.tgz",
+      "integrity": "sha512-2VKOsnNyvS05HFPKtmAWtef+nZyKCot/V3Jh/A5sYMhUvtthNjp6CjakYTtc5xZ8J8Fp5FKrUWGxptVtZ2OzEA==",
       "cpu": [
         "ppc64"
       ],
@@ -9923,9 +9922,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.46.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.46.4.tgz",
-      "integrity": "sha512-r0WKLSfFAK8ucG024v2yiLSJMedoWvk8yWqfNICX28NHDGeu3F/wBf8KG6mclghx4FsLePxJr/9N8rIj1PtCnw==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.47.0.tgz",
+      "integrity": "sha512-uY5UP7YZM4DMQiiP9Fl4/7O3UbT2p3uI0qvqLXZSGWBfyYuqi2DYQ48ExylgBN3T8AJork+b+mLGq6VXsxBfuw==",
       "cpu": [
         "riscv64"
       ],
@@ -9936,9 +9935,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.46.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.46.4.tgz",
-      "integrity": "sha512-IaizpPP2UQU3MNyPH1u0Xxbm73D+4OupL0bjo4Hm0496e2wg3zuvoAIhubkD1NGy9fXILEExPQy87mweujEatA==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.47.0.tgz",
+      "integrity": "sha512-qpcN2+/ivq3TcrXtZoHrS9WZplV3Nieh0gvnGb+SFZg7h/YkWsOXINJnjJRWHp9tEur7T8lMnMeQMPS7s9MjUg==",
       "cpu": [
         "riscv64"
       ],
@@ -9949,9 +9948,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.46.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.46.4.tgz",
-      "integrity": "sha512-aCM29orANR0a8wk896p6UEgIfupReupnmISz6SUwMIwTGaTI8MuKdE0OD2LvEg8ondDyZdMvnaN3bW4nFbATPA==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.47.0.tgz",
+      "integrity": "sha512-XfuI+o7a2/KA2tBeP+J1CT3siyIQyjpGEL6fFvtUdoHJK1k5iVI3qeGT2i5y6Bb+xQu08AHKBsUGJ2GsOZzXbQ==",
       "cpu": [
         "s390x"
       ],
@@ -9962,9 +9961,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.46.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.46.4.tgz",
-      "integrity": "sha512-0Xj1vZE3cbr/wda8d/m+UeuSL+TDpuozzdD4QaSzu/xSOMK0Su5RhIkF7KVHFQsobemUNHPLEcYllL7ZTCP/Cg==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.47.0.tgz",
+      "integrity": "sha512-ylkLO6G7oUiN28mork3caDmgXHqRuopAxjYDaOqs4CoU9pkfR0R/pGQb2V1x2Zg3tlFj4b/DvxZroxC3xALX6g==",
       "cpu": [
         "x64"
       ],
@@ -9975,9 +9974,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.46.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.46.4.tgz",
-      "integrity": "sha512-kM/orjpolfA5yxsx84kI6bnK47AAZuWxglGKcNmokw2yy9i5eHY5UAjcX45jemTJnfHAWo3/hOoRqEeeTdL5hw==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.47.0.tgz",
+      "integrity": "sha512-1L72a+ice8xKqJ2afsAVW9EfECOhNMAOC1jH65TgghLaHSFwNzyEdeye+1vRFDNy52OGKip/vajj0ONtX7VpAg==",
       "cpu": [
         "x64"
       ],
@@ -9988,9 +9987,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.46.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.46.4.tgz",
-      "integrity": "sha512-cNLH4psMEsWKILW0isbpQA2OvjXLbKvnkcJFmqAptPQbtLrobiapBJVj6RoIvg6UXVp5w0wnIfd/Q56cNpF+Ew==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.47.0.tgz",
+      "integrity": "sha512-wluhdd1uNLk/S+ex2Yj62WFw3un2cZo2ZKXy9cOuoti5IhaPXSDSvxT3os+SJ1cjNorE1PwAOfiJU7QUH6n3Zw==",
       "cpu": [
         "arm64"
       ],
@@ -10001,9 +10000,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.46.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.46.4.tgz",
-      "integrity": "sha512-OiEa5lRhiANpv4SfwYVgQ3opYWi/QmPDC5ve21m8G9pf6ZO+aX1g2EEF1/IFaM1xPSP7mK0msTRXlPs6mIagkg==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.47.0.tgz",
+      "integrity": "sha512-0SMTA6AeG7u2rfwdkKSo6aZD/obmA7oyhR+4ePwLzlwxNE8sfSI9zmjZXtchvBAZmtkVQNt/lZ6RxSl9wBj4pw==",
       "cpu": [
         "ia32"
       ],
@@ -10014,9 +10013,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.46.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.46.4.tgz",
-      "integrity": "sha512-IKL9mewGZ5UuuX4NQlwOmxPyqielvkAPUS2s1cl6yWjjQvyN3h5JTdVFGD5Jr5xMjRC8setOfGQDVgX8V+dkjg==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.47.0.tgz",
+      "integrity": "sha512-mw1/7kAGxLcfzoG7DIKFHvKr2ZUQasKOPCgT2ubkNZPgIDZOJPymqThtRWEeAlXBoipehP4BUFpBAZIrPhFg8Q==",
       "cpu": [
         "x64"
       ],
@@ -12742,39 +12741,39 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.18.tgz",
-      "integrity": "sha512-3slwjQrrV1TO8MoXgy3aynDQ7lslj5UqDxuHnrzHtpON5CBinhWjJETciPngpin/T3OuW3tXUf86tEurusnztw==",
+      "version": "3.5.19",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.19.tgz",
+      "integrity": "sha512-/afpyvlkrSNYbPo94Qu8GtIOWS+g5TRdOvs6XZNw6pWQQmj5pBgSZvEPOIZlqWq0YvoUhDDQaQ2TnzuJdOV4hA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@vue/shared": "3.5.18",
+        "@babel/parser": "^7.28.3",
+        "@vue/shared": "3.5.19",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.18.tgz",
-      "integrity": "sha512-RMbU6NTU70++B1JyVJbNbeFkK+A+Q7y9XKE2EM4NLGm2WFR8x9MbAtWxPPLdm0wUkuZv9trpwfSlL6tjdIa1+A==",
+      "version": "3.5.19",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.19.tgz",
+      "integrity": "sha512-Drs6rPHQZx/pN9S6ml3Z3K/TWCIRPvzG2B/o5kFK9X0MNHt8/E+38tiRfojufrYBfA6FQUFB2qBBRXlcSXWtOA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.18",
-        "@vue/shared": "3.5.18"
+        "@vue/compiler-core": "3.5.19",
+        "@vue/shared": "3.5.19"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.18.tgz",
-      "integrity": "sha512-5aBjvGqsWs+MoxswZPoTB9nSDb3dhd1x30xrrltKujlCxo48j8HGDNj3QPhF4VIS0VQDUrA1xUfp2hEa+FNyXA==",
+      "version": "3.5.19",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.19.tgz",
+      "integrity": "sha512-YWCm1CYaJ+2RvNmhCwI7t3I3nU+hOrWGWMsn+Z/kmm1jy5iinnVtlmkiZwbLlbV1SRizX7vHsc0/bG5dj0zRTg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.0",
-        "@vue/compiler-core": "3.5.18",
-        "@vue/compiler-dom": "3.5.18",
-        "@vue/compiler-ssr": "3.5.18",
-        "@vue/shared": "3.5.18",
+        "@babel/parser": "^7.28.3",
+        "@vue/compiler-core": "3.5.19",
+        "@vue/compiler-dom": "3.5.19",
+        "@vue/compiler-ssr": "3.5.19",
+        "@vue/shared": "3.5.19",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.17",
         "postcss": "^8.5.6",
@@ -12782,13 +12781,13 @@
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.18.tgz",
-      "integrity": "sha512-xM16Ak7rSWHkM3m22NlmcdIM+K4BMyFARAfV9hYFl+SFuRzrZ3uGMNW05kA5pmeMa0X9X963Kgou7ufdbpOP9g==",
+      "version": "3.5.19",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.19.tgz",
+      "integrity": "sha512-/wx0VZtkWOPdiQLWPeQeqpHWR/LuNC7bHfSX7OayBTtUy8wur6vT6EQIX6Et86aED6J+y8tTw43qo2uoqGg5sw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.18",
-        "@vue/shared": "3.5.18"
+        "@vue/compiler-dom": "3.5.19",
+        "@vue/shared": "3.5.19"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -12798,53 +12797,53 @@
       "license": "MIT"
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.18.tgz",
-      "integrity": "sha512-x0vPO5Imw+3sChLM5Y+B6G1zPjwdOri9e8V21NnTnlEvkxatHEH5B5KEAJcjuzQ7BsjGrKtfzuQ5eQwXh8HXBg==",
+      "version": "3.5.19",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.19.tgz",
+      "integrity": "sha512-4bueZg2qs5MSsK2dQk3sssV0cfvxb/QZntTC8v7J448GLgmfPkQ+27aDjlt40+XFqOwUq5yRxK5uQh14Fc9eVA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.5.18"
+        "@vue/shared": "3.5.19"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.18.tgz",
-      "integrity": "sha512-DUpHa1HpeOQEt6+3nheUfqVXRog2kivkXHUhoqJiKR33SO4x+a5uNOMkV487WPerQkL0vUuRvq/7JhRgLW3S+w==",
+      "version": "3.5.19",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.19.tgz",
+      "integrity": "sha512-TaooCr8Hge1sWjLSyhdubnuofs3shhzZGfyD11gFolZrny76drPwBVQj28/z/4+msSFb18tOIg6VVVgf9/IbIA==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.18",
-        "@vue/shared": "3.5.18"
+        "@vue/reactivity": "3.5.19",
+        "@vue/shared": "3.5.19"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.18.tgz",
-      "integrity": "sha512-YwDj71iV05j4RnzZnZtGaXwPoUWeRsqinblgVJwR8XTXYZ9D5PbahHQgsbmzUvCWNF6x7siQ89HgnX5eWkr3mw==",
+      "version": "3.5.19",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.19.tgz",
+      "integrity": "sha512-qmahqeok6ztuUTmV8lqd7N9ymbBzctNF885n8gL3xdCC1u2RnM/coX16Via0AiONQXUoYpxPojL3U1IsDgSWUQ==",
       "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.5.18",
-        "@vue/runtime-core": "3.5.18",
-        "@vue/shared": "3.5.18",
+        "@vue/reactivity": "3.5.19",
+        "@vue/runtime-core": "3.5.19",
+        "@vue/shared": "3.5.19",
         "csstype": "^3.1.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.18.tgz",
-      "integrity": "sha512-PvIHLUoWgSbDG7zLHqSqaCoZvHi6NNmfVFOqO+OnwvqMz/tqQr3FuGWS8ufluNddk7ZLBJYMrjcw1c6XzR12mA==",
+      "version": "3.5.19",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.19.tgz",
+      "integrity": "sha512-ZJ/zV9SQuaIO+BEEVq/2a6fipyrSYfjKMU3267bPUk+oTx/hZq3RzV7VCh0Unlppt39Bvh6+NzxeopIFv4HJNg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.5.18",
-        "@vue/shared": "3.5.18"
+        "@vue/compiler-ssr": "3.5.19",
+        "@vue/shared": "3.5.19"
       },
       "peerDependencies": {
-        "vue": "3.5.18"
+        "vue": "3.5.19"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.18.tgz",
-      "integrity": "sha512-cZy8Dq+uuIXbxCZpuLd2GJdeSO/lIzIspC2WtkqIpje5QyFbvLaI5wZtdUjLHjGZrlVX6GilejatWwVYYRc8tA==",
+      "version": "3.5.19",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.19.tgz",
+      "integrity": "sha512-IhXCOn08wgKrLQxRFKKlSacWg4Goi1BolrdEeLYn6tgHjJNXVrWJ5nzoxZqNwl5p88aLlQ8LOaoMa3AYvaKJ/Q==",
       "license": "MIT"
     },
     "node_modules/@webassemblyjs/ast": {
@@ -14325,9 +14324,9 @@
       "optional": true
     },
     "node_modules/bare-fs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.2.0.tgz",
-      "integrity": "sha512-oRfrw7gwwBVAWx9S5zPMo2iiOjxyiZE12DmblmMQREgcogbNO0AFaZ+QBxxkEXiPspcpvO/Qtqn8LabUx4uYXg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.2.1.tgz",
+      "integrity": "sha512-mELROzV0IhqilFgsl1gyp48pnZsaV9xhQapHLDsvn4d4ZTfbFhcghQezl7FTEDNBcGqLUnNI3lUlm6ecrLWdFA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -15010,9 +15009,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001735",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001735.tgz",
-      "integrity": "sha512-EV/laoX7Wq2J9TQlyIXRxTJqIw4sxfXS4OYgudGxBYRuTv0q7AM6yMEpU/Vo1I94thg9U6EZ2NfZx9GJq83u7w==",
+      "version": "1.0.30001736",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001736.tgz",
+      "integrity": "sha512-ImpN5gLEY8gWeqfLUyEF4b7mYWcYoR2Si1VhnrbM4JizRFmfGaAQ12PhNykq6nvI4XvKLrsp8Xde74D5phJOSw==",
       "funding": [
         {
           "type": "opencollective",
@@ -31061,9 +31060,9 @@
       "license": "MIT"
     },
     "node_modules/rollup": {
-      "version": "4.46.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.46.4.tgz",
-      "integrity": "sha512-YbxoxvoqNg9zAmw4+vzh1FkGAiZRK+LhnSrbSrSXMdZYsRPDWoshcSd/pldKRO6lWzv/e9TiJAVQyirYIeSIPQ==",
+      "version": "4.47.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.47.0.tgz",
+      "integrity": "sha512-jZVxJwlAptA83ftdZK1kjLZfi0f6o+vVX7ub3HaRzkehLO3l4VB4vYpMHyunhBt1sawv9fiRWPA8Qi/sbg9Kcw==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -31076,26 +31075,26 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.46.4",
-        "@rollup/rollup-android-arm64": "4.46.4",
-        "@rollup/rollup-darwin-arm64": "4.46.4",
-        "@rollup/rollup-darwin-x64": "4.46.4",
-        "@rollup/rollup-freebsd-arm64": "4.46.4",
-        "@rollup/rollup-freebsd-x64": "4.46.4",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.46.4",
-        "@rollup/rollup-linux-arm-musleabihf": "4.46.4",
-        "@rollup/rollup-linux-arm64-gnu": "4.46.4",
-        "@rollup/rollup-linux-arm64-musl": "4.46.4",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.46.4",
-        "@rollup/rollup-linux-ppc64-gnu": "4.46.4",
-        "@rollup/rollup-linux-riscv64-gnu": "4.46.4",
-        "@rollup/rollup-linux-riscv64-musl": "4.46.4",
-        "@rollup/rollup-linux-s390x-gnu": "4.46.4",
-        "@rollup/rollup-linux-x64-gnu": "4.46.4",
-        "@rollup/rollup-linux-x64-musl": "4.46.4",
-        "@rollup/rollup-win32-arm64-msvc": "4.46.4",
-        "@rollup/rollup-win32-ia32-msvc": "4.46.4",
-        "@rollup/rollup-win32-x64-msvc": "4.46.4",
+        "@rollup/rollup-android-arm-eabi": "4.47.0",
+        "@rollup/rollup-android-arm64": "4.47.0",
+        "@rollup/rollup-darwin-arm64": "4.47.0",
+        "@rollup/rollup-darwin-x64": "4.47.0",
+        "@rollup/rollup-freebsd-arm64": "4.47.0",
+        "@rollup/rollup-freebsd-x64": "4.47.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.47.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.47.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.47.0",
+        "@rollup/rollup-linux-arm64-musl": "4.47.0",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.47.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.47.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.47.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.47.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.47.0",
+        "@rollup/rollup-linux-x64-gnu": "4.47.0",
+        "@rollup/rollup-linux-x64-musl": "4.47.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.47.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.47.0",
+        "@rollup/rollup-win32-x64-msvc": "4.47.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -35074,9 +35073,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.11.0.tgz",
-      "integrity": "sha512-heTSIac3iLhsmZhUCjyS3JQEkZELateufzZuBaVM5RHXdSBMb1LPMQf5x+FH7qjsZYDP0ttAc3nnVpUB+wYbOg==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
+      "integrity": "sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -35736,16 +35735,16 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.5.18",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.18.tgz",
-      "integrity": "sha512-7W4Y4ZbMiQ3SEo+m9lnoNpV9xG7QVMLa+/0RFwwiAVkeYoyGXqWE85jabU4pllJNUzqfLShJ5YLptewhCWUgNA==",
+      "version": "3.5.19",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.19.tgz",
+      "integrity": "sha512-ZRh0HTmw6KChRYWgN8Ox/wi7VhpuGlvMPrHjIsdRbzKNgECFLzy+dKL5z9yGaBSjCpmcfJCbh3I1tNSRmBz2tg==",
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.18",
-        "@vue/compiler-sfc": "3.5.18",
-        "@vue/runtime-dom": "3.5.18",
-        "@vue/server-renderer": "3.5.18",
-        "@vue/shared": "3.5.18"
+        "@vue/compiler-dom": "3.5.19",
+        "@vue/compiler-sfc": "3.5.19",
+        "@vue/runtime-dom": "3.5.19",
+        "@vue/server-renderer": "3.5.19",
+        "@vue/shared": "3.5.19"
       },
       "peerDependencies": {
         "typescript": "*"


### PR DESCRIPTION
This PR upgrades the Node version to 24. This version will be the active LTS in November 2025, meaning we can stay on this version for 2 years.

I have removed the `node-fetch` dependency as `fetch` is now built-in. I also noticed a bug with vitest now using the `apos-build` folder for tests as well, so I have that excluded.

In my own testing I found some errors regarding a missing `moderator` role in the Resource model, so I added that in to prevent that error. I've seen no other big issues locally, and the unit / end-to-end tests work well still.