### PR TITLE
fix: allow explanation should be only around explanation field

### DIFF
--- a/packages/ui/src/form-elements/a-b-slider/index.tsx
+++ b/packages/ui/src/form-elements/a-b-slider/index.tsx
@@ -234,7 +234,7 @@ const RangeSlider: FC<RangeSliderProps> = ({
                 </Paragraph>
             </div>
 
-            { (skipQuestion && skipQuestionAllowExplanation) && (
+            { skipQuestion && (
                 <div className="skip-question-container">
                     <Spacer size={2} />
                     <FormLabel htmlFor={`${randomId}_skip`} type="checkbox" className="--label-grid">
@@ -253,7 +253,7 @@ const RangeSlider: FC<RangeSliderProps> = ({
                         <span>{skipQuestionLabel}</span>
                     </FormLabel>
 
-                    { skipSelected && (
+                    { (skipSelected && skipQuestionAllowExplanation) && (
                         <div className="marginTop10 marginBottom15">
                             <Spacer size={2} />
                             <TextInput


### PR DESCRIPTION
This change ensures that the explanation input is only shown when both skipping is selected and explanations are allowed, while the skip question option itself is always shown if skipping is enabled. 