### PR TITLE
Fix/headers or calls causing errors

### DIFF
--- a/apps/cms-server/views/layout.html
+++ b/apps/cms-server/views/layout.html
@@ -10,8 +10,8 @@ page or piece.') }}
 {% endblock %}
 
 {% block extraHead %}
-<script src="{{data.global.reactCdn}}" crossorigin="anonymous"></script>
-<script src="{{data.global.reactDomCdn}}" crossorigin="anonymous"></script>
+<script src="{{data.global.reactCdn}}"></script>
+<script src="{{data.global.reactDomCdn}}"></script>
 
 {% if data.global.favicon %}
   <link rel="icon" type="image/x-icon" href="{{data.global.favicon._url}}"/>

--- a/packages/data-store/src/api/resource.js
+++ b/packages/data-store/src/api/resource.js
@@ -7,7 +7,7 @@ export default {
       'Content-Type': 'application/json'
     };
 
-    return resourceId ? this.fetch(url, { headers }) : [];
+    return ( !resourceId || resourceId === 'undefined' ) ? [] : this.fetch(url, { headers });
   },
 
   update: async function({ projectId, resourceId }, data) {


### PR DESCRIPTION
This PR contains an extra check for the `resourceId`, as it sometimes tries to make the call with an undefined `resourceId`. This of course causes an error.

I also removed the cross-origin anonymous, as it is of no use at all if you do not have an SRI.

Sometimes there are CORS errors and these changes are to prevent these problems.