### PR TITLE
fix: add processor configuration for sharp to handle Samsung S9 JPG errors

### DIFF
--- a/apps/image-server/server.js
+++ b/apps/image-server/server.js
@@ -94,6 +94,14 @@ const imageSteamConfig = {
     supportWebP: !disableWebpSupport,
     hqOriginalMaxPixels: process.env.HQ_ORIGINAL_MAX_PIXELS || 160000,  // default value of image-steam is 400 * 400 = 160000 px
   },
+  processor: {
+    sharp: {
+      defaults: {
+        // Fix for Samsung S9 JPG's
+        failOnError: false,
+      },
+    },
+  },
 };
 
 if (s3.isEnabled()) {


### PR DESCRIPTION
Images uploaded from a Samsung S9 can trigger the error 'Error: VipsJpeg: Invalid SOS parameters for sequential JPEG'. The solution was found here: https://github.com/lovell/sharp/issues/1578