### PR TITLE
feat: add preview tab to resource detail page in admin

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/resources/[id]/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/resources/[id]/index.tsx
@@ -11,6 +11,7 @@ import ProjectResourceCreate from "./info";
 import ProjectResourceVotes from "./votes";
 import ProjectResourceArguments from "./comments";
 import ProjectResourceCreateArgument from "@/pages/projects/[project]/resources/[id]/createComment";
+import ProjectResourcePreview from "./preview";
 
 export default function ProjectResource() {
   const router = useRouter();
@@ -42,6 +43,7 @@ export default function ProjectResource() {
               <TabsTrigger value="votes">Stemmen</TabsTrigger>
               <TabsTrigger value="comments">Reacties</TabsTrigger>
               <TabsTrigger value="createComment">Reactie plaatsen</TabsTrigger>
+              <TabsTrigger value="preview">Preview</TabsTrigger>
             </TabsList>
             <TabsContent value="info" className="p-0">
               <ProjectResourceCreate />
@@ -54,6 +56,9 @@ export default function ProjectResource() {
             </TabsContent>
             <TabsContent value="createComment" className="p-0">
               <ProjectResourceCreateArgument />
+            </TabsContent>
+            <TabsContent value="preview" className="p-0">
+              <ProjectResourcePreview />
             </TabsContent>
           </Tabs>
 

--- a/apps/admin-server/src/pages/projects/[project]/resources/[id]/preview.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/resources/[id]/preview.tsx
@@ -1,0 +1,99 @@
+import React, { useState, useMemo, useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { useWidgetsHook, Widget } from '@/hooks/use-widgets';
+import { WidgetDefinitions, WidgetDefinition } from '@/lib/widget-definitions';
+import WidgetPreview from '@/components/widget-preview';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+const RESOURCE_DETAIL_TYPES: WidgetDefinition[] = ['resourcedetail'];
+
+function getWidgetLabel(widget: Widget): string {
+  return (
+    widget.description ||
+    `${WidgetDefinitions[widget.type]?.name || widget.type} (Widget ${widget.id})`
+  );
+}
+
+export default function ProjectResourcePreview() {
+  const router = useRouter();
+  const projectId = router.query.project as string;
+  const resourceId = router.query.id as string;
+
+  const { data: widgets, isLoading } = useWidgetsHook(projectId);
+  const [selectedWidgetId, setSelectedWidgetId] = useState<string>();
+
+  const resourceDetailWidgets = useMemo(() => {
+    if (!widgets || !Array.isArray(widgets)) return [];
+    return widgets.filter((w: Widget) =>
+      RESOURCE_DETAIL_TYPES.includes(w.type)
+    );
+  }, [widgets]);
+
+  useEffect(() => {
+    if (!selectedWidgetId && resourceDetailWidgets.length > 0) {
+      setSelectedWidgetId(String(resourceDetailWidgets[0].id));
+    }
+  }, [resourceDetailWidgets, selectedWidgetId]);
+
+  const selectedWidget = resourceDetailWidgets.find(
+    (w) => String(w.id) === selectedWidgetId
+  );
+
+  const previewConfig = selectedWidget
+    ? { ...(selectedWidget.config as object), resourceId }
+    : null;
+
+  if (isLoading) {
+    return <p className="p-6">Laden...</p>;
+  }
+
+  if (resourceDetailWidgets.length === 0) {
+    return (
+      <div className="p-6 bg-white rounded-md">
+        <p>
+          Er zijn geen resource detail widgets geconfigureerd in dit project.
+          Maak eerst een widget aan van het type &quot;Inzending
+          detailpagina&quot;.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="p-6 bg-white rounded-md mb-4">
+        <label className="text-sm font-medium mb-2 block">
+          Selecteer een widget om de inzending te previewen
+        </label>
+        <Select
+          onValueChange={setSelectedWidgetId}
+          value={selectedWidgetId}>
+          <SelectTrigger className="w-full max-w-md">
+            <SelectValue placeholder="Kies een widget..." />
+          </SelectTrigger>
+          <SelectContent className="overflow-y-auto max-h-[16rem]">
+            {resourceDetailWidgets.map((w) => (
+              <SelectItem key={w.id} value={String(w.id)}>
+                {getWidgetLabel(w)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {previewConfig && selectedWidget && (
+        <WidgetPreview
+          type={selectedWidget.type}
+          config={previewConfig}
+          projectId={projectId}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Allows admins to preview how a resource (inzending) looks on the website by selecting a resource detail widget configured in the project.