### PR TITLE
fix: Disable CMS widget preview by default

### DIFF
--- a/charts/openstad-headless/templates/cms/deployment.yaml
+++ b/charts/openstad-headless/templates/cms/deployment.yaml
@@ -68,7 +68,7 @@ spec:
             value: {{ .Values.cms.disableRateLimiter | default "false" | quote }}
 
           - name: DISABLE_WIDGET_PREVIEW
-            value: {{ .Values.cms.disableWidgetPreview | default "false" | quote }}
+            value: {{ .Values.cms.disableWidgetPreview | default "true" | quote }}
 
           # Inject extra environment variables
           {{- if .Values.cms.extraEnvVars }}

--- a/charts/openstad-headless/values.yaml
+++ b/charts/openstad-headless/values.yaml
@@ -445,7 +445,7 @@ cms:
       secretName: openstad-tls-cms
       hosts: []
 
-  disableWidgetPreview: "false"
+  disableWidgetPreview: "true"
 
   # Inject extra environment variables
   extraEnvVars: []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -297,7 +297,7 @@ services:
       - APOS_RELEASE_ID=${APOS_RELEASE_ID}
       - REACT_CDN=${REACT_CDN}
       - REACT_DOM_CDN=${REACT_DOM_CDN}
-      - DISABLE_WIDGET_PREVIEW=${CMS_DISABLE_WIDGET_PREVIEW:-false}
+      - DISABLE_WIDGET_PREVIEW=${CMS_DISABLE_WIDGET_PREVIEW:-true}
     ports:
       - '${CMS_PORT}:${CMS_PORT}'
     volumes:

--- a/scripts/create-docker-config.js
+++ b/scripts/create-docker-config.js
@@ -115,7 +115,7 @@ CMS_PORT=${process.env.CMS_PORT}
 CMS_OVERWRITE_URL=${process.env.CMS_OVERWRITE_URL}
 CMS_MONGODB_URI=${process.env.CMS_MONGODB_URI || 'mongodb://openstad-mongo:27017/{database}'}
 CMS_DEFAULT_SETTINGS=${process.env.CMS_DEFAULT_SETTINGS}
-CMS_DISABLE_WIDGET_PREVIEW=${process.env.CMS_DISABLE_WIDGET_PREVIEW || 'false'}
+CMS_DISABLE_WIDGET_PREVIEW=${process.env.CMS_DISABLE_WIDGET_PREVIEW || 'true'}
 `;
 
     await fs.writeFile('./.env', configfile);


### PR DESCRIPTION
This pull request updates the default configuration to disable the widget preview feature in the CMS by default.