### PR TITLE
fix: handle optional chaining for resource statuses and tags

### DIFF
--- a/packages/resource-overview/src/gridder-resource-detail.tsx
+++ b/packages/resource-overview/src/gridder-resource-detail.tsx
@@ -68,7 +68,7 @@ export const GridderResourceDetail = ({
     ? resource?.tags.filter((tag: { type: string }) => dialogTagGroups.includes(tag.type))
     : resource?.tags;
 
-  resourceFilteredTags = resourceFilteredTags.length
+  resourceFilteredTags = resourceFilteredTags?.length
     ? resourceFilteredTags?.sort((a: { seqnr?: number }, b: { seqnr?: number }) => {
       if (a.seqnr === undefined || a.seqnr === null) return 1;
       if (b.seqnr === undefined || b.seqnr === null) return -1;

--- a/packages/resource-overview/src/resource-overview.tsx
+++ b/packages/resource-overview/src/resource-overview.tsx
@@ -275,8 +275,8 @@ const defaultItemRenderer = (
   const resourceImages = (Array.isArray(resource.images) && resource.images.length > 0) ? resource.images : [{ url: defaultImage }];
   const hasImages = (Array.isArray(resourceImages) && resourceImages.length > 0 && resourceImages[0].url !== '') ? '' : 'resource-has-no-images';
 
-  let resourceFilteredStatuses = resource?.statuses
-    ? resource.statuses?.sort((a: { seqnr?: number }, b: { seqnr?: number }) => {
+  let resourceFilteredStatuses = Array.isArray(resource?.statuses)
+    ? resource.statuses.sort((a: { seqnr?: number }, b: { seqnr?: number }) => {
         if (a.seqnr === undefined || a.seqnr === null) return 1;
         if (b.seqnr === undefined || b.seqnr === null) return -1;
         return a.seqnr - b.seqnr;
@@ -303,7 +303,7 @@ const defaultItemRenderer = (
     ? resource?.tags.filter((tag: { type: string }) => overviewTagGroups.includes(tag.type))
     : resource?.tags || [];
 
-  resourceFilteredTags = resourceFilteredTags.length
+  resourceFilteredTags = resourceFilteredTags?.length
     ? resourceFilteredTags?.sort((a: { seqnr?: number }, b: { seqnr?: number }) => {
       if (a.seqnr === undefined || a.seqnr === null) return 1;
       if (b.seqnr === undefined || b.seqnr === null) return -1;


### PR DESCRIPTION
The resource dialog could trigger an error, because the length would be checked and the variable was not always an array.