### PR TITLE
Return sensible error codes

### DIFF
--- a/apps/api-server/src/routes/api/action.js
+++ b/apps/api-server/src/routes/api/action.js
@@ -3,6 +3,7 @@ const db      = require('../../db');
 const auth = require('../../middleware/sequelize-authorization-middleware');
 const pagination = require('../../middleware/pagination');
 const rateLimiter = require("@openstad-headless/lib/rateLimiter");
+const createError = require('http-errors');
 
 let router = express.Router({mergeParams: true});
 
@@ -72,7 +73,9 @@ router.route('/:actionId(\\d+)')
          //   .scope(...req.scope)
             .findOne({ where: { id: actionId } })
             .then(found => {
-                if ( !found ) throw new Error('Action not found');
+                if (!found) {
+                  return next(createError(404, 'Action not found'));
+                }
                 req.results = found;
                 next();
             })

--- a/apps/api-server/src/routes/api/area.js
+++ b/apps/api-server/src/routes/api/area.js
@@ -75,7 +75,9 @@ router.route('/:areaId(\\d+)')
         where: { id: areaId },
       })
       .then(found => {
-        if (!found) throw new Error('area not found');
+        if (!found) {
+          return next(createError(404, 'Area not found'));
+        }
 
         req.area = found;
         req.results = req.area;
@@ -127,7 +129,9 @@ router.route('/:areaId(\\d+)')
         // where: { id: areaInstance.id, projectId: req.params.projectId },
       })
       .then(found => {
-        if (!found) throw new Error('area not found');
+        if (!found) {
+          return next(createError(404, 'Area not found'));
+        }
         req.results = found;
         next();
       })

--- a/apps/api-server/src/routes/api/datalayer.js
+++ b/apps/api-server/src/routes/api/datalayer.js
@@ -66,7 +66,9 @@ router.route('/:datalayerId(\\d+)')
         where: { id: datalayerId },
       })
       .then(found => {
-        if (!found) throw new Error('datalayer not found');
+        if (!found) {
+          return next(createError(404, 'datalayer not found'));
+        }
 
         req.datalayer = found;
         req.results = req.datalayer;
@@ -111,7 +113,9 @@ router.route('/:datalayerId(\\d+)')
         // where: { id: datalayerInstance.id, projectId: req.params.projectId },
       })
       .then(found => {
-        if (!found) throw new Error('datalayer not found');
+        if (!found) {
+          return next(createError(404, 'datalayer not found'));
+        }
         req.results = found;
         next();
       })

--- a/apps/api-server/src/routes/api/poll.js
+++ b/apps/api-server/src/routes/api/poll.js
@@ -134,7 +134,9 @@ router.route('/:pollId(\\d+)')
 				where: { id: pollId, resourceId: req.params.resourceId }
 			})
 			.then(found => {
-				if ( !found ) throw new Error('Poll not found');
+				if (!found) {
+          return next(createError(404, 'Poll not found'));
+        }
         if (req.query.includeVoteCount) found.countVotes(!req.query.includeVotes);
 
 		    req.results = found;
@@ -195,7 +197,9 @@ router.route('/:pollId(\\d+)/vote')
 				where: { id: pollId, resourceId: req.params.resourceId }
 			})
 			.then(found => {
-				if ( !found ) throw new Error('Poll not found');
+				if (!found) {
+          return next(createError(404, 'Poll not found'));
+        }
 		    req.results = found;
 				next();
 			})
@@ -251,7 +255,7 @@ router.route('/:pollId(\\d+)/vote')
 				console.log('err', err)
 				next(err);
 			});
-    
+   
 	})
 	.post(function( req, res, next ) {
 		db.PollVote

--- a/apps/api-server/src/routes/api/project.js
+++ b/apps/api-server/src/routes/api/project.js
@@ -784,7 +784,9 @@ router.route('/:projectId(\\d+)/:willOrDo(will|do)-anonymize-all-users')
 		db.Project
 			.findOne({ where })
 			.then(found => {
-				if ( !found ) throw new Error('Project not found');
+				if (!found) {
+          return next(createError(404, 'Project not found'));
+        }
 				req.results = found;
 				req.project = req.results; // middleware expects this to exist
         		next();

--- a/apps/api-server/src/routes/api/resource.js
+++ b/apps/api-server/src/routes/api/resource.js
@@ -422,7 +422,9 @@ router
         where: { id: resourceId, projectId: req.params.projectId },
       })
       .then((found) => {
-        if (!found) throw new Error('Resource not found');
+        if (!found) {
+          return next(createError(404, 'Resource not found'));
+        }
         found.project = req.project;
         if (req.query.includePoll) {
           // TODO: naar poll hooks
@@ -547,7 +549,9 @@ router
           where: { id: resourceInstance.id, projectId: req.params.projectId },
         })
         .then((found) => {
-          if (!found) throw new Error('Resource not found');
+          if (!found) {
+            return next(createError(404, 'Resource not found'));
+          }
 
           if (req.query.includePoll) {
             // TODO: naar poll hooks
@@ -589,7 +593,9 @@ router
           where: { id: resourceInstance.id, projectId: req.params.projectId },
         })
         .then((found) => {
-          if (!found) throw new Error('Resource not found');
+          if (!found) {
+            return next(createError(404, 'Resource not found'));
+          }
 
           if (req.query.includePoll) {
             // TODO: naar poll hooks

--- a/apps/api-server/src/routes/api/status.js
+++ b/apps/api-server/src/routes/api/status.js
@@ -3,6 +3,7 @@ const db = require('../../db');
 const auth = require('../../middleware/sequelize-authorization-middleware');
 const pagination = require('../../middleware/pagination');
 const rateLimiter = require("@openstad-headless/lib/rateLimiter");
+const createError = require('http-errors');
 
 let router = express.Router({ mergeParams: true });
 
@@ -85,7 +86,9 @@ router
     db.Status.scope(...req.scope)
       .findOne({ where: { id: statusId } })
       .then((found) => {
-        if (!found) throw new Error('Status not found');
+        if (!found) {
+          return next(createError(404, 'Status not found'));
+        }
         req.results = found;
         next();
       })

--- a/apps/api-server/src/routes/api/submission.js
+++ b/apps/api-server/src/routes/api/submission.js
@@ -194,7 +194,9 @@ router.route('/')
 				    where: {id: submissionId, projectId: req.params.projectId}
 				})
 				.then(found => {
-					if ( !found ) throw new Error('Submission not found');
+					if (!found) {
+            return next(createError(404, 'Submission not found'));
+          }
 					req.results = found;
 					next();
 				})

--- a/apps/api-server/src/routes/api/widget.js
+++ b/apps/api-server/src/routes/api/widget.js
@@ -5,6 +5,7 @@ const db = require('../../db');
 const sanitize = require('../../util/sanitize');
 const rateLimiter = require("@openstad-headless/lib/rateLimiter");
 const getWidgetSettings = require('../widget/widget-settings');
+const createError = require('http-errors');
 router.all('*', function (req, res, next) {
   req.scope = [];
   return next();
@@ -183,7 +184,9 @@ router
     db.Widget.scope(...req.scope)
       .findOne(query)
       .then((found) => {
-        if (!found) throw new Error('Widget not found');
+        if (!found) {
+          return next(createError(404, 'Widget not found'));
+        }
         req.results = found;
         req.widget = req.results; // middleware expects this to exist
         next();
@@ -210,7 +213,7 @@ router
 
       if (typesToSanitize.includes(widget.dataValues.type)) {
         widget.dataValues.config.rawInput = sanitize.content(widget.dataValues.config.rawInput);
-    }            
+    }
       widget.update({ config, description }).then((result) => res.json(result));
     }
   })

--- a/apps/api-server/src/routes/notification/message.js
+++ b/apps/api-server/src/routes/notification/message.js
@@ -79,7 +79,9 @@ router.route('/:messageId(\\d+)')
 				where: { id: messageId }
 			})
 			.then(found => {
-				if ( !found ) throw new Error('NotificationMessage not found');
+				if (!found) {
+          return next(createError(404, 'NotificationMessage not found'));
+        }
 		    req.results = found;
 				next();
 			})

--- a/apps/api-server/src/routes/notification/notification.js
+++ b/apps/api-server/src/routes/notification/notification.js
@@ -79,7 +79,9 @@ router.route('/:notificationId(\\d+)')
 				where: { id: notificationId }
 			})
 			.then(found => {
-				if ( !found ) throw new Error('Notification not found');
+				if (!found) {
+          return next(createError(404, 'Notification not found'));
+        }
 		    req.results = found;
 				next();
 			})

--- a/apps/api-server/src/routes/notification/template.js
+++ b/apps/api-server/src/routes/notification/template.js
@@ -79,7 +79,9 @@ router.route('/:templateId(\\d+)')
 				where: { id: templateId }
 			})
 			.then(found => {
-				if ( !found ) throw new Error('NotificationTemplate not found');
+				if (!found) {
+          return next(createError(404, 'NotificationTemplate not found'));
+        }
 		    req.results = found;
 				next();
 			})

--- a/apps/api-server/src/routes/widget/widget.js
+++ b/apps/api-server/src/routes/widget/widget.js
@@ -116,7 +116,9 @@ router
       include: [db.Project.scope('includeAreas')],
     })
       .then((found) => {
-        if (!found) throw new Error('Widget not found');
+        if (!found) {
+          return next(createError(404, 'Widget not found'));
+        }
         req.widget = found;
         next();
       })


### PR DESCRIPTION
Return 404 status code when a model cannot be found.

This would return a generic Error object, which would return a `500` status code. This is incorrect and should be a `404` status code instead.