### PR TITLE
fix: Ensure projectId is set in defaultConfig when creating widgets

### DIFF
--- a/apps/api-server/src/routes/api/widget.js
+++ b/apps/api-server/src/routes/api/widget.js
@@ -58,6 +58,17 @@ router
       return next(new Error('Invalid widget type'));
     }
 
+    try {
+        if (
+            !!widgetDefinition.defaultConfig &&
+            !widgetDefinition.defaultConfig.projectId
+        ) {
+            widgetDefinition.defaultConfig.projectId = projectId;
+        }
+    } catch (err) {
+        console.log('Error setting projectId in defaultConfig', err);
+    }
+
     const createdWidget = await db.Widget.create({
       projectId,
       description: widget.description,


### PR DESCRIPTION
This pull request introduces a small update to the widget creation route in the API server. The change ensures that the `projectId` is set in the widget's `defaultConfig` if it is not already present, with error handling added for robustness.