### PR TITLE
feat(docker): use `npm ci`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN npm config set fetch-timeout 300000
 ARG BUILD_ENV=production
 ENV BUILD_ENV=${BUILD_ENV}
 
-RUN npm install --legacy-peer-deps -ws
+RUN npm ci --legacy-peer-deps -ws
 
 FROM builder AS base
 


### PR DESCRIPTION
Use `npm ci` instead of `npm install` to ensure we are installing dependency versions as specificied in package-lock.json.

`npm install` can update these versions if they don't match with package.json. `npm ci` will throw an error in that case.