### PR TITLE
Feat/map settings and improvements

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/settings/map.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/settings/map.tsx
@@ -38,6 +38,7 @@ const formSchema = z.object({
   areaId: z.string().optional(),
   tilesVariant: z.string().optional(),
   customUrl: z.string().optional(),
+  autoZoomAndCenter: z.string().optional(),
 });
 
 export default function ProjectSettingsMap() {
@@ -55,6 +56,7 @@ export default function ProjectSettingsMap() {
         areaId: data?.config?.map?.areaId || '',
         tilesVariant: data?.config?.map?.tilesVariant || 'nlmaps',
         customUrl: data?.config?.map?.customUrl || '',
+        autoZoomAndCenter: data?.config?.map?.autoZoomAndCenter || 'area',
       }
     },
     [data, areas]
@@ -78,6 +80,7 @@ export default function ProjectSettingsMap() {
           maxZoom: values.maxZoom,
           tilesVariant: values.tilesVariant,
           customUrl: values.customUrl,
+          autoZoomAndCenter: values.autoZoomAndCenter,
         },
       });
       if (project) {
@@ -252,6 +255,40 @@ export default function ProjectSettingsMap() {
                   )}
                 />
               )}
+
+              <FormField
+                control={form.control}
+                name="autoZoomAndCenter"
+                render={({ field }) => (
+                  <FormItem className="md:col-span-2">
+                    <FormLabel>
+                      Waarop moet de kaart automatisch centreren?
+                    </FormLabel>
+                    <FormDescription>
+                      Kies of de kaart moet centreren op het geselecteerde gebied (polygoon) of op alle zichtbare punten op de kaart. Het centreren gebeurt bij het laden van de pagina en na het filteren in een overzicht.
+                    </FormDescription>
+                    <Select
+                      onValueChange={field.onChange}
+                      value={field.value || 'area'}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder="Gebied" />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="area">
+                          <strong>Gebied</strong>: De kaart zoomt automatisch in en centreert zich op het geselecteerde gebied (polygoon).
+                        </SelectItem>
+                        <SelectItem value="markers">
+                          <strong>Punten</strong>: De kaart zoomt automatisch in en centreert zich op alle zichtbare punten op de kaart.
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
               <Button
                 type="submit"

--- a/apps/admin-server/src/pages/projects/[project]/widgets/begrootmodule/[id]/sorting.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/begrootmodule/[id]/sorting.tsx
@@ -69,9 +69,8 @@ const formSchema = z.object({
   defaultSorting: z.string(),
   sorting: z
     .array(z.object({ value: z.string(), label: z.string() }))
-    .refine((value) => value.some((item) => item), {
-      message: 'You have to select at least one item.',
-    }),
+    .optional()
+    .default([])
 });
 
 export default function WidgetStemBegrootSorting(

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourceoverview/[id]/display.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourceoverview/[id]/display.tsx
@@ -285,6 +285,20 @@ export default function WidgetResourceOverviewDisplay(
             </>
           )}
 
+          <FormField
+            control={form.control}
+            name="displayLocationFilter"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Locatie filter weergeven
+                </FormLabel>
+                {YesNoSelect(field, props)}
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
 
           <Heading size="xl" className="col-span-full mt-6">Tegels</Heading>
           <Separator style={{margin: "-10px 0 0"}} className="my-4 col-span-full" />
@@ -562,20 +576,6 @@ export default function WidgetResourceOverviewDisplay(
               <FormItem>
                 <FormLabel>
                   Tags in dialog weergeven
-                </FormLabel>
-                {YesNoSelect(field, props)}
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name="displayLocationFilter"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>
-                  Locatie filter weergeven
                 </FormLabel>
                 {YesNoSelect(field, props)}
                 <FormMessage />

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourceoverview/[id]/sorting.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourceoverview/[id]/sorting.tsx
@@ -69,9 +69,8 @@ const formSchema = z.object({
   defaultSorting: z.string(),
   sorting: z
     .array(z.object({ value: z.string(), label: z.string() }))
-    .refine((value) => value.some((item) => item), {
-      message: 'You have to select at least one item.',
-    }),
+    .optional()
+    .default([])
 });
 
 export default function WidgetResourceOverviewSorting(

--- a/packages/leaflet-map/src/base-map.tsx
+++ b/packages/leaflet-map/src/base-map.tsx
@@ -589,12 +589,12 @@ const BaseMap = ({
 
   // ToDo: waarom kan ik die niet gewoon als props meesturen
   const tileLayerProps = {
+    ...props,
     tilesVariant,
-    customUrlSetting,
+    "customUrl": customUrlSetting,
     tiles,
     minZoom,
     maxZoom,
-    ...props,
   };
 
   useEffect(() => {

--- a/packages/leaflet-map/src/base-map.tsx
+++ b/packages/leaflet-map/src/base-map.tsx
@@ -298,55 +298,66 @@ const BaseMap = ({
   let [mapRef] = useMapRef(mapId);
 
   const setBoundsAndCenter = useCallback(
-    (polygons: Array<Array<LocationType>>) => {
-      let allPolygons: LocationType[][] = [];
+    (polygons: Array<Array<LocationType>>, focus: "area" | "markers") => {
+      if (focus === 'area') {
+        let allPolygons: LocationType[][] = [];
 
-      if (polygons && Array.isArray(polygons)) {
-        polygons.forEach((points: Array<LocationType>) => {
-          let poly: LocationType[] = [];
-          if (points && Array.isArray(points)) {
-            points.forEach((point: LocationType) => {
-              parseLocation(point);
-              if (point.lat) {
-                poly.push(point);
-              }
-            });
-          }
-          if (poly.length > 0) {
-            allPolygons.push(poly);
-          }
+        if (polygons && Array.isArray(polygons)) {
+          polygons.forEach((points: Array<LocationType>) => {
+            let poly: LocationType[] = [];
+            if (points && Array.isArray(points)) {
+              points.forEach((point: LocationType) => {
+                parseLocation(point);
+                if (point.lat) {
+                  poly.push(point);
+                }
+              });
+            }
+            if (poly.length > 0) {
+              allPolygons.push(poly);
+            }
+          });
+        }
+
+        if (allPolygons.length == 0) {
+          mapRef.panTo(
+            new LatLng(definedCenterPoint.lat, definedCenterPoint.lng)
+          );
+          return;
+        }
+
+        if (allPolygons.length == 1 && allPolygons[0].length == 1 && allPolygons[0][0].lat && allPolygons[0][0].lng) {
+          mapRef.panTo(new LatLng(allPolygons[0][0].lat, allPolygons[0][0].lng));
+          return;
+        }
+
+        let combinedBounds = latLngBounds([]);
+        allPolygons.forEach((poly) => {
+          let bounds = latLngBounds(
+            poly.map(
+              (p) =>
+                new LatLng(
+                  p.lat || definedCenterPoint.lat,
+                  p.lng || definedCenterPoint.lng
+                )
+            )
+          );
+          combinedBounds.extend(bounds);
         });
+
+        mapRef.fitBounds(combinedBounds);
+      } else if (focus === 'markers') {
+        const markersForBounds = currentMarkers?.filter((m) => m.lat && m.lng) || [];
+
+        if (markersForBounds.length == 0) {
+          centerAndZoomHandler('area');
+          return;
+        }
+
+        mapRef.fitBounds( latLngBounds(markersForBounds as [{ "lat": number, "lng": number }]) );
       }
-
-      if (allPolygons.length == 0) {
-        mapRef.panTo(
-          new LatLng(definedCenterPoint.lat, definedCenterPoint.lng)
-        );
-        return;
-      }
-
-      if (allPolygons.length == 1 && allPolygons[0].length == 1 && allPolygons[0][0].lat && allPolygons[0][0].lng) {
-        mapRef.panTo(new LatLng(allPolygons[0][0].lat, allPolygons[0][0].lng));
-        return;
-      }
-
-      let combinedBounds = latLngBounds([]);
-      allPolygons.forEach((poly) => {
-        let bounds = latLngBounds(
-          poly.map(
-            (p) =>
-              new LatLng(
-                p.lat || definedCenterPoint.lat,
-                p.lng || definedCenterPoint.lng
-              )
-          )
-        );
-        combinedBounds.extend(bounds);
-      });
-
-      mapRef.fitBounds(combinedBounds);
     },
-    [center, mapRef]
+    [center, mapRef, currentMarkers]
   );
 
   // map is ready
@@ -355,47 +366,52 @@ const BaseMap = ({
     window.dispatchEvent(event);
   }, [mapId]);
 
-  // auto zoom and center on init
+  const centerAndZoomHandler = useCallback((overwriteAutoZoomAndCenter: string = '') => {
+    const autoZoomAndCenterSetting = overwriteAutoZoomAndCenter || autoZoomAndCenter;
+
+    if (autoZoomAndCenterSetting === 'area') {
+        if (area?.length) {
+          const updatedArea = Array.isArray(area[0]) ? area : [area];
+          setBoundsAndCenter(updatedArea as any, 'area');
+          return;
+        }
+
+        if (!area?.length && visibleMapDataLayers?.length) {
+          const coords = visibleMapDataLayers.reduce((acc: Array<{ lat: number, lng: number }>, layer: MapDataLayer) => {
+            const features = layer?.layer?.features ?? [];
+            features.forEach((feature: MapDataLayerFeature) => {
+              if (feature?.geometry?.type === 'LineString' && Array.isArray(feature.geometry.coordinates)) {
+                (feature.geometry.coordinates as Array<[number, number]>).forEach((coord) => {
+                  acc.push({lat: coord[1], lng: coord[0]});
+                });
+              } else if (feature?.geometry?.type === 'Point' && Array.isArray(feature.geometry.coordinates)) {
+                const coord = feature.geometry.coordinates as [number, number];
+                acc.push({lat: coord[1], lng: coord[0]});
+              }
+            });
+            return acc;
+          }, []);
+
+          if (coords.length > 0) {
+            const bounds = latLngBounds(coords.map((c: any) => [c.lat, c.lng] as [number, number]));
+            mapRef.fitBounds(bounds);
+          }
+          return;
+        }
+      }
+
+      if (currentMarkers?.length || isMapReady) {
+        setBoundsAndCenter([], 'markers');
+      }
+    },
+    [autoZoomAndCenter, area, setBoundsAndCenter, mapRef, visibleMapDataLayers, currentMarkers]
+  )
+
   useEffect(() => {
     if (!mapRef || !autoZoomAndCenter) return;
     if ( !zoomAfterInit && isMapReady ) return;
 
-    if (autoZoomAndCenter === 'area') {
-      if (area?.length) {
-        const updatedArea = Array.isArray(area[0]) ? area : [area];
-        setBoundsAndCenter(updatedArea as any);
-        return;
-      }
-
-      if (!area?.length && visibleMapDataLayers?.length) {
-        const coords = visibleMapDataLayers.reduce((acc: Array<{ lat: number, lng: number }>, layer: MapDataLayer) => {
-          const features = layer?.layer?.features ?? [];
-          features.forEach((feature: MapDataLayerFeature) => {
-            if (feature?.geometry?.type === 'LineString' && Array.isArray(feature.geometry.coordinates)) {
-              (feature.geometry.coordinates as Array<[number, number]>).forEach((coord) => {
-                acc.push({ lat: coord[1], lng: coord[0] });
-              });
-            } else if (feature?.geometry?.type === 'Point' && Array.isArray(feature.geometry.coordinates)) {
-              const coord = feature.geometry.coordinates as [number, number];
-              acc.push({ lat: coord[1], lng: coord[0] });
-            }
-          });
-          return acc;
-        }, []);
-
-        if (coords.length > 0) {
-          const bounds = latLngBounds(coords.map((c: any) => [c.lat, c.lng] as [number, number]));
-          mapRef.fitBounds(bounds);
-        }
-        return;
-      }
-    }
-
-    if (currentMarkers?.length) {
-      setBoundsAndCenter(currentMarkers as any);
-    } else if (center) {
-      setBoundsAndCenter([center] as any);
-    }
+    centerAndZoomHandler();
   }, [isMapReady, mapRef, area, center, autoZoomAndCenter, mapDataLayers, currentMarkers, setBoundsAndCenter]);
 
   // Quick fix for map not being ready on first render. This will set the center and zoom settings correctly.

--- a/packages/leaflet-map/src/base-map.tsx
+++ b/packages/leaflet-map/src/base-map.tsx
@@ -206,6 +206,7 @@ const BaseMap = ({
     datalayer: [],
     enableOnOffSwitching: false,
   },
+  zoomAfterInit = true,
   ...props
 }: PropsWithChildren<BaseMapWidgetProps & { onClick?: (e: LeafletMouseEvent & { isInArea: boolean }, map: object) => void }>) => {
 
@@ -357,6 +358,7 @@ const BaseMap = ({
   // auto zoom and center on init
   useEffect(() => {
     if (!mapRef || !autoZoomAndCenter) return;
+    if ( !zoomAfterInit && isMapReady ) return;
 
     if (autoZoomAndCenter === 'area') {
       if (area?.length) {

--- a/packages/leaflet-map/src/editor-map.tsx
+++ b/packages/leaflet-map/src/editor-map.tsx
@@ -15,7 +15,7 @@ import React from 'react';
 
 const EditorMap = ({
   fieldName = 'location',
-  centerOnEditorMarker = true,
+  centerOnEditorMarker = false,
   editorMarker = undefined,
   markerIcon = undefined,
   center = undefined,
@@ -78,6 +78,7 @@ const EditorMap = ({
         markers={[currentEditorMarker]}
         onClick={updateLocation}
         onMarkerClick={removeMarker}
+        zoomAfterInit={false}
       />
 
       <input

--- a/packages/leaflet-map/src/editor-map.tsx
+++ b/packages/leaflet-map/src/editor-map.tsx
@@ -79,6 +79,7 @@ const EditorMap = ({
         onClick={updateLocation}
         onMarkerClick={removeMarker}
         zoomAfterInit={false}
+        autoZoomAndCenter="area"
       />
 
       <input

--- a/packages/leaflet-map/src/resource-detail-map.tsx
+++ b/packages/leaflet-map/src/resource-detail-map.tsx
@@ -79,7 +79,7 @@ const ResourceDetailMap = ({
         {...props}
         {...zoom}
         area={polygon}
-        autoZoomAndCenter="area"
+        autoZoomAndCenter={props?.map?.autoZoomAndCenter || 'area'}
         center={currentCenter}
         markers={[currentMarker]}
       />

--- a/packages/leaflet-map/src/resource-overview-map.tsx
+++ b/packages/leaflet-map/src/resource-overview-map.tsx
@@ -275,7 +275,7 @@ const ResourceOverviewMap = ({
         {...props}
         {...zoom}
         area={polygon}
-        autoZoomAndCenter="area"
+        autoZoomAndCenter={props?.map?.autoZoomAndCenter || 'area'}
         categorize={{ categories, categorizeByField }}
         center={center}
         markers={currentMarkers}

--- a/packages/leaflet-map/src/types/basemap-props.ts
+++ b/packages/leaflet-map/src/types/basemap-props.ts
@@ -20,6 +20,7 @@ export type BaseMapProps = {
   onMarkerClick?: (e: LeafletMouseEvent, map: any) => void,
   zoomposition?: string,
 	disableDefaultUI?: boolean,
+  zoomAfterInit?: boolean,
   clustering?: MarkerClusterGroupProps,
   categorize?: CategorizeType,
   minZoom?: number,

--- a/packages/resource-overview/src/resource-overview.tsx
+++ b/packages/resource-overview/src/resource-overview.tsx
@@ -697,20 +697,19 @@ function ResourceOverviewInner({
           if (sort === 'createdAt_asc') {
             return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
           }
-          if ( selectedProjects.length > 0 ) {
-            if (sort === 'title') {
-              return a.title.localeCompare(b.title);
-            }
-            if (sort === 'votes_desc') {
-              return b.yes - a.yes;
-            }
-            if (sort === 'votes_asc' || sort === 'ranking') {
-              return a.yes - b.yes;
-            }
-            if (sort === 'random') {
-              return Math.random() - 0.5;
-            }
+          if (sort === 'title') {
+            return a.title.localeCompare(b.title);
           }
+          if (sort === 'votes_desc') {
+            return b.yes - a.yes;
+          }
+          if (sort === 'votes_asc' || sort === 'ranking') {
+            return a.yes - b.yes;
+          }
+          if (sort === 'random') {
+            return Math.random() - 0.5;
+          }
+
           return 0;
         });
 

--- a/packages/types/project-setting-props.ts
+++ b/packages/types/project-setting-props.ts
@@ -77,5 +77,6 @@ export type ProjectSettingProps = {
     areaId: string;
     tilesVariant?: string;
     customUrl?: string;
+    autoZoomAndCenter?: "area" | "markers";
   };
 };

--- a/packages/ui/src/form-elements/map/index.tsx
+++ b/packages/ui/src/form-elements/map/index.tsx
@@ -164,7 +164,7 @@ const MapField: FC<MapProps> = ({
                   fieldRequired={fieldRequired}
                   markerIcon={undefined}
                   centerOnEditorMarker={false}
-                  autoZoomAndCenter='area'
+                  autoZoomAndCenter={props?.map?.autoZoomAndCenter || 'area'}
                   area={polygon}
                   {...zoom}
                   dataLayerSettings={dataLayerSettings}


### PR DESCRIPTION
This pull request introduces a new configurable map setting, `autoZoomAndCenter`, allowing users to control whether maps automatically center and zoom on a selected area or on all visible markers. For the `EditorMap` the auto zoom and center is disabled, to improve user experience.
Additionally the sorting for overviews has changed so more sorting options are available. These options were already selectable in the settings, but weren't allowed in the code for some reason.

**Map configuration and UI improvements:**

* Added a new `autoZoomAndCenter` option to project map settings, allowing selection between centering the map on a selected area (polygon) or on all visible markers. 
* Updated the `ProjectSettingProps` type to include the new `autoZoomAndCenter` property.

**Map rendering logic updates:**

* Refactored the `BaseMap` component and related map components to respect the `autoZoomAndCenter` setting, supporting both "area" and "markers" options for initial zoom and centering. Added a `zoomAfterInit` prop for enabling or disabling auto zoom and center after initialisation.

**Form schema and validation improvements:**

* Updated sorting schemas in widget sorting forms to make the `sorting` field optional with a default empty array, removing the requirement for at least one item.