### PR TITLE
Support configurable contactEmail in helpText

### DIFF
--- a/apps/auth-server/config/auth.js
+++ b/apps/auth-server/config/auth.js
@@ -21,7 +21,7 @@ const types = [
     title: 'Controleer stemcode',
     description: 'Vul hieronder je unieke code in om een OpenStad account aan te maken. Deze code heb je thuis gestuurd gekregen van ons.',
     label: 'Mijn stemcode',
-    helpText: 'Let op, de unieke code is hoofdlettergevoelig! Werkt deze nog steeds niet? <a href="mailto:info@openstad.nl">Neem contact met ons op.</a>',
+    helpText: 'Let op, de unieke code is hoofdlettergevoelig! Werkt deze nog steeds niet? <a href="mailto:[[contactEmail]]">Neem contact met ons op.</a>',
     errorMessage: 'Vul een geldige stemcode in. Heb je een typefout gemaakt? Stemcodes zijn hoofdlettergevoelig.',
     displaySidebar: false,
     displayBackbutton: true,

--- a/apps/auth-server/controllers/auth/code.js
+++ b/apps/auth-server/controllers/auth/code.js
@@ -14,6 +14,7 @@ exports.login = (req, res, next) => {
   const config = req.client.config ? req.client.config : {};
   const backUrl = config && config.backUrl ? config.backUrl : false;
   const configAuthType = config.authTypes && config.authTypes[authType] ? config.authTypes[authType] : {};
+  const contactEmail = config.contactEmail || '';
 
   res.render('auth/code/login', {
     client: req.client,
@@ -21,7 +22,7 @@ exports.login = (req, res, next) => {
     title: configAuthType.title ? configAuthType.title : authCodeConfig.title,
     description: configAuthType.description ?  configAuthType.description : authCodeConfig.description,
     label: configAuthType.label ?  configAuthType.label : authCodeConfig.label,
-    helpText: configAuthType.helpText ? configAuthType.helpText : authCodeConfig.helpText,
+    helpText: (configAuthType.helpText ? configAuthType.helpText : authCodeConfig.helpText).replace(/\[\[contactEmail\]\]/g, contactEmail),
     buttonText: configAuthType.buttonText ? configAuthType.buttonText : authCodeConfig.buttonText,
     displaySidebar: configAuthType.displaySidebar ? configAuthType.displaySidebar : authCodeConfig.displaySidebar,
     backUrl: authCodeConfig.displayBackbutton ? backUrl : false,

--- a/apps/auth-server/controllers/auth/phonenumber.js
+++ b/apps/auth-server/controllers/auth/phonenumber.js
@@ -38,6 +38,7 @@ exports.index = (req, res) => {
 exports.login = (req, res) => {
   const config = req.client.config ? req.client.config : {};
   const configAuthType = config.authTypes && config.authTypes['Phonenumber'] ? config.authTypes['Phonenumber'] : {};
+  const contactEmail = config.contactEmail || '';
 
   res.render('auth/phonenumber/login', {
     loginUrl: authPhonenumberConfig.loginUrl,
@@ -48,7 +49,7 @@ exports.login = (req, res) => {
     subtitle: configAuthType.loginSubtitle || authPhonenumberConfig.loginSubtitle,
     description: configAuthType.loginDescription || configAuthType.description || authPhonenumberConfig.loginDescription || authPhonenumberConfig.description,
     label: configAuthType.loginLabel || configAuthType.label || authPhonenumberConfig.loginLabel || authPhonenumberConfig.label,
-    helpText: configAuthType.loginHelpText || configAuthType.helpText || authPhonenumberConfig.loginHelpText || authPhonenumberConfig.helpText,
+    helpText: (configAuthType.loginHelpText || configAuthType.helpText || authPhonenumberConfig.loginHelpText || authPhonenumberConfig.helpText).replace(/\[\[contactEmail\]\]/g, contactEmail),
     buttonText: configAuthType.loginButtonText || configAuthType.buttonText || authPhonenumberConfig.loginButtonText || authPhonenumberConfig.buttonText,
   });
 };
@@ -138,6 +139,7 @@ exports.postLogin = async(req, res, next) => {
 exports.smsCode = (req, res) => {
   const config = req.client.config ? req.client.config : {};
   const configAuthType = config.authTypes && config.authTypes['Phonenumber'] ? config.authTypes['Phonenumber'] : {};
+  const contactEmail = config.contactEmail || '';
 
   res.render('auth/phonenumber/sms-code', {
     loginUrl: authPhonenumberConfig.smsCodeUrl,
@@ -148,7 +150,7 @@ exports.smsCode = (req, res) => {
     subtitle: configAuthType.smsCodeSubtitle || authPhonenumberConfig.smsCodeSubtitle,
     description: configAuthType.smsCodeDescription || configAuthType.description || authPhonenumberConfig.smsCodeDescription || authPhonenumberConfig.description,
     label: configAuthType.smsCodeLabel || configAuthType.label || authPhonenumberConfig.smsCodeLabel || authPhonenumberConfig.label,
-    helpText: configAuthType.smsCodeHelpText || configAuthType.helpText || authPhonenumberConfig.smsCodeHelpText || authPhonenumberConfig.helpText,
+    helpText: (configAuthType.smsCodeHelpText || configAuthType.helpText || authPhonenumberConfig.smsCodeHelpText || authPhonenumberConfig.helpText).replace(/\[\[contactEmail\]\]/g, contactEmail),
     buttonText: configAuthType.smsCodeButtonText || configAuthType.buttonText || authPhonenumberConfig.smsCodeButtonText || authPhonenumberConfig.buttonText,
   });
 };


### PR DESCRIPTION
Replace the hardcoded mailto in the auth UI copy with a [[contactEmail]] placeholder and inject a client-specific contactEmail at render time. Updated apps/auth-server/config/auth.js to use the placeholder, and updated controllers (apps/auth-server/controllers/auth/code.js and phonenumber.js) to read config.contactEmail (defaulting to '') and replace [[contactEmail]] in helpText before rendering views so each client can show its own contact address.