### PR TITLE
Add URL enrichment for related blog posts

### DIFF
--- a/apps/cms-server/modules/openstad-blog-post-widget/index.js
+++ b/apps/cms-server/modules/openstad-blog-post-widget/index.js
@@ -110,8 +110,11 @@ module.exports = {
             }
             
             posts = posts.concat(showAll ? additionalPosts : additionalPosts.slice(0, maxItems ? maxItems - posts.length : undefined));
-            // Remove duplicates
             posts = posts.filter((post, index, arr) => arr.findIndex(p => p._id === post._id) === index);
+            
+            if (posts.length > 0) {
+              await blogModule.addUrls(req, posts);
+            }
             
             widget.relatedPosts = posts.map(post => {
               if (post.createdAt) {


### PR DESCRIPTION
Calls blogModule.addUrls to enrich relatedPosts with URLs if posts are present. Ensures related posts have proper URL data before mapping for widget display.