### PR TITLE
feat: Track visited tag tabs to improve tag navigation logic

### DIFF
--- a/packages/stem-begroot/src/stem-begroot.tsx
+++ b/packages/stem-begroot/src/stem-begroot.tsx
@@ -141,6 +141,7 @@ function StemBegroot({
   //   useState<boolean>(false);
 
   const [activeTagTab, setActiveTagTab] = useState<string>('');
+  const [visitedTagTabs, setVisitedTagTabs] = useState<Array<string>>([]);
 
   const stringToArray = (str: string) => {
     return str
@@ -830,6 +831,16 @@ function StemBegroot({
                     if (props.votes.voteType === "countPerTag" || props.votes.voteType === "budgetingPerTag") {
                       const unmetTags = tagCounter.filter(tagObj => {
                         const key = Object.keys(tagObj)[0];
+
+                        if (
+                          tagObj[key].min === 0 &&
+                          tagObj[key].current === 0 &&
+                          key !== activeTagTab &&
+                          !visitedTagTabs.includes(key)
+                        ) {
+                          return true;
+                        }
+
                         return tagObj[key].current < tagObj[key].min;
                       });
 
@@ -840,6 +851,7 @@ function StemBegroot({
 
                       if (nextUnmetTag) {
                         const tagName = Object.keys(nextUnmetTag)[0];
+                        setVisitedTagTabs( prev => prev.includes(activeTagTab) ? prev : [...prev, activeTagTab] );
                         setActiveTagTab(tagName);
                         return;
                       }
@@ -921,6 +933,16 @@ function StemBegroot({
                     if (props.votes.voteType === "countPerTag" || props.votes.voteType === "budgetingPerTag") {
                       const unmetTags = tagCounter.filter(tagObj => {
                         const key = Object.keys(tagObj)[0];
+
+                        if (
+                          tagObj[key].min === 0 &&
+                          tagObj[key].current === 0 &&
+                          key !== activeTagTab &&
+                          !visitedTagTabs.includes(key)
+                        ) {
+                          return true;
+                        }
+
                         return tagObj[key].current < tagObj[key].min;
                       });
 


### PR DESCRIPTION
This pull request introduces improvements to the tab navigation logic in the `StemBegroot` component to ensure users are guided through all relevant tags, especially those that haven't been visited yet.

Enhancements to tag tab navigation:

* Added a new state variable `visitedTagTabs` to track which tag tabs the user has already visited. 
* Updated the logic for determining unmet tags to exclude tags that have already been visited, ensuring users are prompted to interact with all necessary tags.