### PR TITLE
feat: add options to display resource title and summary in document map

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/content.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/content.tsx
@@ -39,6 +39,8 @@ const formSchema = z.object({
     maxCharactersWarning: z.string().optional().default("Je hebt {maxCharacters} karakters teveel"),
     minCharactersError: z.string().optional().default("Tekst moet minimaal {minCharacters} karakters bevatten"),
     maxCharactersError: z.string().optional().default("Tekst moet maximaal {maxCharacters} karakters bevatten"),
+    displayResourceTitle: z.string().optional(),
+    displayResourceSummary: z.string().optional(),
 });
 
 export default function DocumentContent(
@@ -74,6 +76,8 @@ export default function DocumentContent(
             maxCharactersWarning: props?.maxCharactersWarning || 'Je hebt {maxCharacters} karakters teveel',
             minCharactersError: props?.minCharactersError || 'Tekst moet minimaal {minCharacters} karakters bevatten',
             maxCharactersError: props?.maxCharactersError || 'Tekst moet maximaal {maxCharacters} karakters bevatten',
+            displayResourceTitle: props?.displayResourceTitle || 'yes',
+            displayResourceSummary: props?.displayResourceSummary || 'yes',
         },
     });
 
@@ -345,19 +349,19 @@ export default function DocumentContent(
 
                     <FormField
                         control={form.control}
-                        name="displayResourceDescription"
+                        name="displayResourceTitle"
                         render={({ field }) => (
                             <FormItem>
                                 <FormLabel>
-                                    Wil je de beschrijving van de resource tonen?
+                                    Wil je de titel van de resource tonen?
                                 </FormLabel>
                                 <Select
                                     onValueChange={field.onChange}
-                                    value={field.value || 'no'}
+                                    value={field.value || 'yes'}
                                 >
                                     <FormControl>
                                         <SelectTrigger>
-                                            <SelectValue placeholder="no" />
+                                            <SelectValue placeholder="yes" />
                                         </SelectTrigger>
                                     </FormControl>
                                     <SelectContent>
@@ -369,6 +373,60 @@ export default function DocumentContent(
                             </FormItem>
                         )}
                     />
+
+                    <FormField
+                        control={form.control}
+                        name="displayResourceSummary"
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormLabel>
+                                    Wil je de samenvatting van de resource tonen?
+                                </FormLabel>
+                                <Select
+                                    onValueChange={field.onChange}
+                                    value={field.value || 'yes'}
+                                >
+                                    <FormControl>
+                                        <SelectTrigger>
+                                            <SelectValue placeholder="yes" />
+                                        </SelectTrigger>
+                                    </FormControl>
+                                    <SelectContent>
+                                        <SelectItem value="no">Nee</SelectItem>
+                                        <SelectItem value="yes">Ja</SelectItem>
+                                    </SelectContent>
+                                </Select>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+
+                  <FormField
+                    control={form.control}
+                    name="displayResourceDescription"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>
+                          Wil je de beschrijving van de resource tonen?
+                        </FormLabel>
+                        <Select
+                          onValueChange={field.onChange}
+                          value={field.value || 'no'}
+                        >
+                          <FormControl>
+                            <SelectTrigger>
+                              <SelectValue placeholder="no" />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            <SelectItem value="no">Nee</SelectItem>
+                            <SelectItem value="yes">Ja</SelectItem>
+                          </SelectContent>
+                        </Select>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
 
                     <Heading size="lg" className="mt-8 mb-2">Map Instellingen</Heading>
 

--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -71,6 +71,8 @@ export type DocumentMapProps = BaseProps &
     displayResourceInfo?: string;
     displayMapSide?: string;
     displayResourceDescription?: string;
+    displayResourceTitle?: string;
+    displayResourceSummary?: string;
     infoPopupContent?: string;
     likeWidget?: Omit<
       LikeWidgetProps,
@@ -123,6 +125,8 @@ function DocumentMap({
   displayResourceInfo = 'left',
   displayMapSide = 'left',
   displayResourceDescription = 'no',
+  displayResourceTitle = 'yes',
+  displayResourceSummary = 'yes',
   infoPopupContent = 'Op deze afbeelding kun je reacties plaatsen. Klik op de afbeelding om een reactie toe te voegen. Klik op een marker om de bijbehorende reacties te bekijken.',
   largeDoc = false,
   loginText = 'Inloggen om deel te nemen aan de discussie',
@@ -808,9 +812,8 @@ function DocumentMap({
               </div>
               {displayResourceInfo === 'left' && (
                 <section className="content-intro">
-                  {resource.title ? <Heading level={1}>{resource.title}</Heading> : null}
-                  {resource.summary ? <Heading level={2} appearance='utrecht-heading-4' dangerouslySetInnerHTML={{ __html: resource.summary }}></Heading> : null}
-
+                  {(displayResourceTitle === 'yes' && resource.title) ? <Heading level={1}>{resource.title}</Heading> : null}
+                  {(displayResourceSummary === 'yes' && resource.summary) ? <Heading level={2} appearance='utrecht-heading-4' dangerouslySetInnerHTML={{ __html: resource.summary }}></Heading> : null}
                   {(displayResourceDescription === 'yes' && resource.description) ? <Paragraph dangerouslySetInnerHTML={{ __html: resource.description }} /> : null}
                 </section>
               )}
@@ -820,9 +823,8 @@ function DocumentMap({
           {displayResourceInfo === 'right' && (
             <div className="content-container mobileonly">
               <section className="content-intro">
-                {resource.title ? <Heading level={1}>{resource.title}</Heading> : null}
-                {resource.summary ? <Heading level={2} appearance='utrecht-heading-4' dangerouslySetInnerHTML={{ __html: resource.summary }}></Heading> : null}
-
+                {(displayResourceTitle === 'yes' && resource.title) ? <Heading level={1}>{resource.title}</Heading> : null}
+                {(displayResourceSummary === 'yes' && resource.summary) ? <Heading level={2} appearance='utrecht-heading-4' dangerouslySetInnerHTML={{ __html: resource.summary }}></Heading> : null}
                 {(displayResourceDescription === 'yes' && resource.description) ? <Paragraph dangerouslySetInnerHTML={{ __html: resource.description }} /> : null}
               </section>
             </div>
@@ -1037,12 +1039,9 @@ function DocumentMap({
 
           {displayResourceInfo === 'right' && (
             <section className="content-intro desktoponly">
-              {resource.title ? <Heading level={1} appearance='utrecht-heading-2'>{resource.title}</Heading> : null}
-              <Spacer size={1}/>
-              {resource.summary ? <Heading level={2} appearance='utrecht-heading-4' dangerouslySetInnerHTML={{ __html: resource.summary }}></Heading> : null}
-
+              {(displayResourceTitle === 'yes' && resource.title) ? <><Heading level={1} appearance='utrecht-heading-2'>{resource.title}</Heading><Spacer size={1}/></> : null}
+              {(displayResourceSummary === 'yes' && resource.summary) ? <Heading level={2} appearance='utrecht-heading-4' dangerouslySetInnerHTML={{ __html: resource.summary }}></Heading> : null}
               {(displayResourceDescription === 'yes' && resource.description) ? <Paragraph dangerouslySetInnerHTML={{ __html: resource.description }} /> : null}
-
             </section>
           )}
 


### PR DESCRIPTION
This pull request adds `displayResourceTitle` and `displayResourceSummary` so it's possible to hide those. By default they are shown.