### PR TITLE
fix: Update permissions for CI workflows to ensure read access to contents

### DIFF
--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -51,7 +51,8 @@ jobs:
     name: Run Component tests
     runs-on: ubuntu-latest
     needs: generate-ci-build-id
-
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -186,7 +187,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [generate-ci-build-id, build-and-push-docker-image]
     #if: github.event_name == 'pull_request' && github.base_ref == 'main'
-
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request makes minor updates to the GitHub Actions workflow file `.github/workflows/build-publish-docker.yml` by explicitly setting minimal permissions for the jobs that run component tests and publish Docker images, fixing issues [268](https://github.com/openstad/openstad-headless/security/code-scanning/268) and [269](https://github.com/openstad/openstad-headless/security/code-scanning/269).

@rudivanhierden & @IanR01 If it is accepted, I would also like to ignore issues [130](https://github.com/openstad/openstad-headless/security/code-scanning/130) and [271](https://github.com/openstad/openstad-headless/security/code-scanning/271), as these are values ​​in the admin.