### PR TITLE
Fix: Invalid auth variable check breaks e2e

### DIFF
--- a/apps/api-server/scripts/init-database.js
+++ b/apps/api-server/scripts/init-database.js
@@ -8,7 +8,7 @@ const { Umzug, SequelizeStorage } = require('umzug');
 
 const { AUTH_ADMIN_CLIENT_ID: authId, AUTH_ADMIN_CLIENT_SECRET: authSecret } = process.env;
 
-if (authId.includes(':') || authSecret.includes(':')) {
+if ((typeof authId !== "undefined" && authId.includes(':')) || (typeof authSecret !== "undefined" && authSecret.includes(':'))) {
   throw new Error("Auth client id/secret must not contain ':'");
 }
 


### PR DESCRIPTION
The auth ID / secret does not exist per se in the end-to-end test. This leads to an error (see https://github.com/openstad/openstad-headless/actions/runs/17578749905/job/49931502316):

> TypeError: Cannot read properties of undefined (reading 'includes')

By checking if the auth id & secret are not undefined before checking if they include a `:`, we prevent this error from occuring.