### PR TITLE
ci: add SHA suffix to PR images

### DIFF
--- a/.github/workflows/build-publish-docker.yml
+++ b/.github/workflows/build-publish-docker.yml
@@ -227,14 +227,14 @@ jobs:
             echo "type=raw,value=v${{ needs.get-openstad-version.outputs.openstad_version }}",priority=900 >> $GITHUB_OUTPUT
             echo "type=ref,event=branch,suffix=-{{sha}}",priority=700 >> $GITHUB_OUTPUT
             echo "type=ref,event=tag" >> $GITHUB_OUTPUT
-            echo "type=ref,event=pr" >> $GITHUB_OUTPUT
+            echo "type=ref,event=pr,suffix=-{{sha}}" >> $GITHUB_OUTPUT
             echo "type=raw,value=latest,enable={{is_default_branch}}" >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT
           else
             echo "tags<<EOF" >> $GITHUB_OUTPUT
             echo "type=ref,event=branch,suffix=-{{sha}}",priority=700 >> $GITHUB_OUTPUT
             echo "type=ref,event=tag" >> $GITHUB_OUTPUT
-            echo "type=ref,event=pr" >> $GITHUB_OUTPUT
+            echo "type=ref,event=pr,suffix=-{{sha}}" >> $GITHUB_OUTPUT
             echo "type=raw,value=latest,enable={{is_default_branch}}" >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
This adds the sha suffix to images created from a pull request. This allows us to make multiple images at different commits and reference each one.