### PR TITLE
Support multiple choice options in submission export

### DIFF
--- a/apps/admin-server/src/components/dialog-export-settings.tsx
+++ b/apps/admin-server/src/components/dialog-export-settings.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import { DialogClose } from '@radix-ui/react-dialog';
+
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Heading, Paragraph } from '@/components/ui/typography';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+} from '@/components/ui/dialog';
+
+export interface ExportSettings {
+  splitMultipleChoice: boolean;
+}
+
+type Props = {
+  disabled?: boolean;
+  onExport: (settings: ExportSettings) => void;
+};
+
+export function ExportSettingsDialog({ disabled, onExport }: Props) {
+  const [open, setOpen] = useState<boolean>(false);
+  const [splitMultipleChoice, setSplitMultipleChoice] = useState<boolean>(false);
+
+  const handleExport = () => {
+    onExport({ splitMultipleChoice });
+    setOpen(false);
+  };
+
+  return (
+    <Dialog open={open} modal={true} onOpenChange={setOpen}>
+      <Button
+        className="text-xs p-2"
+        type="button"
+        disabled={disabled}
+        onClick={(e) => {
+          e.preventDefault();
+          setOpen(true);
+        }}
+      >
+        Exporteer inzendingen
+      </Button>
+      <DialogContent
+        onEscapeKeyDown={(e: KeyboardEvent) => {
+          e.stopPropagation();
+        }}
+        onInteractOutside={(e: Event) => {
+          e.stopPropagation();
+          setOpen(false);
+        }}
+      >
+        <div>
+          <Heading size="lg">Export instellingen</Heading>
+          <Paragraph className="mb-6">
+            Pas de export instellingen aan voordat je de inzendingen downloadt.
+          </Paragraph>
+
+          <div className="flex items-center space-x-3 mb-8">
+            <Checkbox
+              id="splitMultipleChoice"
+              checked={splitMultipleChoice}
+              onCheckedChange={(checked) =>
+                setSplitMultipleChoice(checked === true)
+              }
+            />
+            <label
+              htmlFor="splitMultipleChoice"
+              className="text-sm font-medium leading-none cursor-pointer"
+            >
+              Meerkeuzevragen in aparte kolommen (Ja/Nee per optie)
+            </label>
+          </div>
+
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button
+                onClick={(e) => {
+                  e.preventDefault();
+                  setOpen(false);
+                }}
+                type="button"
+                variant="ghost"
+              >
+                Annuleren
+              </Button>
+            </DialogClose>
+
+            <Button type="button" onClick={handleExport}>
+              Exporteren
+            </Button>
+          </DialogFooter>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/admin-server/src/lib/export-helpers/normalize-to-array.tsx
+++ b/apps/admin-server/src/lib/export-helpers/normalize-to-array.tsx
@@ -1,0 +1,21 @@
+export const normalizeToArray = (value: any): string[] => {
+  if (!value) return [];
+
+  if (Array.isArray(value)) {
+    return value.map(v => String(v));
+  }
+
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      if (Array.isArray(parsed)) {
+        return parsed.map(v => String(v));
+      }
+    } catch {
+      return [value];
+    }
+    return [value];
+  }
+
+  return [String(value)];
+};

--- a/apps/admin-server/src/pages/projects/[project]/submissions/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/submissions/index.tsx
@@ -1,9 +1,9 @@
 import { PageLayout } from '../../../../components/ui/page-layout';
-import { Button } from '../../../../components/ui/button';
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { ListHeading, Paragraph } from '@/components/ui/typography';
 import { RemoveResourceDialog } from '@/components/dialog-resource-remove';
+import { ExportSettingsDialog, ExportSettings } from '@/components/dialog-export-settings';
 import { toast } from 'react-hot-toast';
 import { sortTable, searchTable } from '@/components/ui/sortTable';
 import useSubmissions from "@/hooks/use-submission";
@@ -106,14 +106,12 @@ export default function ProjectSubmissions() {
               </SelectContent>
             </Select>
 
-            <Button
-              className="text-xs p-2"
-              type="submit"
-              onClick={() => exportSubmissionsToCSV(filterData, activeWidget, selectedWidget)}
+            <ExportSettingsDialog
               disabled={activeWidget === "0"}
-            >
-              Exporteer inzendingen
-            </Button>
+              onExport={(settings: ExportSettings) =>
+                exportSubmissionsToCSV(filterData, activeWidget, selectedWidget, settings)
+              }
+            />
           </div>
         }>
         <div className="container py-6">


### PR DESCRIPTION
Add option to export multiple choice answers as separate columns with Ja/Nee values instead of combined values separated by pipes.

This opens a modal when exporting to select the option to split multiple choice answers into separate columns. 
<img width="564" height="260" alt="image" src="https://github.com/user-attachments/assets/bd60c6b1-8b20-457a-94a0-07b9284e740f" />

This gives us a place to add more export settings in the future.