### PR TITLE
feat: Add image choice field to choice guide with support for multiple selections

### DIFF
--- a/apps/admin-server/src/lib/export-helpers/choiceguide-export.tsx
+++ b/apps/admin-server/src/lib/export-helpers/choiceguide-export.tsx
@@ -121,7 +121,7 @@ export const exportChoiceGuideToCSV = (widgetName: string, selectedWidget: any, 
 
         choiceOptions.forEach((choiceOption: any) => {
           try {
-            const calculatedScores = calculateScoreForItem(choiceOption, row?.result || {}, weights, choiceType, hiddenFields);
+            const calculatedScores = calculateScoreForItem(choiceOption, row?.result || {}, weights, choiceType, hiddenFields, items);
             scores[choiceOption.title] = calculatedScores.x ? (calculatedScores.x).toFixed(0) : 0;
           } catch (error) {
             scores[choiceOption.title] = 0;

--- a/packages/choiceguide/src/choiceguide.tsx
+++ b/packages/choiceguide/src/choiceguide.tsx
@@ -194,6 +194,7 @@ function ChoiceGuide(props: ChoiceGuideProps) {
                         answers={answers}
                         widgetId={widgetId}
                         hiddenFields={hiddenFields}
+                        items={formFields}
                       />
                   )}
               </div>

--- a/packages/choiceguide/src/includes/sidebar.tsx
+++ b/packages/choiceguide/src/includes/sidebar.tsx
@@ -14,7 +14,8 @@ const ChoiceGuideSidebar: React.FC<ChoiceGuideSidebarProps> = (props) => {
       props.answers,
       props.weights,
       props.choicesType,
-      props.hiddenFields
+      props.hiddenFields,
+      props.items
     );
     setScore(itemScore);
   }, [props.choiceOptions, props.answers, props.weights]);
@@ -81,6 +82,8 @@ const ChoiceGuideSidebar: React.FC<ChoiceGuideSidebarProps> = (props) => {
                       choicesPreferenceMaxColor={props.choicesPreferenceMaxColor}
                       showPageCountAndCurrentPageInButton={props.showPageCountAndCurrentPageInButton}
                       startWithAllQuestionsAnswered={props.startWithAllQuestionsAnswered}
+                      hiddenFields={props.hiddenFields}
+                      items={props.items}
                     />
                   </li>
                 ))}

--- a/packages/choiceguide/src/includes/sidebarItem.tsx
+++ b/packages/choiceguide/src/includes/sidebarItem.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { ChoiceOptions, Score } from '../props';
+import {ChoiceOptions, Item, Score} from '../props';
 import { calculateColor, calculateScoreForItem } from '../parts/scoreUtils';
 
 const defaultBarColor = {
@@ -16,6 +16,8 @@ type ChoiceItemProps = {
   choicesPreferenceMinColor?: string;
   choicesPreferenceMaxColor?: string;
   showPageCountAndCurrentPageInButton?: boolean;
+  hiddenFields?: string[];
+  items?: Array<Item>;
 };
 
 const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
@@ -27,7 +29,9 @@ const ChoiceItem: React.FC<ChoiceItemProps> = (props) => {
       props.choiceOption,
       props.answers,
       props.weights,
-      props.choicesType
+      props.choicesType,
+      props.hiddenFields,
+      props.items
     );
     setScore(itemScore);
   }, [props.choiceOption, props.answers, props.weights]);

--- a/packages/choiceguide/src/parts/init-fields.tsx
+++ b/packages/choiceguide/src/parts/init-fields.tsx
@@ -87,6 +87,37 @@ export const InitializeFormFields = (items, data, showForm = true) => {
                     }
 
                     break;
+                case 'images':
+                    fieldData['type'] = 'imageChoice';
+                    fieldData['multiple'] = item.multiple || false;
+
+                    if (item.options && item.options.length > 0) {
+                        fieldData['choices'] = item.options.map((option) => {
+                            return {
+                                value: option.titles[0].key,
+                                label: option.titles[0].key,
+                                imageSrc: option.titles[0].image,
+                                imageAlt: option.titles[0].key,
+                                hideLabel: option.titles[0].hideLabel,
+                                trigger: option.trigger || ''
+                            };
+                        });
+                    } else {
+                        fieldData['choices'] = [
+                            {
+                                label: item?.text1 || '',
+                                value: item?.key1 || '',
+                                imageSrc: item?.image1 || ''
+                            },
+                            {
+                                label: item?.text2 || '',
+                                value: item?.key2 || '',
+                                imageSrc: item?.image2 || ''
+                            }
+                        ];
+                    }
+
+                    break;
                 case 'imageUpload':
                     fieldData['allowedTypes'] = item.allowedTypes || ["image/*"];
                     break;

--- a/packages/choiceguide/src/parts/init-weights.tsx
+++ b/packages/choiceguide/src/parts/init-weights.tsx
@@ -22,7 +22,7 @@ export const InitializeWeights = (
 
     items.forEach((item) => {
       const itemType = item.type || '';
-      const allowedTypes = ["radiobox", "checkbox", "select", "a-b-slider"];
+      const allowedTypes = ["radiobox", "checkbox", "select", "a-b-slider", "images"];
 
       if (!allowedTypes.includes(itemType) || !itemType) return;
 

--- a/packages/choiceguide/src/parts/scoreUtils.tsx
+++ b/packages/choiceguide/src/parts/scoreUtils.tsx
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import {ChoiceOptions, Score} from "../props";
+import {Item} from "../props";
 
 export const calculateColor = (score: number, minColor = '#ff9100', maxColor = '#bed200') => {
     const maxColorMatch = maxColor.match(/#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})/i);
@@ -18,7 +19,8 @@ export const calculateScoreForItem = (
   answers: Record<string, string>,
   weights: Record<string, Record<string, Record<string, any>>>,
   choicesType: 'default' | 'minus-to-plus-100' | 'plane' | 'hidden',
-  hiddenFields: string[]
+  hiddenFields: string[],
+  items: Item[]
 ): Score => {
     const results: Score = { x: 0, y: 0, z: 0 };
     let totalScores = { x: 0, y: 0, z: 0 };
@@ -46,12 +48,15 @@ export const calculateScoreForItem = (
                 const secondOptionWeights = optionWeights[optionId];
 
                 const isRadioBox = answerKey.startsWith('radiobox');
+                const isImageChoice = answerKey.startsWith('images');
+                const imageChoiceTrigger = answerKey.replace('images-', '');
+                const isImageChoiceMultiple = isImageChoice && items?.find(item => item?.trigger === imageChoiceTrigger && item?.multiple === true);
 
                 ['x', 'y', 'z'].forEach((secondDimension) => {
                     const optionValue = secondOptionWeights[secondDimension];
 
                     if (typeof optionValue === 'number' && optionValue !== 0) {
-                        if (isRadioBox) {
+                        if ( isRadioBox || (isImageChoice && !isImageChoiceMultiple) ) {
                             tempScores[secondDimension] = Math.max(tempScores[secondDimension], optionValue);
                         } else {
                             tempScores[secondDimension] += optionValue;

--- a/packages/choiceguide/src/props.ts
+++ b/packages/choiceguide/src/props.ts
@@ -64,6 +64,7 @@ export type ChoiceGuideSidebarProps = {
     weights?: WeightOverview;
     widgetId?: string;
     hiddenFields?: string[];
+    items?: Array<Item>;
 }
 
 export type Score = {
@@ -119,6 +120,7 @@ export type Item = {
     routingInitiallyHide?: boolean;
     routingSelectedQuestion?: string;
     routingSelectedAnswer?: string;
+    imageOptionUpload?: string;
 };
 
 export type Option = {
@@ -132,6 +134,8 @@ export type Title = {
     weights?: Record<string, Weight>;
     isOtherOption?: boolean;
     defaultValue?: boolean;
+    image?: string;
+    hideLabel?: boolean;
 };
 
 export type Weight = {


### PR DESCRIPTION
This pull request introduces the "images" answer type for choice guide widgets, allowing users to select options represented by images, with support for multiple selection.

### Support for Image-Based Answer Options

* Added a new "images" answer type to the form schema, option selection logic, and UI, allowing answer options to be represented with images. This includes support for uploading images, hiding image labels, and enabling multiple selections. 
* Updated form field initialization to handle the new "images" type, mapping option images and labels appropriately. 
* Modified the score calculation logic to correctly process image-based options, including handling multiple selections.
* Included "images" as an allowed type for weight initialization, ensuring weights can be assigned to image-based options. 