### PR TITLE
feat(auth): add support for initial users

### DIFF
--- a/charts/openstad-headless/templates/auth/deployment.yaml
+++ b/charts/openstad-headless/templates/auth/deployment.yaml
@@ -274,6 +274,9 @@ spec:
                 name: {{ template "openstad.auth.databaseSecret.fullname" . }}
                 key: {{ .Values.secrets.auth.dbNameKey | default "database" }}
 
+          - name: AUTH_INITIAL_USERS
+            value: '{{ .Values.auth.initialUsers | default "[]" | toJson }}'
+
           {{- if .Values.auth.extraEnvVars }}
           {{- include "common.tplvalues.render" (dict "value" .Values.auth.extraEnvVars "context" $) | nindent 10 }}
           {{- end }}

--- a/charts/openstad-headless/values.yaml
+++ b/charts/openstad-headless/values.yaml
@@ -244,6 +244,9 @@ auth:
   # Inject extra environment variables
   extraEnvVars: []
 
+  # Supply an array of e-mails to create as initial users. The admin client will be set to auth type "URL" and "admin" will be added to the twoFactorRoles.
+  initialUsers: []
+
   # Resources:
   resources:
     # Max resources


### PR DESCRIPTION
Providing a list of e-mail addresses for initial users will create these users for the admin client. The admin client will have its' authType set to `URL` and the `twoFactorRoles` will be set to `admin`
 as well. This allows us to speed up the install process and prevent
 manual creation of users & admin client setup.