### PR TITLE
Op 615/gebruikers overzicht inladen adminpanel langlang

### DIFF
--- a/apps/admin-server/src/hooks/use-users.tsx
+++ b/apps/admin-server/src/hooks/use-users.tsx
@@ -9,9 +9,32 @@ type userType = {
   };
 }
 
-function useUsers() {
+export type UsersPaginationOptions = {
+  page?: number;
+  pageSize?: number;
+  q?: string;
+};
 
-  const usersSwr = useSWR('/api/openstad/api/user');
+export type UsersPaginationMetadata = {
+  page: number;
+  pageSize: number;
+  pageCount: number;
+  totalCount: number;
+};
+
+function useUsers(options?: UsersPaginationOptions) {
+  const page = options?.page;
+  const pageSize = options?.pageSize ?? 20;
+  const q = options?.q?.trim();
+
+  const url =
+    page !== undefined
+      ? `/api/openstad/api/user?page=${page}&pageSize=${pageSize}${q ? `&q=${encodeURIComponent(q)}` : ''}`
+      : '/api/openstad/api/user';
+  const usersSwr = useSWR(url);
+  const res = usersSwr.data;
+  const data = res?.records ?? res;
+  const metadata = res?.metadata;
 
   async function createUser(user:userType) {
     let url = `/api/openstad/api/project/${user.projectId}/user`;
@@ -29,7 +52,7 @@ function useUsers() {
 
   }
 
-  return { ...usersSwr, createUser };
+  return { ...usersSwr, data, metadata, createUser };
 }
 
 export {

--- a/apps/api-server/src/routes/api/user.js
+++ b/apps/api-server/src/routes/api/user.js
@@ -139,6 +139,16 @@ router.route('/')
     };
     if (req.params.projectId) dbQuery.where.projectId = req.params.projectId;
 
+    const q = req.query.q && typeof req.query.q === 'string' ? req.query.q.trim() : '';
+    if (q) {
+      const like = '%' + String(q).replace(/[\\%_]/g, (m) => (m === '\\' ? '\\\\' : '\\' + m)) + '%';
+      dbQuery.where[Op.or] = [
+        { name: { [Op.like]: like } },
+        { email: { [Op.like]: like } },
+        { postcode: { [Op.like]: like } },
+      ];
+    }
+
     db.User
       .scope(...req.scope)
       .findAndCountAll(dbQuery)

--- a/packages/stem-begroot/src/stem-begroot.tsx
+++ b/packages/stem-begroot/src/stem-begroot.tsx
@@ -23,7 +23,6 @@ import { Step4 } from './step-4';
 import '@utrecht/component-library-css';
 import '@utrecht/design-tokens/dist/root.css';
 import { Button, Heading, ButtonLink } from '@utrecht/component-library-react';
-import useTags from '@openstad-headless/admin-server/src/hooks/use-tag';
 import NotificationService from '../../lib/NotificationProvider/notification-service';
 import NotificationProvider from '../../lib/NotificationProvider/notification-provider';
 
@@ -142,7 +141,7 @@ function StemBegroot({
     api: props.api,
   });
 
-   const { data: allTags } = useTags(props.projectId);
+   const { data: allTags } = datastore.useTags({ projectId: props.projectId, type: 'tag' });
 
   const [pendingVoteFetched, setPendingVoteFetched] = useState<boolean>(false);
 


### PR DESCRIPTION
**Changes**
Users overview: pagination, server-side search, loading spinner
Paginate users list in admin (frontend uses existing backend page/pageSize).
Search via API q param instead of client-side filter, fixes backspace clearing results.
Show spinner while validating and keep previous list visible while loading to avoid empty flash.