### PR TITLE
Add fallback for back button visibility based on browser history

### DIFF
--- a/apps/auth-server/controllers/auth/code.js
+++ b/apps/auth-server/controllers/auth/code.js
@@ -12,7 +12,7 @@ const authCodeConfig    = require('../../config/auth').get(authType);
 
 exports.login = (req, res, next) => {
   const config = req.client.config ? req.client.config : {};
-  const backUrl = config && config.backUrl ? config.backUrl : req.client.redirectUrl;
+  const backUrl = config && config.backUrl ? config.backUrl : false;
   const configAuthType = config.authTypes && config.authTypes[authType] ? config.authTypes[authType] : {};
 
   res.render('auth/code/login', {

--- a/apps/auth-server/views/elements/navbar.html
+++ b/apps/auth-server/views/elements/navbar.html
@@ -7,6 +7,17 @@
              Terug
           </a>
         </li>
+        {% else %}
+        <li class="nav-link" id="back-button" style="display: none;">
+          <a href="javascript:history.back()" class="backlink">
+             Terug
+          </a>
+        </li>
+        <script>
+          if (history.length > 1) {
+            document.getElementById('back-button').style.display = '';
+          }
+        </script>
         {% endif %}
     </ul>
     <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
Implement a fallback mechanism for the back button in the navbar, ensuring it only displays when there is a valid browser history or backUrl is not empty. This improves user navigation experience.