### PR TITLE
stabilize randomId to prevent infinite loop in widget preview

### DIFF
--- a/apps/admin-server/src/components/widget-preview.tsx
+++ b/apps/admin-server/src/components/widget-preview.tsx
@@ -28,7 +28,8 @@ export default function WidgetPreview({ type, config, projectId }: Props) {
     }
   }, [sessionData]);
 
-  const randomId = Math.floor(Math.random() * 1000000);
+  const idRef = React.useRef(Math.floor(Math.random() * 1000000));
+  const randomId = idRef.current;
 
   const fetchWidget = useCallback(() => {
     const previewContainer = document.querySelector(


### PR DESCRIPTION
This change was made to prevent a memory leak that we observed. It seemed to originate from an infinite rerender of the widget preview