### PR TITLE
Add ellipsis and visiblePages to paginator

### DIFF
--- a/packages/ui/src/paginator/index.tsx
+++ b/packages/ui/src/paginator/index.tsx
@@ -7,13 +7,41 @@ import { IconButton } from '../iconbutton';
 const Paginator = ({
   page,
   totalPages,
+  visiblePages = 5,
   onPageChange,
 }: React.HTMLAttributes<HTMLDivElement> & {
   page: number;
   totalPages: number;
+  visiblePages?: number;
   onPageChange: (page: number) => void;
 }) => {
-  const pages = Array.from({length:totalPages}, (_, index) => index);
+  const getVisiblePages = () => {
+    const pages: (number | string)[] = [];
+    if (totalPages <= visiblePages) {
+      for (let i = 0; i < totalPages; i++) pages.push(i);
+      return pages;
+    }
+    if (page < visiblePages - 2) {
+      for (let i = 0; i < visiblePages - 2; i++) pages.push(i);
+      pages.push('...');
+      pages.push(totalPages - 1);
+      return pages;
+    }
+    if (page >= totalPages - visiblePages + 1) {
+      pages.push(0);
+      pages.push('...');
+      for (let i = totalPages - visiblePages; i < totalPages; i++) pages.push(i);
+      return pages;
+    }
+    pages.push(0);
+    pages.push('...');
+    for (let i = page - 1; i <= page + visiblePages - 4; i++) pages.push(i);
+    pages.push('...');
+    pages.push(totalPages - 1);
+    return pages;
+  };
+
+  const visible = getVisiblePages();
 
   return (
     <div className="osc-paginator">
@@ -25,30 +53,33 @@ const Paginator = ({
         text="Vorige pagina"
         iconOnly={true}
         test-id={"previous-page-button"}
-      >
+      />
 
-      </IconButton>
-
-      {pages.map((pageNr) => (
-        <IconButton
-          className="secondary round"
-          onClick={() => onPageChange(pageNr)}
-          disabled={pageNr === page}
-          test-id={`page-button-${pageNr}`}
-        >
-          {pageNr + 1}
-        </IconButton>
-      ))}
+      {visible.map((item, idx) =>
+        item === '...' ? (
+          <span key={`ellipsis-${idx}`} className="osc-paginator-ellipsis">...</span>
+        ) : (
+          <IconButton
+            key={`page-${item}`}
+            className="secondary round"
+            onClick={() => onPageChange(item as number)}
+            disabled={item === page}
+            test-id={`page-button-${item}`}
+          >
+            {(item as number) + 1}
+          </IconButton>
+        )
+      )}
 
       <IconButton
         icon="ri-arrow-right-s-line"
         className="secondary round"
         onClick={() => onPageChange(page + 1)}
-        disabled={page >= totalPages -1}
+        disabled={page >= totalPages - 1}
         text="Volgende pagina"
         iconOnly={true}
         test-id={"next-page-button"}
-      ></IconButton>
+      />
     </div>
   );
 };


### PR DESCRIPTION
Paginator now supports a configurable number of visible page buttons and displays ellipsis when not all pages can be shown. This improves usability for large page counts by preventing overcrowding of page buttons.