### PR TITLE
fix: Sanitize file names for document uploads and handle file removal correctly

### DIFF
--- a/packages/ui/src/form-elements/document-upload/index.tsx
+++ b/packages/ui/src/form-elements/document-upload/index.tsx
@@ -126,7 +126,9 @@ const DocumentUploadField: FC<DocumentUploadProps> = ({
             for (let i = 0; i < documents.length; i++) {
                 const file = documents[i].file;
                 if (file && file.name) {
-                    let fileInUploadedDocuments = uploadedDocuments.find(o => o.name === file.name);
+                    const sanitizedFileName = file.name.replace(/\./g, '_');
+
+                    let fileInUploadedDocuments = uploadedDocuments.find(o => o.name === sanitizedFileName);
 
                     if (fileInUploadedDocuments) {
                         allDocuments.push(fileInUploadedDocuments);
@@ -141,7 +143,7 @@ const DocumentUploadField: FC<DocumentUploadProps> = ({
                 value: allDocuments,
             });
         }
-    }, [documents.length, uploadedDocuments.length]);
+    }, [uploadedDocuments.length, setUploadedDocuments, setDocuments]);
 
     function waitForElm(selector: any) {
         return new Promise(resolve => {
@@ -258,6 +260,22 @@ const DocumentUploadField: FC<DocumentUploadProps> = ({
                     }}
                     aria-invalid={fieldInvalid}
                     aria-describedby={`${randomId}_error`}
+                    onremovefile={(error: FilePondErrorDescription | null, file: FilePondFile) => {
+                        const fileName = file?.file?.name;
+
+                        if (!!fileName) {
+                           const uploadDocumentFileName = fileName.replace(/\./g, '_');
+                           const fileIsInUploadedDocuments = uploadedDocuments.find(item => item.name === uploadDocumentFileName);
+
+                           if (!fileIsInUploadedDocuments) return;
+
+                           const updatedDocuments = uploadedDocuments.filter(item => item.name !== uploadDocumentFileName);
+                           setUploadedDocuments(updatedDocuments);
+
+                           const updatedFiles = documents.filter(item => item.file.name !== fileName);
+                           setDocuments(updatedFiles);
+                        }
+                    }}
                     {...filePondSettings}
                 />
                 <NotificationProvider />


### PR DESCRIPTION
This pull request updates the `DocumentUploadField` component in `packages/ui/src/form-elements/document-upload/index.tsx` to improve how file names are handled during upload and removal, preventing mismatches. The changes focus on sanitizing file names by replacing periods with underscores, and updating state management for uploaded documents and files.

**File name sanitization and state management improvements:**

* File names are now sanitized by replacing all periods (`.`) with underscores (`_`) before checking or updating the `uploadedDocuments` array, preventing mismatches due to file name formatting. 
* The dependency array for the `useEffect` hook is updated to include `setUploadedDocuments` and `setDocuments`, ensuring state updates are properly triggered when these setters change.

**File removal handling:**

* Added an `onremovefile` handler to synchronize state when a file is removed, using the sanitized file name to update both `uploadedDocuments` and `documents` arrays, ensuring consistency between uploaded files and the component state.