### PR TITLE
chore: remove react logs

### DIFF
--- a/apps/api-server/src/util/react-check.js
+++ b/apps/api-server/src/util/react-check.js
@@ -19,9 +19,7 @@ module.exports = `
   
   function checkReactDom() {
     if (!hasReactDom && !window.OpenStadReactDOMLoaded) {
-    console.log ('!hasReactDom && !window.OpenStadReactDOMLoaded');
       if (window.OpenStadReactDOMIsLoading) {
-      console.log ('window.OpenStadReactDOMIsLoading');
         document.addEventListener('OpenStadReactDomLoaded', renderWidget);
         return;
       }
@@ -37,7 +35,6 @@ module.exports = `
       
       // Get same version of react-dom as react, ensuring we have a xx.x.x format
       if (!/18\.\d{1,2}\.\d{1,2}/.test(reactVersion) === false) {
-      console.log('react version is not 18');
         throw new Error('React version 18 is required');
       }
       
@@ -51,7 +48,6 @@ module.exports = `
         }
         document.addEventListener('OpenStadReactDomLoaded', renderWidget);
         triggerEvent('OpenStadReactDomLoaded');
-        console.log ('react dom on load');
       }
       document.body.appendChild(script);
       window.OpenStadReactDOMLoaded = true;
@@ -59,17 +55,13 @@ module.exports = `
         typeof ReactDOM !== 'undefined' &&
         ReactDOM.version.substr(0, 2) !== '18'
     ) {
-    console.log ('react dom not version 18');
       throw new Error('ReactDOM version 18 is required');
     } else {
-    console.log ('react dom check else');
       window.OpenStadReactDOMLoaded = true;
       
       if (typeof window.OpenStadReactDomLoadedEventHasFired === 'undefined' || !window.OpenStadReactDomLoadedEventHasFired) {
-      console.log ('typeof window.OpenStadReactDomLoadedEventHasFired === undefined || !window.OpenStadReactDomLoadedEventHasFired');
         document.addEventListener('OpenStadReactDomLoaded', renderWidget);
       } else {
-      console.log ('else van typeof window.OpenStadReactDomLoadedEventHasFired === undefined || !window.OpenStadReactDomLoadedEventHasFired');
         renderWidget();
       }
     }
@@ -87,35 +79,27 @@ module.exports = `
     script.src = '${reactJs}';
     script.onload = (e) => {
       checkReactDom();
-      console.log ('react js onload');
     }
     
     document.body.appendChild(script);
     window.OpenStadReactLoaded = true;
   } else if (hasReact && React.version.substr(0, 2) < '18') {
-  console.log ('react version is not 18');
     throw new Error('React version 18 is required');
   } else if (hasReact && !hasReactWithScheduler && !window.OpenStadReactLoaded) {
-  console.log ('hasReact && !hasReactWithScheduler && !window.OpenStadReactLoaded');
-    console.log ('Loading React 18.3.1 UMD version -- current version is without Scheduler which means React DOM won\\'t load correctly.');
     
     const script = document.createElement('script');
     script.src = '${reactJs}';
     script.onload = (e) => {
-      console.log ('react js onload');
       checkReactDom();
     }
     
     document.body.appendChild(script);
     window.OpenStadReactLoaded = true;
   } else {
-  console.log ('react check else');
     if (typeof window.OpenStadReactDomLoadedEventHasFired === 'undefined' || !window.OpenStadReactDomLoadedEventHasFired) {
-    console.log ('typeof window.OpenStadReactDomLoadedEventHasFired === undefined || !window.OpenStadReactDomLoadedEventHasFired');
       // React has been loaded by a previous component on the page, render the widget when ReactDOM is loaded
       checkReactDom();
     } else {
-    console.log ('else van typeof window.OpenStadReactDomLoadedEventHasFired === undefined || !window.OpenStadReactDomLoadedEventHasFired');
       renderWidget();
     }
   }


### PR DESCRIPTION
This removes the `console.log`s in the `react-check.js`, which are currently showing in the consoles of all visitors viewing a widget.