### PR TITLE
fix: add proximity options and default handling to PostcodeAutoFill component

### DIFF
--- a/packages/ui/src/location/index.tsx
+++ b/packages/ui/src/location/index.tsx
@@ -18,6 +18,8 @@ type Props = {
   locationDefault: PostcodeAutoFillLocation;
   zipCodeAutofillApiUrl?: string;
   zipCodeApiUrl?: string;
+  proximityOptions?: { label: string; value: string }[];
+  proximityDefault?: string;
 };
 
 type Suggestion = {
@@ -35,11 +37,16 @@ type FullSuggestion = Suggestion & {
 };
 
 export default function PostcodeAutoFill({ onValueChange, locationDefault, ...props }: Props) {
+  const options = props.proximityOptions || proximityOptions;
+  const defaultProximity = props.proximityDefault || (options.length === 1
+      ? options[0].value
+      : options[Math.floor((options.length / 2) - 1)]?.value || "0.5");
+
   const [input, setInput] = useState('');
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [loading, setLoading] = useState(false);
   const [selected, setSelected] = useState<FullSuggestion | null>(null);
-  const [proximity, setProximity] = useState("0.5");
+  const [proximity, setProximity] = useState(defaultProximity);
   const [showDropdown, setShowDropdown] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [highlightedIndex, setHighlightedIndex] = useState<number>(0);
@@ -48,9 +55,9 @@ export default function PostcodeAutoFill({ onValueChange, locationDefault, ...pr
   useEffect(() => {
     if ( !locationDefault && input !== '' ) {
       reset();
-      setProximity("0.5");
+      setProximity(defaultProximity);
     }
-  }, [ locationDefault ]);
+  }, [ locationDefault, defaultProximity ]);
 
   useEffect(() => {
     if (input.length < 3) {
@@ -217,7 +224,7 @@ export default function PostcodeAutoFill({ onValueChange, locationDefault, ...pr
         <FormLabel htmlFor={'proximityField'}>Selecteer straal</FormLabel>
         <Select
           onValueChange={(value) => setProximity(value)}
-          options={proximityOptions}
+          options={options}
           id="proximityField"
           value={proximity}
           disableDefaultOption={true}

--- a/packages/ui/types/src/location/index.d.ts
+++ b/packages/ui/types/src/location/index.d.ts
@@ -6,6 +6,11 @@ type Props = {
     locationDefault: PostcodeAutoFillLocation;
     zipCodeAutofillApiUrl?: string;
     zipCodeApiUrl?: string;
+    proximityOptions?: {
+        label: string;
+        value: string;
+    }[];
+    proximityDefault?: string;
 };
 export default function PostcodeAutoFill({ onValueChange, locationDefault, ...props }: Props): React.JSX.Element;
 export {};


### PR DESCRIPTION
The default for proximity was hardcoded. The options were hardcoded, so it wasn't a problem earlier, but after the options became dynamic it was.