### PR TITLE
feat: make polygon titles clickable to open URLs

### DIFF
--- a/packages/leaflet-map/src/area.tsx
+++ b/packages/leaflet-map/src/area.tsx
@@ -162,7 +162,18 @@ export function Area({
                   </Popup>
                 </>
               ) : (
-                <Tooltip permanent direction="center">{item.title}</Tooltip>
+                <Tooltip
+                  permanent
+                  direction="center"
+                >
+                  <span
+                    onClick={() => {
+                      if (item.url) window.open(item.url, '_self');
+                    }}
+                  >
+                    {item.title}
+                  </span>
+                </Tooltip>
               )}
             </Polygon>
 

--- a/packages/leaflet-map/src/css/base-map.css
+++ b/packages/leaflet-map/src/css/base-map.css
@@ -152,6 +152,7 @@
   color: white;
   text-shadow: 0 0 4px black;
   font-size: .9rem;
+  pointer-events: all;
 }
 
 .leaflet-overlay-pane .leaflet-interactive {


### PR DESCRIPTION
The titles of the permanent tooltips were not clickable. This update makes them clickable.