### PR TITLE
fix: remove custom key generation for S3 file uploads

### DIFF
--- a/apps/image-server/server.js
+++ b/apps/image-server/server.js
@@ -43,9 +43,6 @@ if (s3.isEnabled()) {
       destination: function (req, file, cb) {
         cb(null, 'images/');
       },
-      key: function (req, file, cb) {
-        cb(null, 'images/' + createFilename(file.originalname));
-      },
     });
   } catch (error) {
     throw new Error(`S3 Multer storage error: ${error.message}`);


### PR DESCRIPTION
Generated keys are not stored in the way the GET requests are trying to pull it. Without a file generation the problem is fixed, because it just uses a generated string. Less is more.