### PR TITLE
Fix Apostrophe session secret

### DIFF
--- a/charts/openstad-headless/Chart.yaml
+++ b/charts/openstad-headless/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.37
+version: 2.0.38
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
By providing a session secret for each project in the CMS server, we ensure that the sessions don't interfere between projects.

The session secret is a sha256 hash of the (internal) API Url, the Apostrophe Release ID, the project URL and the project ID. This ensures that the session secret is the same for each project for each restart of the CMS server, but new versions of the CMS server will invalidate the sessions.