### PR TITLE
Helm deployments: add low-memory values file

### DIFF
--- a/charts/openstad-headless/low-memory.yaml
+++ b/charts/openstad-headless/low-memory.yaml
@@ -1,0 +1,72 @@
+admin:
+  extraEnvVars:
+    - name: NODE_OPTIONS
+      value: '--max-old-space-size=128 --max-semi-space-size=8'
+  resources:
+    limits:
+      memory: 256Mi
+    requests:
+      memory: 256Mi
+  customCommand:
+    - npm
+    - run
+    - start
+  customWorkingDir: /opt/openstad-headless/apps/admin-server
+
+api:
+  extraEnvVars:
+    - name: NODE_OPTIONS
+      value: '--max-old-space-size=128 --max-semi-space-size=8'
+  resources:
+    limits:
+      memory: 256Mi
+    requests:
+      memory: 256Mi
+  customCommand:
+    - node
+    - server.js
+  customWorkingDir: /opt/openstad-headless/apps/api-server
+
+auth:
+  extraEnvVars:
+    - name: NODE_OPTIONS
+      value: '--max-old-space-size=128 --max-semi-space-size=8'
+  fromEmail: noreply@headless-acc.draad.dev
+  fromName: Openstad Openstad Headless ACC
+  resources:
+    limits:
+      memory: 256Mi
+    requests:
+      memory: 256Mi
+  customCommand:
+    - node
+    - app.js
+  customWorkingDir: /opt/openstad-headless/apps/auth-server
+
+cms:
+  extraEnvVars:
+    - name: NODE_OPTIONS
+      value: '--max-old-space-size=128 --max-semi-space-size=8'
+  resources:
+    limits:
+      memory: 256Mi
+    requests:
+      memory: 256Mi
+  customCommand:
+    - node
+    - app.js
+  customWorkingDir: /opt/openstad-headless/apps/cms-server
+
+image:
+  extraEnvVars:
+    - name: NODE_OPTIONS
+      value: '--max-old-space-size=128 --max-semi-space-size=8'
+  resources:
+    limits:
+      memory: 256Mi
+    requests:
+      memory: 256Mi
+  customCommand:
+    - node
+    - server.js
+  customWorkingDir: /opt/openstad-headless/apps/image-server

--- a/charts/openstad-headless/templates/admin/deployment.yaml
+++ b/charts/openstad-headless/templates/admin/deployment.yaml
@@ -72,5 +72,11 @@ spec:
           {{- if .Values.admin.extraEnvVars }}
           {{- include "common.tplvalues.render" (dict "value" .Values.admin.extraEnvVars "context" $) | nindent 10 }}
           {{- end }}
+        {{- if .Values.admin.customCommand }}
+        command: {{ .Values.admin.customCommand }}
+        {{- end }}
+        {{- if .Values.admin.customWorkingDir }}
+        workingDir: {{ .Values.admin.customWorkingDir }}
+        {{- end }}
         resources:
 {{ toYaml .Values.admin.resources | indent 12 }}

--- a/charts/openstad-headless/templates/api/deployment.yaml
+++ b/charts/openstad-headless/templates/api/deployment.yaml
@@ -214,6 +214,12 @@ spec:
             - containerPort: {{ .Values.api.service.httpPort }}
               name: http
               protocol: TCP
+          {{- if .Values.api.customCommand }}
+          command: {{ .Values.api.customCommand }}
+          {{- end }}
+          {{- if .Values.api.customWorkingDir }}
+          workingDir: {{ .Values.api.customWorkingDir }}
+          {{- end }}
           resources:
 {{ toYaml .Values.api.resources | indent 12 }}
           readinessProbe:

--- a/charts/openstad-headless/templates/auth/deployment.yaml
+++ b/charts/openstad-headless/templates/auth/deployment.yaml
@@ -189,7 +189,12 @@ spec:
           {{- if .Values.auth.extraEnvVars }}
           {{- include "common.tplvalues.render" (dict "value" .Values.auth.extraEnvVars "context" $) | nindent 10 }}
           {{- end }}
-
+        {{- if .Values.auth.customCommand }}
+        command: {{ .Values.auth.customCommand }}
+        {{- end }}
+        {{- if .Values.auth.customWorkingDir }}
+        workingDir: {{ .Values.auth.customWorkingDir }}
+        {{- end }}
         resources:
 {{ toYaml .Values.auth.resources | indent 12 }}
         readinessProbe:

--- a/charts/openstad-headless/templates/cms/deployment.yaml
+++ b/charts/openstad-headless/templates/cms/deployment.yaml
@@ -74,6 +74,12 @@ spec:
           {{- if .Values.cms.extraEnvVars }}
           {{- include "common.tplvalues.render" (dict "value" .Values.cms.extraEnvVars "context" $) | nindent 10 }}
           {{- end }}
+        {{- if .Values.cms.customCommand }}
+        command: {{ .Values.cms.customCommand }}
+        {{- end }}
+        {{- if .Values.cms.customWorkingDir }}
+        workingDir: {{ .Values.cms.customWorkingDir }}
+        {{- end }}
         resources:
 {{ toYaml .Values.cms.resources | indent 12 }}
         volumeMounts:

--- a/charts/openstad-headless/templates/image/deployment.yaml
+++ b/charts/openstad-headless/templates/image/deployment.yaml
@@ -64,6 +64,12 @@ spec:
           {{- if .Values.image.extraEnvVars }}
           {{- include "common.tplvalues.render" (dict "value" .Values.image.extraEnvVars "context" $) | nindent 10 }}
           {{- end }}
+        {{- if .Values.image.customCommand }}
+        command: {{ .Values.image.customCommand }}
+        {{- end }}
+        {{- if .Values.image.customWorkingDir }}
+        workingDir: {{ .Values.image.customWorkingDir }}
+        {{- end }}
         resources:
 {{ toYaml .Values.image.resources | indent 12 }}
         volumeMounts:

--- a/operations/deployments/openstad-headless/environments/prod/images.yml
+++ b/operations/deployments/openstad-headless/environments/prod/images.yml
@@ -1,15 +1,15 @@
 admin:
   deploymentContainer:
-    image: ghcr.io/openstad/admin-server:main-9b1a287
+    image: ghcr.io/openstad/admin-server:main-ccc4f34
 api:
   deploymentContainer:
-    image: ghcr.io/openstad/api-server:main-9b1a287
+    image: ghcr.io/openstad/api-server:main-ccc4f34
 auth:
   deploymentContainer:
-    image: ghcr.io/openstad/auth-server:main-9b1a287
+    image: ghcr.io/openstad/auth-server:main-ccc4f34
 image:
   deploymentContainer:
-    image: ghcr.io/openstad/image-server:main-9b1a287
+    image: ghcr.io/openstad/image-server:main-ccc4f34
 cms:
   deploymentContainer:
-    image: ghcr.io/openstad/cms-server:main-9b1a287
+    image: ghcr.io/openstad/cms-server:main-ccc4f34


### PR DESCRIPTION
This adds a way to override the command & working dir for the deployments in the helm charts, which allows us to run commands other than the default `npm run start`, which also keeps a `npm` process running (not ideal fow low memory deployment).

With the `low-memory.yaml` file, we run in lower memory mode, meaning we cut out `npm run start` and run the node process directly. We also use 256Mi memory per deployment, and change the `--max-old-space-size` and `--max-semi-space-size` for Node accordingly. This will ensure that Node garbage collection is more optimally suited for the new 256Mi memory.