### PR TITLE
fix: enforce non-null email notification consent

### DIFF
--- a/apps/api-server/migrations/099-add-email-notification-consent-users.js
+++ b/apps/api-server/migrations/099-add-email-notification-consent-users.js
@@ -4,8 +4,9 @@ module.exports = {
     async up({ context: queryInterface }) {
         await queryInterface.addColumn('users', 'emailNotificationConsent', {
             type: Sequelize.BOOLEAN,
-            allowNull: true,
+            allowNull: false,
             after: 'postcode',
+            defaultValue: false,
         });
     },
 

--- a/apps/api-server/src/adapter/openstad/router.js
+++ b/apps/api-server/src/adapter/openstad/router.js
@@ -228,6 +228,9 @@ router
 
         if (clientConsentIsSet) {
             data.emailNotificationConsent = currentValue[clientId];
+        } else {
+          // clientConsent is not set (correctly); remove it to prevent overwriting existing consent
+          delete data.emailNotificationConsent;
         }
     }
 

--- a/apps/auth-server/migrations/006-add-email-notification-consent-users.js
+++ b/apps/auth-server/migrations/006-add-email-notification-consent-users.js
@@ -4,7 +4,7 @@ module.exports = {
     async up({ context: queryInterface }) {
         await queryInterface.addColumn('users', 'emailNotificationConsent', {
             type: Sequelize.JSON,
-            allowNull: true,
+            allowNull: false,
             after: 'postcode',
             defaultValue: {},
         });


### PR DESCRIPTION
This is a fix for the emailNotificationConsent migration and router, which would give errors on the default values.