### PR TITLE
OP-710/Trim allowedDomains when saving

### DIFF
--- a/apps/api-server/src/routes/api/project.js
+++ b/apps/api-server/src/routes/api/project.js
@@ -633,7 +633,11 @@ router.route('/:projectId') //(\\d+)
     try {
       let providers = await authSettings.providers({ project });
       const configData = req.body.config?.auth?.provider?.openstad?.config || {};
-      const allowedDomains = req.body.config?.allowedDomains || false;
+      let allowedDomains = req.body.config?.allowedDomains || false;
+      if (Array.isArray(allowedDomains)) {
+        allowedDomains = allowedDomains.map((d) => (typeof d === 'string' ? d.trim() : d));
+        req.body.config.allowedDomains = allowedDomains;
+      }
       const twoFactorRoles = req.body.config?.auth?.provider?.openstad?.twoFactorRoles;
 
       for (let provider of providers) {


### PR DESCRIPTION
**changes**

- trimming alloweddomains when saving. Is was possible to save one with a space at the end, causing a domain check failing
