### PR TITLE
Run CI for all branches

### DIFF
--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -6,8 +6,7 @@ on:
       - 'operations/deployments/openstad-headless/environments/prod/images.yml'
       - 'charts/openstad-headless/values.yaml'
     branches:
-      - 'develop'
-      - 'main'
+      - '*'
   pull_request:
     branches:
       - 'develop'


### PR DESCRIPTION
This PR ensures that the CI is run for all branches. We can then use the resulting images for acceptation tests.