### PR TITLE
Feat/anonymize all users

### DIFF
--- a/apps/admin-server/src/components/notification-form.tsx
+++ b/apps/admin-server/src/components/notification-form.tsx
@@ -25,6 +25,7 @@ import {
 import useNotificationTemplate from '@/hooks/use-notification-template';
 import { fetchSessionUser } from '@/auth';
 import { applyFilters } from '@/lib/nunjucks-filters';
+import {useProject} from "@/hooks/use-project";
 
 const nunjucksEnv = new nunjucks.Environment();
 applyFilters(nunjucksEnv);
@@ -157,6 +158,49 @@ const initialDataEnqueteSubmissionAdmin = `<mjml>
 </mjml>
 `;
 
+const initialDataAccountExpiry = `<mjml>
+        <mj-body background-color="#f6f6f7">
+            <mj-section background-color="#ffffff" padding="20px">
+                <mj-column>
+
+                    <mj-text font-size="20px" color="#333333" font-family="Helvetica" align="center">
+                        We gaan je account verwijderen
+                    </mj-text>
+
+                    <mj-divider border-color="#cccccc" border-width="1px"></mj-divider>
+                    <mj-divider border-width="0" padding="10px"  ></mj-divider>
+
+                    <mj-text  line-height="1.3" font-size="16px" color="#555555" font-family="Helvetica">
+                        Beste {{user.name or 'bezoeker'}},
+                    </mj-text>
+
+                    <mj-text  line-height="1.3" font-size="16px" color="#555555" font-family="Helvetica">
+                        Je bent al een tijd niet actief geweest op de website
+                        
+                        {% if projectUrl %}
+                            <a href="{{projectUrl}}">{{projectUrl}}</a>.
+                        {% else %}
+                            {{projectName}}.
+                        {% endif %}
+                        
+                        We willen niet onnodig je gegevens blijven bewaren, en gaan die daarom verwijderen. Dat betekent dat een eventuele bijdrage die je hebt geleverd op de website, bijvoorbeeld inzendingen en/of reacties, geanonimiseerd worden.
+                    </mj-text>
+
+                    <mj-text  line-height="1.3" font-size="16px" color="#555555" font-family="Helvetica">
+                        Wil je dit liever niet? Dan hoef je alleen een keer in te loggen op de website om je account actief te houden. Doe dit wel voor {{anonymizeDate}}, want anders gaan we op die dag je gegevens verwijderen.
+                    </mj-text>
+
+                    <mj-divider border-width="0" padding="10px" ></mj-divider>
+                    <mj-divider border-color="#cccccc" border-width="1px"></mj-divider>
+
+                    <mj-text  line-height="1.3" font-size="14px" color="#999999" font-family="Helvetica" align="center">
+                        Dit is een automatisch bericht, antwoorden op deze e-mail is niet mogelijk.
+                    </mj-text>
+                </mj-column>
+            </mj-section>
+        </mj-body>
+    </mjml>`;
+
 type Props = {
   type:
   | 'login email'
@@ -244,6 +288,7 @@ export function NotificationForm({ type, engine, id, label, subject, body }: Pro
       || ( type === 'login email' ? initialData : "" )
       || ( type === 'new enquete - admin' ? initialDataEnqueteSubmissionAdmin : "" )
       || ( type === 'new enquete - user' ? initialDataEnqueteSubmissionUser : "" )
+      || ( type === 'user account about to expire' ? initialDataAccountExpiry : "" )
 
   const defaults = React.useCallback(
     () => ({

--- a/apps/admin-server/src/components/ui/alert.tsx
+++ b/apps/admin-server/src/components/ui/alert.tsx
@@ -4,7 +4,9 @@ export function Alert({ variant = 'info', className = '', children }: any) {
   const color =
     variant === 'warning'
       ? 'bg-yellow-100 border-yellow-400 text-yellow-800'
-      : 'bg-blue-100 border-blue-400 text-blue-800';
+      : (variant === 'error'
+        ? 'bg-red-100 border-red-400 text-red-800'
+        : 'bg-blue-100 border-blue-400 text-blue-800');
   return (
     <div className={`border-l-4 p-4 mb-4 ${color} ${className}`}>
       {children}

--- a/apps/admin-server/src/hooks/use-project.tsx
+++ b/apps/admin-server/src/hooks/use-project.tsx
@@ -118,7 +118,10 @@ export function useProject(scopes?: Array<string>) {
         },
       }
     );
-    const data = await res.json();
+
+    if (!res.ok) {
+      throw new Error('Could not anonymize users of the project');
+    }
   }
 
   return {

--- a/apps/admin-server/src/pages/projects/[project]/settings/anonymization.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/settings/anonymization.tsx
@@ -23,12 +23,15 @@ import { Separator } from '@/components/ui/separator';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import toast from 'react-hot-toast';
 import InfoDialog from '@/components/ui/info-hover';
+import {YesNoSelect} from "@/lib/form-widget-helpers";
+import {EditFieldProps} from "@/lib/form-widget-helpers/EditFieldProps";
 
 const formSchema = z.object({
   anonymizeUsersXDaysAfterEndDate: z.coerce.number(),
   warnUsersAfterXDaysOfInactivity: z.coerce.number(),
   anonymizeUsersAfterXDaysOfInactivity: z.coerce.number(),
-  anonymizeUserName: z.string().optional()
+  anonymizeUserName: z.string().optional(),
+  allowAnonymizeUsersAfterEndDate: z.boolean().optional(),
 });
 
 const emailFormSchema = z.object({
@@ -36,7 +39,18 @@ const emailFormSchema = z.object({
   template: z.string(),
 });
 
-export default function ProjectSettingsAnonymization() {
+type ProjectSettingsAnonymizationProps = {
+  anonymizeUsersXDaysAfterEndDate?: number;
+  warnUsersAfterXDaysOfInactivity?: number;
+  anonymizeUsersAfterXDaysOfInactivity?: number;
+  anonymizeUserName?: string;
+  allowAnonymizeUsersAfterEndDate?: boolean;
+};
+
+export default function ProjectSettingsAnonymization(
+  props: ProjectSettingsAnonymizationProps &
+    EditFieldProps<ProjectSettingsAnonymizationProps>
+) {
   const category = 'anonymize';
 
   const router = useRouter();
@@ -50,6 +64,7 @@ export default function ProjectSettingsAnonymization() {
   } = useProject();
   const defaults = useCallback(
     () => ({
+      allowAnonymizeUsersAfterEndDate: data?.config?.[category]?.allowAnonymizeUsersAfterEndDate || false,
       anonymizeUsersXDaysAfterEndDate:
         data?.config?.[category]?.anonymizeUsersXDaysAfterEndDate || null,
       warnUsersAfterXDaysOfInactivity:
@@ -159,22 +174,41 @@ export default function ProjectSettingsAnonymization() {
                   <form
                     onSubmit={form.handleSubmit(onSubmit)}
                     className="space-y-4 lg:w-1/2">
+
                     <FormField
                       control={form.control}
-                      name="anonymizeUsersXDaysAfterEndDate"
+                      name={`allowAnonymizeUsersAfterEndDate`}
                       render={({ field }) => (
                         <FormItem>
                           <FormLabel>
-                            Na hoeveel dagen na het einde van het project worden gebruikers geanonimiseerd?
-                            <InfoDialog content={`Na het aantal ingevoerde dagen worden automatisch alle voor- en achternamen van gebruikers van de website aangepast naar "${ form.watch("anonymizeUserName") || "Gebruiker is geanonimiseerd" }".`} />
+                            Gebruikers automatisch anonimiseren na het beëindigen van het project?
+                            <InfoDialog content={`Als je deze optie aanzet worden gebruikers na het aantal dagen dat je hieronder instelt automatisch geanonimiseerd. Dit gebeurt alleen als het project een einddatum heeft en deze datum is verstreken.`} />
                           </FormLabel>
-                          <FormControl>
-                            <Input type="number" placeholder="60" {...field} />
-                          </FormControl>
+                          {YesNoSelect(field, props)}
                           <FormMessage />
                         </FormItem>
                       )}
                     />
+
+                    { !!form.watch("allowAnonymizeUsersAfterEndDate") && (
+                      <FormField
+                        control={form.control}
+                        name="anonymizeUsersXDaysAfterEndDate"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>
+                              Na hoeveel dagen na het einde van het project worden gebruikers geanonimiseerd?
+                              <InfoDialog content={`Na het aantal ingevoerde dagen worden automatisch alle voor- en achternamen van gebruikers van de website aangepast naar "${ form.watch("anonymizeUserName") || "Gebruiker is geanonimiseerd" }".`} />
+                            </FormLabel>
+                            <FormControl>
+                              <Input type="number" placeholder="60" {...field} />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    )}
+
                     <FormField
                       control={form.control}
                       name="warnUsersAfterXDaysOfInactivity"

--- a/apps/admin-server/src/pages/projects/[project]/settings/anonymization.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/settings/anonymization.tsx
@@ -27,6 +27,7 @@ import {YesNoSelect} from "@/lib/form-widget-helpers";
 import {EditFieldProps} from "@/lib/form-widget-helpers/EditFieldProps";
 import {NotificationForm} from "@/components/notification-form";
 import useNotificationTemplate from "@/hooks/use-notification-template";
+import {Alert, AlertDescription, AlertTitle} from "@/components/ui/alert";
 
 const formSchema = z.object({
   anonymizeUsersXDaysAfterEndDate: z.coerce.number(),
@@ -129,6 +130,9 @@ export default function ProjectSettingsAnonymization(
   const { data: notificationTemplates } = useNotificationTemplate(project as string);
   const template = notificationTemplates?.find((t: {type: string}) => t.type === 'user account about to expire');
 
+  const sendEmail = data?.emailConfig?.notifications?.fromAddress;
+  const isSendEmailNotSet = sendEmail === '' || sendEmail === 'email@not.set';
+
   return (
     <div>
       <PageLayout
@@ -198,6 +202,17 @@ export default function ProjectSettingsAnonymization(
                       />
                     )}
 
+                    {isSendEmailNotSet && (
+                      <Alert variant="error" className="mb-4">
+                        <AlertTitle>Let op!</AlertTitle>
+                        <AlertDescription>
+                          Het e-mailadres voor het versturen van notificaties is nog niet ingesteld.
+                          Stel deze eerst in bij de <a href={`/projects/${project}/settings/notifications`} className="underline">e-mail instellingen</a>.
+                          Zonder een juist ingesteld e-mailadres kunnen er geen waarschuwingsmails worden verstuurd en zullen gebruikers worden geanonimiseerd zonder waarschuwing.
+                        </AlertDescription>
+                      </Alert>
+                    )}
+
                     <FormField
                       control={form.control}
                       name="warnUsersAfterXDaysOfInactivity"
@@ -258,10 +273,10 @@ export default function ProjectSettingsAnonymization(
                   <NotificationForm
                     type="user account about to expire"
                     label="Gebruikersaccount staat op het punt te verlopen"
-                    engine={template.engine}
-                    id={template.id}
-                    subject={template.subject}
-                    body={template.body}
+                    engine={template?.engine}
+                    id={template?.id}
+                    subject={template?.subject}
+                    body={template?.body}
                   />
 
                 </Form>

--- a/apps/admin-server/src/pages/projects/[project]/settings/anonymization.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/settings/anonymization.tsx
@@ -28,6 +28,7 @@ const formSchema = z.object({
   anonymizeUsersXDaysAfterEndDate: z.coerce.number(),
   warnUsersAfterXDaysOfInactivity: z.coerce.number(),
   anonymizeUsersAfterXDaysOfInactivity: z.coerce.number(),
+  anonymizeUserName: z.string().optional()
 });
 
 const emailFormSchema = z.object({
@@ -55,6 +56,8 @@ export default function ProjectSettingsAnonymization() {
         data?.config?.[category]?.warnUsersAfterXDaysOfInactivity || null,
       anonymizeUsersAfterXDaysOfInactivity:
         data?.config?.[category]?.anonymizeUsersAfterXDaysOfInactivity || null,
+      anonymizeUserName:
+        data?.config?.[category]?.anonymizeUserName || 'Gebruiker is geanonimiseerd'
     }),
     [data?.config]
   );
@@ -116,8 +119,9 @@ export default function ProjectSettingsAnonymization() {
   async function anonymizeAllUsers() {
     try {
       await anonymizeUsersOfProject();
+      toast.success('Alle gebruikers zijn geanonimiseerd!');
     } catch (error) {
-      console.error('Could not anonymize the users', error);
+      toast.error("Het project moet eerst zijn beëindigd voordat gebruikers geanonimiseerd kunnen worden.")
     }
   }
 
@@ -162,7 +166,7 @@ export default function ProjectSettingsAnonymization() {
                         <FormItem>
                           <FormLabel>
                             Na hoeveel dagen na het einde van het project worden gebruikers geanonimiseerd?
-                            <InfoDialog content={'Na het aantal ingevoerde dagen worden automatisch alle voor- en achternamen van gebruikers van de website aangepast naar "gebruiker verwijderd".'} />
+                            <InfoDialog content={`Na het aantal ingevoerde dagen worden automatisch alle voor- en achternamen van gebruikers van de website aangepast naar "${ form.watch("anonymizeUserName") || "Gebruiker is geanonimiseerd" }".`} />
                           </FormLabel>
                           <FormControl>
                             <Input type="number" placeholder="60" {...field} />
@@ -198,6 +202,22 @@ export default function ProjectSettingsAnonymization() {
                           </FormLabel>
                           <FormControl>
                             <Input type="number" placeholder="200" {...field} />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name="anonymizeUserName"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>
+                            Hoe worden gebruikers genoemd na anonimisering?
+                            <InfoDialog content={'Standaard wordt de naam van de gebruiker aangepast naar "Gebruiker is geanonimiseerd". Je kunt dit hier aanpassen naar een andere tekst.'} />
+                          </FormLabel>
+                          <FormControl>
+                            <Input type="text" {...field} />
                           </FormControl>
                           <FormMessage />
                         </FormItem>

--- a/apps/api-server/src/cron/anonymize_inactive_users.js
+++ b/apps/api-server/src/cron/anonymize_inactive_users.js
@@ -48,7 +48,6 @@ module.exports = {
                 if (user.email) {
                   const lastLoginDate = new Date(user.lastLogin);
 
-                  const anonymizeAfterXDays = warnUsersAfterXDaysOfInactivity;
                   const lastLoginTime = new Date(user.lastLogin).getTime();
                   const targetAnonymizeWarnTime = lastLoginTime + (warnUsersAfterXDaysOfInactivity * 24 * 60 * 60 * 1000);
 
@@ -58,7 +57,7 @@ module.exports = {
                   }
                   console.log('CRON anonymize-inactive-users: send warning email to user', user.email, user.lastLogin);
 
-                  const anonymizeDate = new Date(lastLogin.getTime() + anonymizeAfterXDays * 24 * 60 * 60 * 1000);
+                  const anonymizeDate = new Date(lastLoginTime + warnUsersAfterXDaysOfInactivity * 24 * 60 * 60 * 1000);
 
                   const dateInDDMMYYYY = (date) => {
                     const day = String(date.getDate()).padStart(2, '0');

--- a/apps/api-server/src/cron/project_ended_anonymize_users.js
+++ b/apps/api-server/src/cron/project_ended_anonymize_users.js
@@ -1,0 +1,69 @@
+const { Sequelize, Op } = require('sequelize');
+const log = require('debug')('app:cron');
+const config = require('config');
+const db = require('../db');
+const UseLock = require('../lib/use-lock');
+
+// Purpose
+// -------
+// Anonymize users in projects that have ended, if the project settings allow it
+//
+// Runs every day
+module.exports = {
+    cronTime: '0 20 4 * * *',
+    runOnInit: false,
+    onTick: UseLock.createLockedExecutable({
+        name: 'project-ended-anonymize-users',
+        task: async (next) => {
+
+            try {
+                let projects = await db.Project.findAll();
+
+                for (const project of projects) {
+                    const projectEndDate = project?.config?.project?.endDate;
+                    let formattedEndDate = new Date(projectEndDate);
+                    const today = new Date().setHours(0,0,0,0);
+
+                    const projectHasEnded = projectEndDate ? new Date(projectEndDate) < today : false;
+
+                    const allowAnonymization = project?.config?.anonymize?.allowAnonymizeUsersAfterEndDate;
+                    const anonymizeUsersXDaysAfterEndDate = project?.config?.anonymize?.anonymizeUsersXDaysAfterEndDate;
+                    const daysAfterEndDate = isNaN( parseInt(anonymizeUsersXDaysAfterEndDate) ) ? 0 : parseInt(anonymizeUsersXDaysAfterEndDate);
+
+                    const readyToAnonymize =
+                        projectHasEnded && allowAnonymization &&
+                        (new Date(formattedEndDate.getTime() + daysAfterEndDate * 24 * 60 * 60 * 1000)) < today;
+
+                    if ( !readyToAnonymize ) continue;
+
+                    let users = await db.User.findAll({
+                        where: {
+                            projectId: project.id,
+                            role: 'member'
+                        }
+                    })
+
+                    if (users.length > 0) {
+
+                        // for each user
+                        for (const user of users) {
+                            console.log('CRON project-ended-anonymize-users: anonymize user', user.email);
+                            // anonymize user
+                            user.doAnonymize();
+                        }
+                    }
+                }
+
+                return next();
+
+            } catch (err) {
+                console.log('error in project-ended-anonymize-users cron');
+                next(err); // let the locked function handle this
+            }
+
+        }
+    })
+
+};
+
+

--- a/apps/api-server/src/models/User.js
+++ b/apps/api-server/src/models/User.js
@@ -554,33 +554,27 @@ module.exports = function (db, sequelize, DataTypes) {
     let result = await self.willAnonymize();
 
     try {
-
       // anonymize
-
-      let extraData = {};
       if (!self.project) throw Error('Project not found');
-      if (self.project.config.users && self.project.config.users.extraData) {
-        Object.keys(self.project.config.users.extraData).map( key => extraData[key] = null );
-      }
-      
+
       await self.update({
         idpUser: {},
         role: 'anonymous',
-        passwordHash: null,
+        extraData: {},
+        email: null,
+        nickName: null,
+        name: ( self?.project?.config?.anonymize?.anonymizeUserName ) || 'Gebruiker is geanonimiseerd',
+        firstname: null,
+        lastname: null,
         listableByRole: 'editor',
         detailsViewableByRole: 'editor',
-        viewableByRole: 'admin',
-        email: null,
-        nickName: null, 
-        name: ( config.users && config.users.anonymize && config.users.anonymize.name ) || 'Gebruiker is ganonimiseerd',
-        postcode: null,
-        city: null,
-        country: null,
-        address: null,
         phoneNumber: null,
-        extraData,
+        address: null,
+        city: null,
+        postcode: null,
         lastLogin: '1970-01-01T00:00:00.000Z',
         isNotifiedAboutAnonymization: null,
+        updatedAt: new Date(),
       })
 
       // remove existing votes
@@ -589,7 +583,6 @@ module.exports = function (db, sequelize, DataTypes) {
           await vote.destroy();
         };
       }
-      
     } catch (err) {
       console.log(err);
       throw err;

--- a/apps/api-server/src/models/lib/project-config.js
+++ b/apps/api-server/src/models/lib/project-config.js
@@ -40,6 +40,10 @@ module.exports = {
         type: 'int',
         default: 860,
       },
+      anonymizeUserName: {
+        type: 'string',
+        default: 'Gebruiker is geanonimiseerd',
+      }
     },
   },
 

--- a/apps/api-server/src/models/lib/project-config.js
+++ b/apps/api-server/src/models/lib/project-config.js
@@ -28,6 +28,10 @@ module.exports = {
   anonymize: {
     type: 'object',
     subset: {
+      allowAnonymizeUsersAfterEndDate: {
+        type: 'boolean',
+        default: false,
+      },
       anonymizeUsersXDaysAfterEndDate: {
         type: 'int',
         default: 60,

--- a/apps/api-server/src/notifications/default-templates/user account about to expire
+++ b/apps/api-server/src/notifications/default-templates/user account about to expire
@@ -1,46 +1,46 @@
 <!-- template: user account about to expire -->
-<subject>user account about to expire</subject>
+<subject>We gaan je account verwijderen</subject>
 <body>
-  <mjml>
-    <mj-body>
-      <mj-raw>
-        <!-- Company Header -->
-      </mj-raw>
-      <mj-section>
-        <mj-column width="200px">
-          <mj-image src="{{ imagePath }}/logo-openstad.png"> </mj-image>
-        </mj-column>
-      </mj-section>
-      <mj-raw>
-        <!-- Image Header -->
-      </mj-raw>
-      <mj-section>
-        <mj-column width="600px">
-          <mj-image src="{{ imagePath }}/mail-header.jpg"></mj-image>
-        </mj-column>
-      </mj-section>
-      <mj-raw>
-        <!-- Mail context -->
-      </mj-raw>
-      <mj-section>
-        <mj-column width="500px">
-          <mj-text font-size="20px" font-family="Helvetica Neue">Uw account zal binnenkort verwijderd worden.</mj-text>
-          <mj-text>Beste {{user.name}},</mj-text>
-          <mj-text color="#525252">Wegens omstandigheden zal uw account voor de resource {{resource.name}} binnenkort verwijderd worden. Als uw dit wilt voorkomen, kunt u de link hieronder volgen om in te loggen:</mj-text>
-          <mj-button background-color="#12B886" href="{{redirectUrl}}">Weergeven</mj-button>
-        </mj-column>
-      </mj-section>
-      <mj-raw>
-        <!-- ALternate link -->
-      </mj-raw>
-      <mj-section>
-        <mj-column width="400px">
-          <mj-text>Of gebruik deze link in je browser:</mj-text>
-        </mj-column>
-        <mj-column>
-          <mj-text>{{redirectUrl}}</mj-text>
-        </mj-column>
-      </mj-section>
-    </mj-body>
-  </mjml>
+    <mjml>
+        <mj-body background-color=\"#f6f6f7\">
+            <mj-section background-color=\"#ffffff\" padding=\"20px\">
+                <mj-column>
+
+                    <mj-text font-size=\"20px\" color=\"#333333\" font-family=\"Helvetica\" align=\"center\">
+                        We gaan je account verwijderen
+                    </mj-text>
+
+                    <mj-divider border-color=\"#cccccc\" border-width=\"1px\"></mj-divider>
+                    <mj-divider border-width=\"0\" padding=\"10px\"  ></mj-divider>
+
+                    <mj-text  line-height=\"1.3\" font-size=\"16px\" color=\"#555555\" font-family=\"Helvetica\">
+                        Beste {{user.name or 'bezoeker'}},
+                    </mj-text>
+
+                    <mj-text  line-height=\"1.3\" font-size=\"16px\" color=\"#555555\" font-family=\"Helvetica\">
+                        Je bent al een tijd niet actief geweest op de website
+
+                        {% if projectUrl %}
+                            <a href=\"{{projectUrl}}\">{{projectUrl}}</a>.
+                        {% else %}
+                            {{projectName}}.
+                        {% endif %}
+
+                        We willen niet onnodig je gegevens blijven bewaren, en gaan die daarom verwijderen. Dat betekent dat een eventuele bijdrage die je hebt geleverd op de website, bijvoorbeeld inzendingen en/of reacties, geanonimiseerd worden.
+                    </mj-text>
+
+                    <mj-text  line-height=\"1.3\" font-size=\"16px\" color=\"#555555\" font-family=\"Helvetica\">
+                        Wil je dit liever niet? Dan hoef je alleen een keer in te loggen op de website om je account actief te houden. Doe dit wel voor {{anonymizeDate}}, want anders gaan we op die dag je gegevens verwijderen.
+                    </mj-text>
+
+                    <mj-divider border-width=\"0\" padding=\"10px\" ></mj-divider>
+                    <mj-divider border-color=\"#cccccc\" border-width=\"1px\"></mj-divider>
+
+                    <mj-text  line-height=\"1.3\" font-size=\"14px\" color=\"#999999\" font-family=\"Helvetica\" align=\"center\">
+                        Dit is een automatisch bericht, antwoorden op deze e-mail is niet mogelijk.
+                    </mj-text>
+                </mj-column>
+            </mj-section>
+        </mj-body>
+    </mjml>
 </body>

--- a/apps/api-server/src/routes/api/project.js
+++ b/apps/api-server/src/routes/api/project.js
@@ -800,9 +800,7 @@ router.route('/:projectId(\\d+)/:willOrDo(will|do)-anonymize-all-users')
 
 		req.project.doAnonymizeAllUsers(
 			[...result.users],
-			[...result.externalUserIds],
 			req.query.useAuth
-
 		);
       }
       next();

--- a/packages/types/project-setting-props.ts
+++ b/packages/types/project-setting-props.ts
@@ -11,6 +11,7 @@ export type ProjectSettingProps = {
     warnUsersAfterXDaysOfInactivity: number;
     anonymizeUsersAfterXDaysOfInactivity: number;
     anonymizeUserName: string;
+    allowAnonymizeUsersAfterEndDate: boolean;
   };
   auth: {
     default: string;

--- a/packages/types/project-setting-props.ts
+++ b/packages/types/project-setting-props.ts
@@ -10,6 +10,7 @@ export type ProjectSettingProps = {
     anonymizeUsersXDaysAfterEndDate: number;
     warnUsersAfterXDaysOfInactivity: number;
     anonymizeUsersAfterXDaysOfInactivity: number;
+    anonymizeUserName: string;
   };
   auth: {
     default: string;


### PR DESCRIPTION
This pull request introduces significant improvements to the user anonymization workflow for projects, including new configuration options, enhanced notification handling, and a new scheduled job for post-project anonymization. The changes span the admin UI, backend cron jobs, and notification templates.

**Backend: User Anonymization Automation**

* Added a new cron job (`project_ended_anonymize_users.js`) to automatically anonymize users after a project ends, based on configurable settings in each project.
* Improved the existing inactive user anonymization cron job to respect project-specific inactivity and warning periods, and to send more informative notifications with project and anonymization date details.

**Admin UI: Project Settings and Notification Management**

* Extended the project anonymization settings UI to allow admins to:
  * Enable/disable automatic anonymization after project end.
  * Set the number of days after project end before anonymization.
  * Customize the display name for anonymized users.
  * See warnings if notification email settings are missing. 
* Integrated the new notification template for "user account about to expire" into the notification form and project settings page, replacing the previous hardcoded email form.

**Notification Templates and UI Enhancements**

* Added a new MJML notification template for alerting users that their account is about to expire due to inactivity, including dynamic project and anonymization date information.