### PR TITLE
fix: Enhance file name sanitization and improve error messaging for forbidden characters

### DIFF
--- a/packages/ui/src/form-elements/document-upload/index.tsx
+++ b/packages/ui/src/form-elements/document-upload/index.tsx
@@ -126,7 +126,10 @@ const DocumentUploadField: FC<DocumentUploadProps> = ({
             for (let i = 0; i < documents.length; i++) {
                 const file = documents[i].file;
                 if (file && file.name) {
-                    const sanitizedFileName = file.name.replace(/\./g, '_');
+                    let sanitizedFileName = file.name.replace(/\./g, '_'); // Replace all dots with underscores
+                    sanitizedFileName = sanitizedFileName.replace(/ /g, '_'); // Replace spaces with underscores
+                    sanitizedFileName = sanitizedFileName.replace(/[^a-zA-Z0-9_\-]/g, '_'); // Replace special characters with underscores
+                    sanitizedFileName = sanitizedFileName.replace(/_+/g, '_'); // Replace multiple underscores with a single underscore
 
                     let fileInUploadedDocuments = uploadedDocuments.find(o => o.name === sanitizedFileName);
 
@@ -248,7 +251,11 @@ const DocumentUploadField: FC<DocumentUploadProps> = ({
 
                             if (forbiddenChar) {
                                 const forbiddenCharName = forbiddenChar[0];
-                                const errorMessage = `Bestandsnaam mag het teken "${forbiddenCharName}" niet bevatten.`;
+                                const forbiddenCharIndex = fileName.indexOf(forbiddenCharName) + 1;
+
+                                // We don't use forbiddenCharName, because the character might not be rendered correctly in the notification
+                                // For example: '//' will be rendered as ':', which is confusing for the user
+                                const errorMessage = `Bestandsnaam mag het teken op positie ${forbiddenCharIndex} niet bevatten.`;
                                 reject(errorMessage);
                             } else {
                                 resolve(true);


### PR DESCRIPTION
This pull request improves the file name sanitization and error messaging logic in the `DocumentUploadField` component. Required document upload fields wouldn't validate properly because of this. Now they do.

Changed the validation error message for forbidden characters in file names to indicate the position of the invalid character, rather than displaying the character itself. Displaying the character is not reliable as the character sometimes will render differently