### PR TITLE
Show published date instead of created date in blog widget

### DIFF
--- a/apps/cms-server/modules/openstad-blog-post-widget/views/widget.html
+++ b/apps/cms-server/modules/openstad-blog-post-widget/views/widget.html
@@ -28,7 +28,7 @@
         {% endif %}
         <div class="card-content">
           <div class="date">
-            {{ post.createdAt | date('MMMM D, YYYY')}}
+            {{ post.publishedAt | date('MMMM D, YYYY')}}
           </div>
           <h3 class="utrecht-heading-4">{{ post.title }}</h3>
           <p class="utrecht-paragraph">{{ post.summary | truncate(150) }}</p>


### PR DESCRIPTION
Replaces the display of the post's createdAt date with publishedAt in the blog post widget to reflect the actual publication date.