### PR TITLE
fix: add writable tmp volumes for CMS server with readOnlyRootFilesystem

### DIFF
--- a/charts/openstad-headless/templates/cms/deployment.yaml
+++ b/charts/openstad-headless/templates/cms/deployment.yaml
@@ -119,13 +119,21 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.cms.resources | indent 12 }}
-{{- if ne .Values.cms.useS3 "true" }}
         volumeMounts:
+          - mountPath: /tmp
+            name: tmp-dir
+          - mountPath: /opt/openstad-headless/apps/cms-server/data/temp
+            name: temp-dir
+{{- if ne .Values.cms.useS3 "true" }}
           - mountPath: {{ .Values.cms.volumes.data.mountPath | default "/opt/openstad-headless/apps/cms-server/public/uploads/attachments" }}
             name: data-vol
 {{- end }}
-{{- if ne .Values.cms.useS3 "true" }}
       volumes:
+        - name: tmp-dir
+          emptyDir: {}
+        - name: temp-dir
+          emptyDir: {}
+{{- if ne .Values.cms.useS3 "true" }}
         - name: data-vol
           persistentVolumeClaim:
             claimName: cms-data-claim


### PR DESCRIPTION
Multer (used by ApostropheCMS for file uploads) writes to /tmp, and uploadfs writes to data/temp/. Both fail with EROFS when readOnlyRootFilesystem is enabled. Add emptyDir volumes for both paths.

This was caused due to the `readOnlyRootFilesystem` attribute being set to `true`. 