### PR TITLE
Fix kubernetes ingress check

### DIFF
--- a/apps/api-server/src/services/checkHostStatus.js
+++ b/apps/api-server/src/services/checkHostStatus.js
@@ -123,6 +123,7 @@ const checkHostStatus = async (conditions) => {
 
   if (isOnK8s) {
     
+    const defaultProjectHost = new URL(process.env.CMS_URL).host;
     const projects = await db.Project.findAll({ where });
     
     const promises = projects.map(async (project) => {
@@ -130,6 +131,11 @@ const checkHostStatus = async (conditions) => {
       
       if (!project.url) {
         console.error('No url found for project: ', project.id);
+        return;
+      }
+      
+      if (project.url === defaultProjectHost) {
+        console.log('Skipping default project host: ', project.url);
         return;
       }
       


### PR DESCRIPTION
This PR skips the ingress check for the default project ingress.

The default project ingress is managed by Helm, and should not be managed by the api-server. Trying to retrieve the ingress in this manner will result in an error from the Kubernetes API. The API will then try to create the ingress, but there is already an ingress for the provided URL, resulting in another error.