### PR TITLE
fix: add writable /tmp volumes for image-server and api-server

### DIFF
--- a/charts/openstad-headless/templates/api/deployment.yaml
+++ b/charts/openstad-headless/templates/api/deployment.yaml
@@ -290,6 +290,9 @@ spec:
           {{- if .Values.api.customWorkingDir }}
           workingDir: {{ .Values.api.customWorkingDir }}
           {{- end }}
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp-dir
           resources:
 {{ toYaml .Values.api.resources | indent 12 }}
           readinessProbe:
@@ -304,6 +307,9 @@ spec:
             periodSeconds: {{ .Values.api.probe.liveness.periodSeconds }}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
+      volumes:
+        - name: tmp-dir
+          emptyDir: {}
       dnsPolicy: ClusterFirst
       initContainers:
         - command: ["/bin/bash", "-c"]

--- a/charts/openstad-headless/templates/image/deployment.yaml
+++ b/charts/openstad-headless/templates/image/deployment.yaml
@@ -112,17 +112,23 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.image.resources | indent 12 }}
-{{- if ne .Values.image.useS3 "true" }}
         volumeMounts:
+          - mountPath: /tmp
+            name: tmp-dir
+{{- if ne .Values.image.useS3 "true" }}
           - mountPath: {{ .Values.image.volumes.data.mountPath | default "/opt/openstad-headless/apps/image-server/images" }}
             name: data-vol
           - mountPath: {{ .Values.image.volumes.data.documentMountPath | default "/opt/openstad-headless/apps/image-server/documents" }}
             name: data-docs-vol
+{{- end }}
       volumes:
+        - name: tmp-dir
+          emptyDir: {}
+{{- if ne .Values.image.useS3 "true" }}
         - name: data-vol
           persistentVolumeClaim:
             claimName: image-data-claim
         - name: data-docs-vol
           persistentVolumeClaim:
             claimName: docs-data-claim
-{{- end}}
+{{- end }}


### PR DESCRIPTION
Both deployments use readOnlyRootFilesystem but lack a writable /tmp. Sharp (image processing) and Node.js internals need /tmp for temp files. Add emptyDir volumes to prevent EROFS errors at runtime.

Related to #1360, but for the other servers which might be affected.

This was caused due to the `readOnlyRootFilesystem` attribute being set to `true`.