### PR TITLE
fix: Ensure active tag tab is tracked in visited tabs on change

### DIFF
--- a/packages/stem-begroot/src/stem-begroot.tsx
+++ b/packages/stem-begroot/src/stem-begroot.tsx
@@ -529,6 +529,10 @@ function StemBegroot({
     }
   }, [filteredResources]);
 
+  useEffect(() => {
+    setVisitedTagTabs((prev) => prev.includes(activeTagTab) ? prev : [...prev, activeTagTab]);
+  }, [activeTagTab]);
+
   return (
     <>
       <StemBegrootResourceDetailDialog
@@ -851,7 +855,6 @@ function StemBegroot({
 
                       if (nextUnmetTag) {
                         const tagName = Object.keys(nextUnmetTag)[0];
-                        setVisitedTagTabs( prev => prev.includes(activeTagTab) ? prev : [...prev, activeTagTab] );
                         setActiveTagTab(tagName);
                         return;
                       }


### PR DESCRIPTION
This pull request makes a minor improvement to the state management of the `StemBegroot` component by ensuring that the `visitedTagTabs` state is updated whenever the `activeTagTab` changes, instead of updating it in multiple places.

State management improvements:

* Added a `useEffect` hook to update `visitedTagTabs` whenever `activeTagTab` changes, ensuring consistent tracking of visited tabs.
* Removed redundant update logic for `visitedTagTabs` from the code path that sets a new active tag tab, simplifying the code.