### PR TITLE
fix: Clean embedded URL by removing trailing question marks or ampersands

### DIFF
--- a/packages/enquete/src/enquete.tsx
+++ b/packages/enquete/src/enquete.tsx
@@ -59,7 +59,20 @@ function Enquete(props: EnqueteWidgetProps) {
             }
         }
 
-        formData.embeddedUrl = window.location.href;
+        const embeddedUrl = window.location.href;
+
+        const cleanUrlFromEndingQuestionMarks = (url: string) => {
+            const length = url.length;
+            let returnUrl = url;
+
+            if ( url.charAt(length - 1) === '?' || url.charAt(length - 1) === '&' ) {
+                returnUrl = url.slice(0, length - 1);
+            }
+
+            return returnUrl;
+        }
+
+        formData.embeddedUrl = cleanUrlFromEndingQuestionMarks(embeddedUrl);
 
         const result = await createSubmission(formData, props.widgetId);
 


### PR DESCRIPTION
This pull request introduces a small but important improvement to how the `embeddedUrl` is handled in the `Enquete` component. Specifically, it ensures that any trailing `?` or `&` characters are removed from the URL before it is stored in the form data.

URL handling improvement:

* Added a helper function `cleanUrlFromEndingQuestionMarks` to strip any trailing `?` or `&` from `window.location.href` before assigning it to `formData.embeddedUrl` in `enquete.tsx`.