### PR TITLE
feat: Add pagination and batch export functionality for votes

### DIFF
--- a/apps/api-server/src/routes/api/vote.js
+++ b/apps/api-server/src/routes/api/vote.js
@@ -120,9 +120,21 @@ router.route('/')
 			req.scope.push('includeUser');
 		}
 
+		const { page = 0, limit = 0 } = req.query;
+		const whereExtras = {};
+		if ( !!page || !!limit ) {
+			whereExtras.page = page;
+			whereExtras.limit = limit;
+		}
+
 		db.Vote
 			.scope(req.scope)
-			.findAndCountAll({ where, order, ...dbQuery })
+			.findAndCountAll({
+				where,
+				order,
+				...whereExtras,
+				...dbQuery
+			})
 			.then(function( result ) {
         req.results = result.rows;
         req.dbQuery.count = result.count;


### PR DESCRIPTION
A project with 50.000 votes is crashing when trying to load all the votes in the admin. This fixes it by loading and exporting in batches, just like choiceguide results.