### PR TITLE
Fix auth 5xx errors

### DIFF
--- a/apps/auth-server/middleware/client.js
+++ b/apps/auth-server/middleware/client.js
@@ -28,7 +28,7 @@ exports.withOne = async (req, res, next) => {
     clientId = req.params.clientId;
   }
  
-  if (!clientId) return next('No Client ID is set for login');
+  if (!clientId) return next(new Error('No Client ID is set for login'));
 
   let scope = [];
   let where = { clientId: clientId }
@@ -72,7 +72,7 @@ exports.withOne = async (req, res, next) => {
       return next();
 
     } else {
-      return next('No Client found for clientID');
+      return next(new Error('No Client found for clientID'));
     }
 
   } catch(err) {

--- a/apps/auth-server/routes/routes.js
+++ b/apps/auth-server/routes/routes.js
@@ -307,11 +307,10 @@ module.exports = function (app) {
         res.status(404).render('errors/404');
     });
 
-    // Handle 500
+    // Handle errors
     app.use(async function (err, req, res, next) {
-        console.log('===> err', err);
         // Return a 404 for when no client ID has been set, this is not a server error
-        if (err && err.message && err.message.match(/^'No Client ID is set for login/)) {
+        if (err && err.message && err.message.match(/^No Client ID is set for login/)) {
           return res.status(404).render('errors/404');
         }
         // een deserialize error betekent een data fout; daar hoef je een gebruiker niet mee te belasten
@@ -327,6 +326,7 @@ module.exports = function (app) {
           if (req.query.access_token) querystring += `&access_token=${req.query.access_token}`;
           return res.redirect('/logout'+querystring);
         }
+        console.log('===> err', err);
         res.status(500).render('errors/500');
     });
 


### PR DESCRIPTION
The auth server would return `500` errors even when a client ID was not supplied / found, which is what the default `/` route would lead to. Best practice is to monitor for `5xx` errors on your Ingresses, and this would lead to a lot of false positives.

