### PR TITLE
Add archive status banner and settings

### DIFF
--- a/apps/cms-server/modules/@apostrophecms/global/index.js
+++ b/apps/cms-server/modules/@apostrophecms/global/index.js
@@ -85,6 +85,21 @@ module.exports = {
         def: true,
       },
 
+      archiveStatus: {
+        type: 'boolean',
+        label: 'Zet de site in archief modus',
+        def: false,
+      },
+
+      archiveStatusText: {
+        type: 'string',
+        label: 'Tekst die getoond wordt als de site in archief modus staat',
+        def: 'Dit project is afgerond.',
+        if: {
+          archiveStatus: true,
+        },
+      },
+
       siteLogo: {
         type: 'attachment',
         label: 'Site logo',
@@ -373,7 +388,7 @@ module.exports = {
     group: {
       basics: {
         label: 'Algemene instellingen',
-        fields: ['siteTitle', 'hideSiteTitle', 'siteLogo', 'logoAltText'],
+        fields: ['siteTitle', 'hideSiteTitle', 'siteLogo', 'logoAltText', 'archiveStatus', 'archiveStatusText'],
       },
       css: {
         label: 'Vormgeving',

--- a/apps/cms-server/modules/openstad-assets/ui/src/header.scss
+++ b/apps/cms-server/modules/openstad-assets/ui/src/header.scss
@@ -442,6 +442,37 @@ header:has(.header_navbar-container.--show)~#navbar {
   }
 }
 
+// Archive status banner
+.archive-status-banner {
+  background: var(--nlds-header-compact-background-color, var(--utrecht-button-primary-action-background-color));
+  padding: 8px 0;
+  text-align: center;
+  margin: 0;
+  position: sticky;
+  top: 0;
+  z-index: 99;
+
+  p {
+    display: inline-flex;
+    color: var(--nlds-archiveBanner-color, var(--utrecht-button-primary-action-color));
+    margin: 0;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.15em;
+    gap: .5rem;
+    align-items: center;
+
+    &:before {
+      content: '';
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 640 640'%3E%3C!--!Font Awesome Pro v7.1.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) Copyright 2026 Fonticons, Inc.--%3E%3Cpath d='M320 112C434.9 112 528 205.1 528 320C528 434.9 434.9 528 320 528C205.1 528 112 434.9 112 320C112 205.1 205.1 112 320 112zM320 576C461.4 576 576 461.4 576 320C576 178.6 461.4 64 320 64C178.6 64 64 178.6 64 320C64 461.4 178.6 576 320 576zM280 400C266.7 400 256 410.7 256 424C256 437.3 266.7 448 280 448L360 448C373.3 448 384 437.3 384 424C384 410.7 373.3 400 360 400L352 400L352 312C352 298.7 341.3 288 328 288L280 288C266.7 288 256 298.7 256 312C256 325.3 266.7 336 280 336L304 336L304 400L280 400zM320 256C337.7 256 352 241.7 352 224C352 206.3 337.7 192 320 192C302.3 192 288 206.3 288 224C288 241.7 302.3 256 320 256z'/%3E%3C/svg%3E");
+      display: inline-block;
+      width: 1.2rem;
+      height: 1.2rem;
+      background-color: var(--nlds-archiveBanner-color, var(--utrecht-button-primary-action-color));
+    }
+  }
+}
+
 // top bar buttons
 .header-top-bar {
   background: #fff;

--- a/apps/cms-server/views/partials/header.html
+++ b/apps/cms-server/views/partials/header.html
@@ -1,5 +1,9 @@
+{% if data.global.archiveStatus %}
+<div class="archive-status-banner">
+  <p>{{ data.global.archiveStatusText }}</p>
+</div>
+{% endif %}
 <header class="{{ 'amsterdam-header' if data.global.siteLogo === 'amsterdam' }} {{ '--compact' if data.global.compactMenu }}">
-
       <div class="header-top-bar">
         <div class="container">
           <div class="topmenu-dynamic-container">


### PR DESCRIPTION
Introduce an archive mode toggle and banner: add archiveStatus (boolean) and archiveStatusText (string) fields to the global module (with Dutch labels and defaults) and include them in the basics group. Render a conditional archive banner in the header partial when archiveStatus is true. Add SCSS for .archive-status-banner (sticky top, styling, and an inline SVG icon via mask-image) to display the archival notice across the site.