### PR TITLE
fix: Replace dots in choice keys with safe characters for weight handling

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/items.tsx
@@ -711,28 +711,32 @@ export default function WidgetChoiceGuideItems(
               {option.titles[0].key}
             </p>
 
-            {dimensions.length > 0 && dimensions.map((XY, i) => (
-              <FormField
-                control={form.control}
-                name={`weights.${group.id}.choice.${option.titles[0].key}.weight${XY}`}
-                key={`0-${group.id}-${option.titles[0].key}`}
-                render={({ field }) => (
-                  <FormItem>
-                    <FormControl>
-                      <div className={`weight-${XY.toLowerCase()}-container`}>
-                        <Input
-                          type="number"
-                          min={0}
-                          max={100}
-                          {...field}
-                        />
-                      </div>
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            ))}
+            {dimensions.length > 0 && dimensions.map((XY, i) => {
+              const safeKey = option?.titles[0]?.key?.replace(/\./g, '_DOT_');
+
+              return (
+                <FormField
+                  control={form.control}
+                  name={`weights.${group.id}.choice.${safeKey}.weight${XY}`}
+                  key={`0-${group.id}-${safeKey}`}
+                  render={({field}) => (
+                    <FormItem>
+                      <FormControl>
+                        <div className={`weight-${XY.toLowerCase()}-container`}>
+                          <Input
+                            type="number"
+                            min={0}
+                            max={100}
+                            {...field}
+                          />
+                        </div>
+                      </FormControl>
+                      <FormMessage/>
+                    </FormItem>
+                  )}
+                />
+              )
+            })}
           </React.Fragment>
         ))}
       </div>

--- a/packages/choiceguide/src/parts/scoreUtils.tsx
+++ b/packages/choiceguide/src/parts/scoreUtils.tsx
@@ -84,11 +84,12 @@ export const calculateScoreForItem = (
             }
 
             answerArray.forEach((userAnswer) => {
+                const safeUserAnswer = typeof userAnswer === 'string' ? userAnswer?.replace(/\./g, '_DOT_') : userAnswer;
                 const optionWeights = weights[option.id]?.[answerKey];
 
                 if (optionWeights) {
-                    if (typeof userAnswer === 'string' && optionWeights[userAnswer]) {
-                        const dimensions = optionWeights[userAnswer];
+                    if (typeof safeUserAnswer === 'string' && optionWeights[safeUserAnswer]) {
+                        const dimensions = optionWeights[safeUserAnswer];
                         Object.keys(dimensions).forEach((thirdDimension) => {
                             const number = Number(dimensions[thirdDimension]);
 


### PR DESCRIPTION
React Hook Form treats dots (.) in field names as path delimiters, so `option.titles[0].key` containing a dot will break nested field access. 

This no longer happens by replacing the points. The key is used only once to retrieve the weight.