### PR TITLE
fix(auth): handle logout when session is undefined

### DIFF
--- a/apps/cms-server/modules/openstad-auth/index.js
+++ b/apps/cms-server/modules/openstad-auth/index.js
@@ -278,6 +278,10 @@ module.exports = {
       get: {
         // GET /api/v1/openstad-auth/logout
         async logout(req, res) {
+          // If there is no session we can redirect back safely
+          if (!req.session) {
+            return res.redirect('/');
+          }
           req.session.openStadlastJWTCheck = 0;
           req.session.save(() => {
             return res.redirect('/');


### PR DESCRIPTION
In some cases an undefined session would be found, and the logout could not be completed. This would lead to the cms pod crashing.

By checking for `req.session` we can prevent this. If the session doesn't exist we can just redirect back instead of trying to destroy it.