### PR TITLE
style: normalize generated type declaration formatting

### DIFF
--- a/packages/ui/types/src/accordion/index.d.ts
+++ b/packages/ui/types/src/accordion/index.d.ts
@@ -1,12 +1,4 @@
 import React from 'react';
-
 import './index.css';
-
-declare function Accordion({
-  content,
-  closeLabel,
-  openLabel,
-  headingLevel,
-  expanded,
-}: any): React.JSX.Element;
+declare function Accordion({ content, closeLabel, openLabel, headingLevel, expanded, }: any): React.JSX.Element;
 export { Accordion };

--- a/packages/ui/types/src/banner/index.d.ts
+++ b/packages/ui/types/src/banner/index.d.ts
@@ -1,10 +1,6 @@
 import React from 'react';
-
 import '../index.css';
 import './index.css';
-
-export declare function Banner(
-  props: React.HTMLAttributes<HTMLDivElement> & {
+export declare function Banner(props: React.HTMLAttributes<HTMLDivElement> & {
     big?: boolean;
-  }
-): React.JSX.Element;
+}): React.JSX.Element;

--- a/packages/ui/types/src/button/index.d.ts
+++ b/packages/ui/types/src/button/index.d.ts
@@ -1,33 +1,23 @@
 import React from 'react';
-
 import '../index.css';
 import './index.css';
-
 export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  icon?: string;
-  iconBack?: boolean;
+    icon?: string;
+    iconBack?: boolean;
 };
-export declare const Button: React.ForwardRefExoticComponent<
-  React.ButtonHTMLAttributes<HTMLButtonElement> & {
+export declare const Button: React.ForwardRefExoticComponent<React.ButtonHTMLAttributes<HTMLButtonElement> & {
     icon?: string;
     iconBack?: boolean;
-  } & React.RefAttributes<HTMLButtonElement>
->;
-export declare const SecondaryButton: React.ForwardRefExoticComponent<
-  React.ButtonHTMLAttributes<HTMLButtonElement> & {
+} & React.RefAttributes<HTMLButtonElement>>;
+export declare const SecondaryButton: React.ForwardRefExoticComponent<React.ButtonHTMLAttributes<HTMLButtonElement> & {
     icon?: string;
     iconBack?: boolean;
-  } & React.RefAttributes<HTMLButtonElement>
->;
-export declare const GhostButton: React.ForwardRefExoticComponent<
-  React.ButtonHTMLAttributes<HTMLButtonElement> & {
+} & React.RefAttributes<HTMLButtonElement>>;
+export declare const GhostButton: React.ForwardRefExoticComponent<React.ButtonHTMLAttributes<HTMLButtonElement> & {
     icon?: string;
     iconBack?: boolean;
-  } & React.RefAttributes<HTMLButtonElement>
->;
-export declare const PlainButton: React.ForwardRefExoticComponent<
-  React.ButtonHTMLAttributes<HTMLButtonElement> & {
+} & React.RefAttributes<HTMLButtonElement>>;
+export declare const PlainButton: React.ForwardRefExoticComponent<React.ButtonHTMLAttributes<HTMLButtonElement> & {
     icon?: string;
     iconBack?: boolean;
-  } & React.RefAttributes<HTMLButtonElement>
->;
+} & React.RefAttributes<HTMLButtonElement>>;

--- a/packages/ui/types/src/card/index.d.ts
+++ b/packages/ui/types/src/card/index.d.ts
@@ -1,8 +1,6 @@
 import React from 'react';
-
 import '../index.css';
 import './index.css';
-
 type Props = React.HTMLAttributes<HTMLDivElement>;
 export declare function Card(props: Props): React.JSX.Element;
 export {};

--- a/packages/ui/types/src/carousel/index.d.ts
+++ b/packages/ui/types/src/carousel/index.d.ts
@@ -1,30 +1,19 @@
 import React from 'react';
-
 import '../index.css';
 import './index.css';
-
 type Props = {
-  items: Array<any>;
-  itemRenderer: (item: any) => React.JSX.Element;
-  startIndex?: number;
-  previousButton?: HTMLButtonElement;
-  nextButton?: HTMLButtonElement;
-  buttonText?: {
-    next?: string;
-    previous?: string;
-  };
-  beforeIndexChange?: () => void;
-  setIndexInParent?: (setter: (index: number) => void) => void;
-  pager?: boolean;
+    items: Array<any>;
+    itemRenderer: (item: any) => React.JSX.Element;
+    startIndex?: number;
+    previousButton?: HTMLButtonElement;
+    nextButton?: HTMLButtonElement;
+    buttonText?: {
+        next?: string;
+        previous?: string;
+    };
+    beforeIndexChange?: () => void;
+    setIndexInParent?: (setter: (index: number) => void) => void;
+    pager?: boolean;
 } & React.HTMLAttributes<HTMLDivElement>;
-export declare function Carousel({
-  startIndex,
-  items,
-  itemRenderer,
-  buttonText,
-  beforeIndexChange,
-  setIndexInParent,
-  pager,
-  ...props
-}: Props): React.JSX.Element | null;
+export declare function Carousel({ startIndex, items, itemRenderer, buttonText, beforeIndexChange, setIndexInParent, pager, ...props }: Props): React.JSX.Element | null;
 export {};

--- a/packages/ui/types/src/checkbox/index.d.ts
+++ b/packages/ui/types/src/checkbox/index.d.ts
@@ -1,15 +1,9 @@
 import React from 'react';
-
 import '../index.css';
 import './index.css';
-
 type Props = {
-  checked?: boolean;
-  iconVariant?: 'small';
+    checked?: boolean;
+    iconVariant?: 'small';
 } & React.HTMLAttributes<HTMLDivElement>;
-export declare function Checkbox({
-  checked,
-  iconVariant,
-  ...props
-}: Props): React.JSX.Element;
+export declare function Checkbox({ checked, iconVariant, ...props }: Props): React.JSX.Element;
 export {};

--- a/packages/ui/types/src/dialog/index.d.ts
+++ b/packages/ui/types/src/dialog/index.d.ts
@@ -1,17 +1,7 @@
 import * as RadixDialog from '@radix-ui/react-dialog';
 import React, { PropsWithChildren } from 'react';
-
 import '../index.css';
 import './index.css';
-
-export declare const Dialog: ({
-  children,
-  open,
-  onOpenChange,
-  className,
-  ...props
-}: PropsWithChildren<
-  RadixDialog.DialogProps & {
+export declare const Dialog: ({ children, open, onOpenChange, className, ...props }: PropsWithChildren<RadixDialog.DialogProps & {
     className?: string;
-  }
->) => React.JSX.Element;
+}>) => React.JSX.Element;

--- a/packages/ui/types/src/dropdown/index.d.ts
+++ b/packages/ui/types/src/dropdown/index.d.ts
@@ -2,17 +2,12 @@ import '@utrecht/component-library-css';
 import '@utrecht/design-tokens/dist/root.css';
 import React from 'react';
 import { PropsWithChildren } from 'react';
-
 import './index.css';
-
 type Props = {
-  items: Array<{
-    label: string;
-    onClick: () => void;
-  }>;
+    items: Array<{
+        label: string;
+        onClick: () => void;
+    }>;
 };
-export declare const DropDownMenu: ({
-  children,
-  items,
-}: PropsWithChildren & Props) => React.JSX.Element;
+export declare const DropDownMenu: ({ children, items, }: PropsWithChildren & Props) => React.JSX.Element;
 export {};

--- a/packages/ui/types/src/form-elements/a-b-slider/index.d.ts
+++ b/packages/ui/types/src/form-elements/a-b-slider/index.d.ts
@@ -1,64 +1,59 @@
 import { FormValue } from '@openstad-headless/form/src/form';
 import { FC } from 'react';
-
 import './a-b-slider.css';
-
 export type RangeSliderProps = {
-  title: string;
-  overrideDefaultValue?: FormValue | valueObject;
-  description?: string;
-  labelA: string;
-  labelB: string;
-  titleA: string;
-  titleB: string;
-  imageA: string;
-  imageB: string;
-  descriptionA?: string;
-  descriptionB?: string;
-  fieldRequired?: boolean;
-  fieldKey: string;
-  showLabels?: boolean;
-  minCharacters?: number;
-  maxCharacters?: number;
-  disabled?: boolean;
-  type?: string;
-  onChange?: (
-    e: {
-      name: string;
-      value: FormValue | valueObject;
-    },
-    triggerSetLastKey?: boolean
-  ) => void;
-  showMoreInfo?: boolean;
-  moreInfoButton?: string;
-  moreInfoContent?: string;
-  infoImage?: string;
-  randomId?: string;
-  fieldInvalid?: boolean;
-  skipQuestion?: boolean;
-  skipQuestionAllowExplanation?: boolean;
-  skipQuestionExplanation?: string;
-  skipQuestionLabel?: string;
-  defaultValue?: string;
-  prevPageText?: string;
-  nextPageText?: string;
-  fieldOptions?: {
-    value: string;
-    label: string;
-  }[];
-  images?: Array<{
-    url: string;
-    name?: string;
-    imageAlt?: string;
-    imageDescription?: string;
-  }>;
-  createImageSlider?: boolean;
-  imageClickable?: boolean;
+    title: string;
+    overrideDefaultValue?: FormValue | valueObject;
+    description?: string;
+    labelA: string;
+    labelB: string;
+    titleA: string;
+    titleB: string;
+    imageA: string;
+    imageB: string;
+    descriptionA?: string;
+    descriptionB?: string;
+    fieldRequired?: boolean;
+    fieldKey: string;
+    showLabels?: boolean;
+    minCharacters?: number;
+    maxCharacters?: number;
+    disabled?: boolean;
+    type?: string;
+    onChange?: (e: {
+        name: string;
+        value: FormValue | valueObject;
+    }, triggerSetLastKey?: boolean) => void;
+    showMoreInfo?: boolean;
+    moreInfoButton?: string;
+    moreInfoContent?: string;
+    infoImage?: string;
+    randomId?: string;
+    fieldInvalid?: boolean;
+    skipQuestion?: boolean;
+    skipQuestionAllowExplanation?: boolean;
+    skipQuestionExplanation?: string;
+    skipQuestionLabel?: string;
+    defaultValue?: string;
+    prevPageText?: string;
+    nextPageText?: string;
+    fieldOptions?: {
+        value: string;
+        label: string;
+    }[];
+    images?: Array<{
+        url: string;
+        name?: string;
+        imageAlt?: string;
+        imageDescription?: string;
+    }>;
+    createImageSlider?: boolean;
+    imageClickable?: boolean;
 };
 type valueObject = {
-  value: string;
-  skipQuestion: boolean;
-  skipQuestionExplanation: string | undefined;
+    value: string;
+    skipQuestion: boolean;
+    skipQuestionExplanation: string | undefined;
 };
 declare const RangeSlider: FC<RangeSliderProps>;
 export default RangeSlider;

--- a/packages/ui/types/src/form-elements/checkbox/index.d.ts
+++ b/packages/ui/types/src/form-elements/checkbox/index.d.ts
@@ -1,55 +1,51 @@
 import { FormValue } from '@openstad-headless/form/src/form';
 import { FC } from 'react';
-
 export type CheckboxFieldProps = {
-  title: string;
-  overrideDefaultValue?: FormValue;
-  description?: string;
-  choices?: {
-    value: string;
-    label: string;
-    isOtherOption?: boolean;
-    defaultValue?: boolean;
-  }[];
-  fieldRequired?: boolean;
-  requiredWarning?: string;
-  fieldKey: string;
-  disabled?: boolean;
-  type?: string;
-  onChange?: (
-    e: {
-      name: string;
-      value: FormValue;
-    },
-    triggerSetLastKey?: boolean
-  ) => void;
-  showMoreInfo?: boolean;
-  moreInfoButton?: string;
-  moreInfoContent?: string;
-  infoImage?: string;
-  maxChoices?: string;
-  maxChoicesMessage?: string;
-  randomId?: string;
-  fieldInvalid?: boolean;
-  defaultValue?: string | string[];
-  prevPageText?: string;
-  nextPageText?: string;
-  fieldOptions?: {
-    value: string;
-    label: string;
-  }[];
-  images?: Array<{
-    url: string;
-    name?: string;
-    imageAlt?: string;
-    imageDescription?: string;
-  }>;
-  createImageSlider?: boolean;
-  imageClickable?: boolean;
-  randomizeItems?: boolean;
-  value?: FormValue;
-  selectAll?: boolean;
-  selectAllLabel?: string;
+    title: string;
+    overrideDefaultValue?: FormValue;
+    description?: string;
+    choices?: {
+        value: string;
+        label: string;
+        isOtherOption?: boolean;
+        defaultValue?: boolean;
+    }[];
+    fieldRequired?: boolean;
+    requiredWarning?: string;
+    fieldKey: string;
+    disabled?: boolean;
+    type?: string;
+    onChange?: (e: {
+        name: string;
+        value: FormValue;
+    }, triggerSetLastKey?: boolean) => void;
+    showMoreInfo?: boolean;
+    moreInfoButton?: string;
+    moreInfoContent?: string;
+    infoImage?: string;
+    maxChoices?: string;
+    maxChoicesMessage?: string;
+    randomId?: string;
+    fieldInvalid?: boolean;
+    defaultValue?: string | string[];
+    prevPageText?: string;
+    nextPageText?: string;
+    fieldOptions?: {
+        value: string;
+        label: string;
+    }[];
+    images?: Array<{
+        url: string;
+        name?: string;
+        imageAlt?: string;
+        imageDescription?: string;
+    }>;
+    createImageSlider?: boolean;
+    imageClickable?: boolean;
+    randomizeItems?: boolean;
+    value?: FormValue;
+    selectAll?: boolean;
+    selectAllLabel?: string;
 };
 declare const CheckboxField: FC<CheckboxFieldProps>;
 export default CheckboxField;

--- a/packages/ui/types/src/form-elements/document-upload/index.d.ts
+++ b/packages/ui/types/src/form-elements/document-upload/index.d.ts
@@ -2,57 +2,50 @@ import { FormValue } from '@openstad-headless/form/src/form';
 import 'filepond-plugin-image-preview/dist/filepond-plugin-image-preview.css';
 import 'filepond/dist/filepond.min.css';
 import { FC } from 'react';
-
 import './document-upload.css';
-
 export type DocumentUploadProps = {
-  title: string;
-  overrideDefaultValue?:
-    | FormValue
-    | {
+    title: string;
+    overrideDefaultValue?: FormValue | {
         name: string;
         url: string;
-      }[];
-  description?: string;
-  fieldRequired?: boolean;
-  requiredWarning?: string;
-  fieldKey: string;
-  allowedTypes?: string[];
-  disabled?: boolean;
-  multiple?: boolean;
-  type?: string;
-  onChange?: (
-    e: {
-      name: string;
-      value: {
+    }[];
+    description?: string;
+    fieldRequired?: boolean;
+    requiredWarning?: string;
+    fieldKey: string;
+    allowedTypes?: string[];
+    disabled?: boolean;
+    multiple?: boolean;
+    type?: string;
+    onChange?: (e: {
         name: string;
+        value: {
+            name: string;
+            url: string;
+        }[];
+    }, triggerSetLastKey?: boolean) => void;
+    imageUrl?: string;
+    showMoreInfo?: boolean;
+    moreInfoButton?: string;
+    moreInfoContent?: string;
+    infoImage?: string;
+    randomId?: string;
+    fieldInvalid?: boolean;
+    defaultValue?: string;
+    prevPageText?: string;
+    nextPageText?: string;
+    fieldOptions?: {
+        value: string;
+        label: string;
+    }[];
+    images?: Array<{
         url: string;
-      }[];
-    },
-    triggerSetLastKey?: boolean
-  ) => void;
-  imageUrl?: string;
-  showMoreInfo?: boolean;
-  moreInfoButton?: string;
-  moreInfoContent?: string;
-  infoImage?: string;
-  randomId?: string;
-  fieldInvalid?: boolean;
-  defaultValue?: string;
-  prevPageText?: string;
-  nextPageText?: string;
-  fieldOptions?: {
-    value: string;
-    label: string;
-  }[];
-  images?: Array<{
-    url: string;
-    name?: string;
-    imageAlt?: string;
-    imageDescription?: string;
-  }>;
-  createImageSlider?: boolean;
-  imageClickable?: boolean;
+        name?: string;
+        imageAlt?: string;
+        imageDescription?: string;
+    }>;
+    createImageSlider?: boolean;
+    imageClickable?: boolean;
 };
 declare const DocumentUploadField: FC<DocumentUploadProps>;
 export default DocumentUploadField;

--- a/packages/ui/types/src/form-elements/hidden/index.d.ts
+++ b/packages/ui/types/src/form-elements/hidden/index.d.ts
@@ -1,32 +1,28 @@
 import { FormValue } from '@openstad-headless/form/src/form';
 import { FC } from 'react';
-
 export type HiddenInputProps = {
-  overrideDefaultValue?: FormValue;
-  fieldKey: string;
-  defaultValue: string;
-  type?: string;
-  onChange?: (
-    e: {
-      name: string;
-      value: FormValue;
-    },
-    triggerSetLastKey?: boolean
-  ) => void;
-  prevPageText?: string;
-  nextPageText?: string;
-  fieldOptions?: {
-    value: string;
-    label: string;
-  }[];
-  images?: Array<{
-    url: string;
-    name?: string;
-    imageAlt?: string;
-    imageDescription?: string;
-  }>;
-  createImageSlider?: boolean;
-  imageClickable?: boolean;
+    overrideDefaultValue?: FormValue;
+    fieldKey: string;
+    defaultValue: string;
+    type?: string;
+    onChange?: (e: {
+        name: string;
+        value: FormValue;
+    }, triggerSetLastKey?: boolean) => void;
+    prevPageText?: string;
+    nextPageText?: string;
+    fieldOptions?: {
+        value: string;
+        label: string;
+    }[];
+    images?: Array<{
+        url: string;
+        name?: string;
+        imageAlt?: string;
+        imageDescription?: string;
+    }>;
+    createImageSlider?: boolean;
+    imageClickable?: boolean;
 };
 declare const HiddenInput: FC<HiddenInputProps>;
 export default HiddenInput;

--- a/packages/ui/types/src/form-elements/image-choice/index.d.ts
+++ b/packages/ui/types/src/form-elements/image-choice/index.d.ts
@@ -1,57 +1,53 @@
 import { FormValue } from '@openstad-headless/form/src/form';
 import { FC } from 'react';
-
 export type ImageChoiceFieldProps = {
-  title: string;
-  overrideDefaultValue?: FormValue;
-  description?: string;
-  choices: ChoiceItem[];
-  fieldRequired?: boolean;
-  requiredWarning?: string;
-  fieldKey: string;
-  disabled?: boolean;
-  type?: string;
-  onChange?: (
-    e: {
-      name: string;
-      value: FormValue;
-    },
-    triggerSetLastKey?: boolean
-  ) => void;
-  showMoreInfo?: boolean;
-  moreInfoButton?: string;
-  moreInfoContent?: string;
-  infoImage?: string;
-  randomId?: string;
-  fieldInvalid?: boolean;
-  multiple?: boolean;
-  defaultValue?: string;
-  prevPageText?: string;
-  nextPageText?: string;
-  fieldOptions?: {
-    value: string;
-    label: string;
-  }[];
-  images?: Array<{
-    url: string;
-    name?: string;
-    imageAlt?: string;
-    imageDescription?: string;
-  }>;
-  createImageSlider?: boolean;
-  imageClickable?: boolean;
-  infoField?: string;
-  maxChoices?: string;
-  maxChoicesMessage?: string;
+    title: string;
+    overrideDefaultValue?: FormValue;
+    description?: string;
+    choices: ChoiceItem[];
+    fieldRequired?: boolean;
+    requiredWarning?: string;
+    fieldKey: string;
+    disabled?: boolean;
+    type?: string;
+    onChange?: (e: {
+        name: string;
+        value: FormValue;
+    }, triggerSetLastKey?: boolean) => void;
+    showMoreInfo?: boolean;
+    moreInfoButton?: string;
+    moreInfoContent?: string;
+    infoImage?: string;
+    randomId?: string;
+    fieldInvalid?: boolean;
+    multiple?: boolean;
+    defaultValue?: string;
+    prevPageText?: string;
+    nextPageText?: string;
+    fieldOptions?: {
+        value: string;
+        label: string;
+    }[];
+    images?: Array<{
+        url: string;
+        name?: string;
+        imageAlt?: string;
+        imageDescription?: string;
+    }>;
+    createImageSlider?: boolean;
+    imageClickable?: boolean;
+    infoField?: string;
+    maxChoices?: string;
+    maxChoicesMessage?: string;
 };
 export type ChoiceItem = {
-  label: string;
-  value: string;
-  imageSrc: string;
-  imageDescription: string;
-  imageAlt: string;
-  hideLabel?: boolean;
-  description?: string;
+    label: string;
+    value: string;
+    imageSrc: string;
+    imageDescription: string;
+    imageAlt: string;
+    hideLabel?: boolean;
+    description?: string;
 };
 declare const ImageChoiceField: FC<ImageChoiceFieldProps>;
 export default ImageChoiceField;

--- a/packages/ui/types/src/form-elements/image-upload/index.d.ts
+++ b/packages/ui/types/src/form-elements/image-upload/index.d.ts
@@ -2,52 +2,47 @@ import { FormValue } from '@openstad-headless/form/src/form';
 import 'filepond-plugin-image-preview/dist/filepond-plugin-image-preview.css';
 import 'filepond/dist/filepond.min.css';
 import { FC } from 'react';
-
 import './image-upload.css';
-
 export type ImageUploadProps = {
-  title: string;
-  overrideDefaultValue?: FormValue;
-  description?: string;
-  fieldRequired?: boolean;
-  requiredWarning?: string;
-  fieldKey: string;
-  allowedTypes?: string[];
-  disabled?: boolean;
-  multiple?: boolean;
-  type?: string;
-  onChange?: (
-    e: {
-      name: string;
-      value: {
+    title: string;
+    overrideDefaultValue?: FormValue;
+    description?: string;
+    fieldRequired?: boolean;
+    requiredWarning?: string;
+    fieldKey: string;
+    allowedTypes?: string[];
+    disabled?: boolean;
+    multiple?: boolean;
+    type?: string;
+    onChange?: (e: {
         name: string;
+        value: {
+            name: string;
+            url: string;
+        }[];
+    }, triggerSetLastKey?: boolean) => void;
+    imageUrl?: string;
+    showMoreInfo?: boolean;
+    moreInfoButton?: string;
+    moreInfoContent?: string;
+    infoImage?: string;
+    randomId?: string;
+    fieldInvalid?: boolean;
+    defaultValue?: string;
+    prevPageText?: string;
+    nextPageText?: string;
+    fieldOptions?: {
+        value: string;
+        label: string;
+    }[];
+    images?: Array<{
         url: string;
-      }[];
-    },
-    triggerSetLastKey?: boolean
-  ) => void;
-  imageUrl?: string;
-  showMoreInfo?: boolean;
-  moreInfoButton?: string;
-  moreInfoContent?: string;
-  infoImage?: string;
-  randomId?: string;
-  fieldInvalid?: boolean;
-  defaultValue?: string;
-  prevPageText?: string;
-  nextPageText?: string;
-  fieldOptions?: {
-    value: string;
-    label: string;
-  }[];
-  images?: Array<{
-    url: string;
-    name?: string;
-    imageAlt?: string;
-    imageDescription?: string;
-  }>;
-  createImageSlider?: boolean;
-  imageClickable?: boolean;
+        name?: string;
+        imageAlt?: string;
+        imageDescription?: string;
+    }>;
+    createImageSlider?: boolean;
+    imageClickable?: boolean;
 };
 declare const ImageUploadField: FC<ImageUploadProps>;
 export default ImageUploadField;

--- a/packages/ui/types/src/form-elements/info/index.d.ts
+++ b/packages/ui/types/src/form-elements/info/index.d.ts
@@ -1,38 +1,37 @@
 import { FormValue } from '@openstad-headless/form/src/form';
 import { FC } from 'react';
-
 export type InfoFieldProps = {
-  overrideDefaultValue?: FormValue;
-  title?: string;
-  description?: string;
-  fieldKey?: string;
-  type?: string;
-  image?: string;
-  imageAlt?: string;
-  imageDescription?: string;
-  infoBlockStyle?: string;
-  infoBlockShareButton?: boolean;
-  infoBlockExtraButton?: string;
-  infoBlockExtraButtonTitle?: string;
-  showMoreInfo?: boolean;
-  moreInfoButton?: string;
-  moreInfoContent?: string;
-  infoImage?: string;
-  defaultValue?: string;
-  prevPageText?: string;
-  nextPageText?: string;
-  fieldOptions?: {
-    value: string;
-    label: string;
-  }[];
-  images?: Array<{
-    url: string;
-    name?: string;
+    overrideDefaultValue?: FormValue;
+    title?: string;
+    description?: string;
+    fieldKey?: string;
+    type?: string;
+    image?: string;
     imageAlt?: string;
     imageDescription?: string;
-  }>;
-  createImageSlider?: boolean;
-  imageClickable?: boolean;
+    infoBlockStyle?: string;
+    infoBlockShareButton?: boolean;
+    infoBlockExtraButton?: string;
+    infoBlockExtraButtonTitle?: string;
+    showMoreInfo?: boolean;
+    moreInfoButton?: string;
+    moreInfoContent?: string;
+    infoImage?: string;
+    defaultValue?: string;
+    prevPageText?: string;
+    nextPageText?: string;
+    fieldOptions?: {
+        value: string;
+        label: string;
+    }[];
+    images?: Array<{
+        url: string;
+        name?: string;
+        imageAlt?: string;
+        imageDescription?: string;
+    }>;
+    createImageSlider?: boolean;
+    imageClickable?: boolean;
 };
 declare const InfoField: FC<InfoFieldProps>;
 export default InfoField;

--- a/packages/ui/types/src/form-elements/map/index.d.ts
+++ b/packages/ui/types/src/form-elements/map/index.d.ts
@@ -4,12 +4,8 @@ import { DataLayer } from '@openstad-headless/leaflet-map/src/types/resource-ove
 import { BaseProps } from '@openstad-headless/types/base-props.js';
 import { ProjectSettingProps } from '@openstad-headless/types/project-setting-props.js';
 import { FC } from 'react';
-
 import './map.css';
-
-export type MapProps = BaseProps &
-  AreaProps &
-  ProjectSettingProps & {
+export type MapProps = BaseProps & AreaProps & ProjectSettingProps & {
     overrideDefaultValue?: FormValue;
     title: string;
     description: string;
@@ -17,13 +13,10 @@ export type MapProps = BaseProps &
     fieldRequired: boolean;
     disabled?: boolean;
     type?: string;
-    onChange?: (
-      e: {
+    onChange?: (e: {
         name: string;
         value: FormValue;
-      },
-      triggerSetLastKey?: boolean
-    ) => void;
+    }, triggerSetLastKey?: boolean) => void;
     requiredWarning?: string;
     showMoreInfo?: boolean;
     moreInfoButton?: string;
@@ -33,25 +26,25 @@ export type MapProps = BaseProps &
     enableOnOffSwitching?: boolean;
     defaultValue?: FormValue;
     allowedPolygons?: Array<{
-      id: number;
-      name: string;
+        id: number;
+        name: string;
     }>;
     prevPageText?: string;
     nextPageText?: string;
     fieldOptions?: {
-      value: string;
-      label: string;
+        value: string;
+        label: string;
     }[];
     images?: Array<{
-      url: string;
-      name?: string;
-      imageAlt?: string;
-      imageDescription?: string;
+        url: string;
+        name?: string;
+        imageAlt?: string;
+        imageDescription?: string;
     }>;
     createImageSlider?: boolean;
     imageClickable?: boolean;
     enablePolygonTags?: boolean;
     showHiddenPolygonsForAdmin?: boolean;
-  };
+};
 declare const MapField: FC<MapProps>;
 export default MapField;

--- a/packages/ui/types/src/form-elements/matrix/index.d.ts
+++ b/packages/ui/types/src/form-elements/matrix/index.d.ts
@@ -1,49 +1,44 @@
 import { Matrix } from '@openstad-headless/enquete/src/types/enquete-props';
 import { FormValue } from '@openstad-headless/form/src/form';
 import { FC } from 'react';
-
 import './matrix.css';
-
 export type MatrixFieldProps = {
-  title: string;
-  overrideDefaultValue?: FormValue;
-  description?: string;
-  fieldRequired?: boolean;
-  requiredWarning?: string;
-  fieldKey: string;
-  disabled?: boolean;
-  type?: string;
-  onChange?: (
-    e: {
-      name: string;
-      value: string | Record<number, never> | [] | string[];
-    },
-    triggerSetLastKey?: boolean
-  ) => void;
-  showMoreInfo?: boolean;
-  moreInfoButton?: string;
-  moreInfoContent?: string;
-  infoImage?: string;
-  maxChoices?: string;
-  randomId?: string;
-  fieldInvalid?: boolean;
-  matrixMultiple?: boolean;
-  matrix?: Matrix;
-  defaultValue?: FormValue;
-  fieldOptions?: {
-    value: string;
-    label: string;
-  }[];
-  images?: Array<{
-    url: string;
-    name?: string;
-    imageAlt?: string;
-    imageDescription?: string;
-  }>;
-  createImageSlider?: boolean;
-  imageClickable?: boolean;
-  nextPageText?: string;
-  prevPageText?: string;
+    title: string;
+    overrideDefaultValue?: FormValue;
+    description?: string;
+    fieldRequired?: boolean;
+    requiredWarning?: string;
+    fieldKey: string;
+    disabled?: boolean;
+    type?: string;
+    onChange?: (e: {
+        name: string;
+        value: string | Record<number, never> | [] | string[];
+    }, triggerSetLastKey?: boolean) => void;
+    showMoreInfo?: boolean;
+    moreInfoButton?: string;
+    moreInfoContent?: string;
+    infoImage?: string;
+    maxChoices?: string;
+    randomId?: string;
+    fieldInvalid?: boolean;
+    matrixMultiple?: boolean;
+    matrix?: Matrix;
+    defaultValue?: FormValue;
+    fieldOptions?: {
+        value: string;
+        label: string;
+    }[];
+    images?: Array<{
+        url: string;
+        name?: string;
+        imageAlt?: string;
+        imageDescription?: string;
+    }>;
+    createImageSlider?: boolean;
+    imageClickable?: boolean;
+    nextPageText?: string;
+    prevPageText?: string;
 };
 declare const MatrixField: FC<MatrixFieldProps>;
 export default MatrixField;

--- a/packages/ui/types/src/form-elements/number/index.d.ts
+++ b/packages/ui/types/src/form-elements/number/index.d.ts
@@ -1,46 +1,41 @@
 import { FormValue } from '@openstad-headless/form/src/form';
 import { FC } from 'react';
-
 import './style.css';
-
 export type NumberInputProps = {
-  title: string;
-  overrideDefaultValue?: FormValue;
-  description?: string;
-  requiredWarning?: string;
-  fieldKey: string;
-  defaultValue?: string | number;
-  disabled?: boolean;
-  onChange?: (
-    e: {
-      name: string;
-      value: FormValue;
-    },
-    triggerSetLastKey?: boolean
-  ) => void;
-  reset?: (resetFn: () => void) => void;
-  format?: boolean;
-  prepend?: string;
-  append?: string;
-  type?: string;
-  placeholder?: string;
-  randomId?: string;
-  fieldInvalid?: boolean;
-  prevPageText?: string;
-  nextPageText?: string;
-  fieldOptions?: {
-    value: string;
-    label: string;
-  }[];
-  images?: Array<{
-    url: string;
-    name?: string;
-    imageAlt?: string;
-    imageDescription?: string;
-  }>;
-  createImageSlider?: boolean;
-  imageClickable?: boolean;
-  infoImage?: string;
+    title: string;
+    overrideDefaultValue?: FormValue;
+    description?: string;
+    requiredWarning?: string;
+    fieldKey: string;
+    defaultValue?: string | number;
+    disabled?: boolean;
+    onChange?: (e: {
+        name: string;
+        value: FormValue;
+    }, triggerSetLastKey?: boolean) => void;
+    reset?: (resetFn: () => void) => void;
+    format?: boolean;
+    prepend?: string;
+    append?: string;
+    type?: string;
+    placeholder?: string;
+    randomId?: string;
+    fieldInvalid?: boolean;
+    prevPageText?: string;
+    nextPageText?: string;
+    fieldOptions?: {
+        value: string;
+        label: string;
+    }[];
+    images?: Array<{
+        url: string;
+        name?: string;
+        imageAlt?: string;
+        imageDescription?: string;
+    }>;
+    createImageSlider?: boolean;
+    imageClickable?: boolean;
+    infoImage?: string;
 };
 declare const NumberInput: FC<NumberInputProps>;
 export default NumberInput;

--- a/packages/ui/types/src/form-elements/radio/index.d.ts
+++ b/packages/ui/types/src/form-elements/radio/index.d.ts
@@ -1,50 +1,46 @@
 import { FormValue } from '@openstad-headless/form/src/form';
 import { FC } from 'react';
-
 export type RadioboxFieldProps = {
-  title: string;
-  overrideDefaultValue?: FormValue;
-  description?: string;
-  choices?: {
-    value: string;
-    label: string;
-    isOtherOption?: boolean;
-    defaultValue?: boolean;
-  }[];
-  fieldRequired?: boolean;
-  requiredWarning?: string;
-  fieldKey: string;
-  disabled?: boolean;
-  type?: string;
-  onChange?: (
-    e: {
-      name: string;
-      value: FormValue;
-    },
-    triggerSetLastKey?: boolean
-  ) => void;
-  showMoreInfo?: boolean;
-  moreInfoButton?: string;
-  moreInfoContent?: string;
-  infoImage?: string;
-  randomId?: string;
-  fieldInvalid?: boolean;
-  defaultValue?: string;
-  prevPageText?: string;
-  nextPageText?: string;
-  fieldOptions?: {
-    value: string;
-    label: string;
-  }[];
-  images?: Array<{
-    url: string;
-    name?: string;
-    imageAlt?: string;
-    imageDescription?: string;
-  }>;
-  createImageSlider?: boolean;
-  imageClickable?: boolean;
-  randomizeItems?: boolean;
+    title: string;
+    overrideDefaultValue?: FormValue;
+    description?: string;
+    choices?: {
+        value: string;
+        label: string;
+        isOtherOption?: boolean;
+        defaultValue?: boolean;
+    }[];
+    fieldRequired?: boolean;
+    requiredWarning?: string;
+    fieldKey: string;
+    disabled?: boolean;
+    type?: string;
+    onChange?: (e: {
+        name: string;
+        value: FormValue;
+    }, triggerSetLastKey?: boolean) => void;
+    showMoreInfo?: boolean;
+    moreInfoButton?: string;
+    moreInfoContent?: string;
+    infoImage?: string;
+    randomId?: string;
+    fieldInvalid?: boolean;
+    defaultValue?: string;
+    prevPageText?: string;
+    nextPageText?: string;
+    fieldOptions?: {
+        value: string;
+        label: string;
+    }[];
+    images?: Array<{
+        url: string;
+        name?: string;
+        imageAlt?: string;
+        imageDescription?: string;
+    }>;
+    createImageSlider?: boolean;
+    imageClickable?: boolean;
+    randomizeItems?: boolean;
 };
 declare const RadioboxField: FC<RadioboxFieldProps>;
 export default RadioboxField;

--- a/packages/ui/types/src/form-elements/select/index.d.ts
+++ b/packages/ui/types/src/form-elements/select/index.d.ts
@@ -1,53 +1,45 @@
 import { FormValue } from '@openstad-headless/form/src/form';
 import { FC } from 'react';
-
 export type SelectFieldProps = {
-  overrideDefaultValue?: FormValue;
-  title?: string;
-  description?: string;
-  choices?:
-    | string[]
-    | [
-        {
-          value: string;
-          label: string;
-        },
-      ];
-  fieldRequired?: boolean;
-  requiredWarning?: string;
-  fieldKey: string;
-  defaultOption?: string;
-  disabled?: boolean;
-  onChange?: (
-    e: {
-      name: string;
-      value: FormValue;
-    },
-    triggerSetLastKey?: boolean
-  ) => void;
-  type?: string;
-  showMoreInfo?: boolean;
-  moreInfoButton?: string;
-  moreInfoContent?: string;
-  infoImage?: string;
-  randomId?: string;
-  fieldInvalid?: boolean;
-  multiple?: boolean;
-  defaultValue?: string | string[];
-  prevPageText?: string;
-  nextPageText?: string;
-  fieldOptions?: {
-    value: string;
-    label: string;
-  }[];
-  images?: Array<{
-    url: string;
-    name?: string;
-    imageAlt?: string;
-    imageDescription?: string;
-  }>;
-  createImageSlider?: boolean;
-  imageClickable?: boolean;
+    overrideDefaultValue?: FormValue;
+    title?: string;
+    description?: string;
+    choices?: string[] | [{
+        value: string;
+        label: string;
+    }];
+    fieldRequired?: boolean;
+    requiredWarning?: string;
+    fieldKey: string;
+    defaultOption?: string;
+    disabled?: boolean;
+    onChange?: (e: {
+        name: string;
+        value: FormValue;
+    }, triggerSetLastKey?: boolean) => void;
+    type?: string;
+    showMoreInfo?: boolean;
+    moreInfoButton?: string;
+    moreInfoContent?: string;
+    infoImage?: string;
+    randomId?: string;
+    fieldInvalid?: boolean;
+    multiple?: boolean;
+    defaultValue?: string | string[];
+    prevPageText?: string;
+    nextPageText?: string;
+    fieldOptions?: {
+        value: string;
+        label: string;
+    }[];
+    images?: Array<{
+        url: string;
+        name?: string;
+        imageAlt?: string;
+        imageDescription?: string;
+    }>;
+    createImageSlider?: boolean;
+    imageClickable?: boolean;
 };
 declare const SelectField: FC<SelectFieldProps>;
 export default SelectField;

--- a/packages/ui/types/src/form-elements/sort/index.d.ts
+++ b/packages/ui/types/src/form-elements/sort/index.d.ts
@@ -1,46 +1,41 @@
 import { FormValue } from '@openstad-headless/form/src/form';
 import { FC } from 'react';
-
 import './sort.css';
-
 type OptionTitle = {
-  key: string;
+    key: string;
 };
 type Option = {
-  titles?: OptionTitle[];
+    titles?: OptionTitle[];
 };
 export type SortFieldProps = {
-  options?: Option[];
-  title?: string;
-  description?: string;
-  onSort?: (sorted: Option[]) => void;
-  fieldKey: string;
-  type?: string;
-  defaultValue?: string;
-  fieldOptions?: {
-    value: string;
-    label: string;
-  }[];
-  images?: Array<{
-    url: string;
-    name?: string;
-    imageAlt?: string;
-    imageDescription?: string;
-  }>;
-  createImageSlider?: boolean;
-  imageClickable?: boolean;
-  onChange?: (
-    e: {
-      name: string;
-      value: any;
-    },
-    triggerSetLastKey?: boolean
-  ) => void;
-  prevPageText?: string;
-  nextPageText?: string;
-  overrideDefaultValue?: FormValue;
-  numberingStyle?: string;
-  infoImage?: string;
+    options?: Option[];
+    title?: string;
+    description?: string;
+    onSort?: (sorted: Option[]) => void;
+    fieldKey: string;
+    type?: string;
+    defaultValue?: string;
+    fieldOptions?: {
+        value: string;
+        label: string;
+    }[];
+    images?: Array<{
+        url: string;
+        name?: string;
+        imageAlt?: string;
+        imageDescription?: string;
+    }>;
+    createImageSlider?: boolean;
+    imageClickable?: boolean;
+    onChange?: (e: {
+        name: string;
+        value: any;
+    }, triggerSetLastKey?: boolean) => void;
+    prevPageText?: string;
+    nextPageText?: string;
+    overrideDefaultValue?: FormValue;
+    numberingStyle?: string;
+    infoImage?: string;
 };
 declare const SortField: FC<SortFieldProps>;
 export default SortField;

--- a/packages/ui/types/src/form-elements/text/index.d.ts
+++ b/packages/ui/types/src/form-elements/text/index.d.ts
@@ -1,75 +1,63 @@
 import { FormValue } from '@openstad-headless/form/src/form';
 import React, { FC } from 'react';
-
 import './style.css';
-
 declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      'trix-editor': React.DetailedHTMLProps<
-        React.HTMLAttributes<HTMLElement> & {
-          input?: string;
-        },
-        HTMLElement
-      >;
+    namespace JSX {
+        interface IntrinsicElements {
+            'trix-editor': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement> & {
+                input?: string;
+            }, HTMLElement>;
+        }
     }
-  }
 }
 export type TextInputProps = {
-  title: string;
-  overrideDefaultValue?: FormValue;
-  description?: string;
-  minCharacters?: number;
-  minCharactersWarning?: string;
-  maxCharacters?: number;
-  maxCharactersWarning?: string;
-  fieldRequired?: boolean;
-  requiredWarning?: string;
-  fieldKey: string;
-  variant?: 'text input' | 'textarea' | 'richtext';
-  placeholder?: string;
-  defaultValue?: string;
-  disabled?: boolean;
-  rows?: TextInputProps['variant'] extends 'textarea'
-    ? number
-    : undefined | number;
-  type?: string;
-  onChange?: (
-    e: {
-      name: string;
-      value: FormValue;
-    },
-    triggerSetLastKey?: boolean
-  ) => void;
-  reset?: (resetFn: () => void) => void;
-  showMoreInfo?: boolean;
-  moreInfoButton?: string;
-  moreInfoContent?: string;
-  infoImage?: string;
-  randomId?: string;
-  fieldInvalid?: boolean;
-  minCharactersError?: string;
-  maxCharactersError?: string;
-  nextPageText?: string;
-  prevPageText?: string;
-  fieldOptions?: {
-    value: string;
-    label: string;
-  }[];
-  images?: Array<{
-    url: string;
-    name?: string;
-    imageAlt?: string;
-    imageDescription?: string;
-  }>;
-  createImageSlider?: boolean;
-  imageClickable?: boolean;
+    title: string;
+    overrideDefaultValue?: FormValue;
+    description?: string;
+    minCharacters?: number;
+    minCharactersWarning?: string;
+    maxCharacters?: number;
+    maxCharactersWarning?: string;
+    fieldRequired?: boolean;
+    requiredWarning?: string;
+    fieldKey: string;
+    variant?: 'text input' | 'textarea' | 'richtext';
+    placeholder?: string;
+    defaultValue?: string;
+    disabled?: boolean;
+    rows?: TextInputProps['variant'] extends 'textarea' ? number : undefined | number;
+    type?: string;
+    onChange?: (e: {
+        name: string;
+        value: FormValue;
+    }, triggerSetLastKey?: boolean) => void;
+    reset?: (resetFn: () => void) => void;
+    showMoreInfo?: boolean;
+    moreInfoButton?: string;
+    moreInfoContent?: string;
+    infoImage?: string;
+    randomId?: string;
+    fieldInvalid?: boolean;
+    minCharactersError?: string;
+    maxCharactersError?: string;
+    nextPageText?: string;
+    prevPageText?: string;
+    fieldOptions?: {
+        value: string;
+        label: string;
+    }[];
+    images?: Array<{
+        url: string;
+        name?: string;
+        imageAlt?: string;
+        imageDescription?: string;
+    }>;
+    createImageSlider?: boolean;
+    imageClickable?: boolean;
 };
 declare const TrixEditor: React.FC<{
-  value: string;
-  onChange: (
-    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => void;
+    value: string;
+    onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
 }>;
 declare const TextInput: FC<TextInputProps>;
 export { TrixEditor };

--- a/packages/ui/types/src/form-elements/tickmark-slider/index.d.ts
+++ b/packages/ui/types/src/form-elements/tickmark-slider/index.d.ts
@@ -1,49 +1,44 @@
 import { FormValue } from '@openstad-headless/form/src/form';
 import { FC } from 'react';
-
 import './style.css';
-
 export type TickmarkSliderProps = {
-  overrideDefaultValue?: FormValue;
-  index: number;
-  title: string;
-  fieldOptions?: {
-    value: string;
-    label: string;
-  }[];
-  images?: Array<{
-    url: string;
-    name?: string;
+    overrideDefaultValue?: FormValue;
+    index: number;
+    title: string;
+    fieldOptions?: {
+        value: string;
+        label: string;
+    }[];
+    images?: Array<{
+        url: string;
+        name?: string;
+        imageAlt?: string;
+        imageDescription?: string;
+    }>;
+    createImageSlider?: boolean;
+    imageClickable?: boolean;
+    fieldRequired: boolean;
+    fieldKey: string;
+    imageSrc?: string;
     imageAlt?: string;
     imageDescription?: string;
-  }>;
-  createImageSlider?: boolean;
-  imageClickable?: boolean;
-  fieldRequired: boolean;
-  fieldKey: string;
-  imageSrc?: string;
-  imageAlt?: string;
-  imageDescription?: string;
-  description?: string;
-  disabled?: boolean;
-  onChange?: (
-    e: {
-      name: string;
-      value: FormValue;
-    },
-    triggerSetLastKey?: boolean
-  ) => void;
-  type?: string;
-  showSmileys?: boolean;
-  showMoreInfo?: boolean;
-  moreInfoButton?: string;
-  moreInfoContent?: string;
-  infoImage?: string;
-  randomId?: string;
-  fieldInvalid?: boolean;
-  defaultValue?: string;
-  prevPageText?: string;
-  nextPageText?: string;
+    description?: string;
+    disabled?: boolean;
+    onChange?: (e: {
+        name: string;
+        value: FormValue;
+    }, triggerSetLastKey?: boolean) => void;
+    type?: string;
+    showSmileys?: boolean;
+    showMoreInfo?: boolean;
+    moreInfoButton?: string;
+    moreInfoContent?: string;
+    infoImage?: string;
+    randomId?: string;
+    fieldInvalid?: boolean;
+    defaultValue?: string;
+    prevPageText?: string;
+    nextPageText?: string;
 };
 declare const TickmarkSlider: FC<TickmarkSliderProps>;
 export default TickmarkSlider;

--- a/packages/ui/types/src/icon/index.d.ts
+++ b/packages/ui/types/src/icon/index.d.ts
@@ -1,19 +1,10 @@
 import React from 'react';
-
 import './index.css';
-
-export declare function Icon({
-  text,
-  description,
-  icon,
-  variant,
-  iconOnly,
-  onClick,
-}: {
-  text?: string;
-  icon: string;
-  description?: string;
-  variant?: 'small' | 'regular' | 'big';
-  iconOnly?: boolean;
-  onClick?: () => void;
+export declare function Icon({ text, description, icon, variant, iconOnly, onClick, }: {
+    text?: string;
+    icon: string;
+    description?: string;
+    variant?: 'small' | 'regular' | 'big';
+    iconOnly?: boolean;
+    onClick?: () => void;
 }): React.JSX.Element;

--- a/packages/ui/types/src/iconbutton/index.d.ts
+++ b/packages/ui/types/src/iconbutton/index.d.ts
@@ -1,19 +1,15 @@
 import '@utrecht/component-library-css';
 import '@utrecht/design-tokens/dist/root.css';
 import React from 'react';
-
 import '../index.css';
 import './index.css';
-
 export type IconButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  icon?: string;
-  text?: string;
-  iconOnly?: boolean;
-};
-export declare const IconButton: React.ForwardRefExoticComponent<
-  React.ButtonHTMLAttributes<HTMLButtonElement> & {
     icon?: string;
     text?: string;
     iconOnly?: boolean;
-  } & React.RefAttributes<HTMLButtonElement>
->;
+};
+export declare const IconButton: React.ForwardRefExoticComponent<React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    icon?: string;
+    text?: string;
+    iconOnly?: boolean;
+} & React.RefAttributes<HTMLButtonElement>>;

--- a/packages/ui/types/src/image/index.d.ts
+++ b/packages/ui/types/src/image/index.d.ts
@@ -1,13 +1,7 @@
 import React, { ReactNode } from 'react';
-
 import '../index.css';
 import './index.css';
-
-export declare function Image({
-  imageFooter,
-  imageHeader,
-  ...props
-}: React.ImgHTMLAttributes<HTMLImageElement> & {
-  imageFooter?: ReactNode;
-  imageHeader?: ReactNode;
+export declare function Image({ imageFooter, imageHeader, ...props }: React.ImgHTMLAttributes<HTMLImageElement> & {
+    imageFooter?: ReactNode;
+    imageHeader?: ReactNode;
 }): React.JSX.Element;

--- a/packages/ui/types/src/imageselect/index.d.ts
+++ b/packages/ui/types/src/imageselect/index.d.ts
@@ -1,16 +1,11 @@
 import React from 'react';
-
 import '../index.css';
 import './index.css';
-
-export declare const ImageSelect: React.ForwardRefExoticComponent<
-  {
+export declare const ImageSelect: React.ForwardRefExoticComponent<{
     onValueChange?: (resource: any) => void;
     images: Array<string>;
     items: Array<{
-      key: string;
-      text: string;
+        key: string;
+        text: string;
     }>;
-  } & React.SelectHTMLAttributes<HTMLInputElement> &
-    React.RefAttributes<HTMLInputElement>
->;
+} & React.SelectHTMLAttributes<HTMLInputElement> & React.RefAttributes<HTMLInputElement>>;

--- a/packages/ui/types/src/input/index.d.ts
+++ b/packages/ui/types/src/input/index.d.ts
@@ -1,15 +1,11 @@
 import '@utrecht/component-library-css';
 import '@utrecht/design-tokens/dist/root.css';
 import React from 'react';
-
 import '../index.css';
 import './index.css';
-
-declare const Input: React.ForwardRefExoticComponent<
-  React.InputHTMLAttributes<HTMLInputElement> & {
+declare const Input: React.ForwardRefExoticComponent<React.InputHTMLAttributes<HTMLInputElement> & {
     errors?: string;
     info?: string;
     label?: string;
-  } & React.RefAttributes<HTMLInputElement>
->;
+} & React.RefAttributes<HTMLInputElement>>;
 export { Input };

--- a/packages/ui/types/src/list/index.d.ts
+++ b/packages/ui/types/src/list/index.d.ts
@@ -1,25 +1,14 @@
 import React from 'react';
-
 import '../index.css';
 import './index.css';
-
 type Props<T> = {
-  items: Array<T>;
-  renderHeader?: () => React.JSX.Element;
-  renderItem: (item: T, index: number) => React.JSX.Element;
-  columns?: number;
-  emptyListText?: string;
+    items: Array<T>;
+    renderHeader?: () => React.JSX.Element;
+    renderItem: (item: T, index: number) => React.JSX.Element;
+    columns?: number;
+    emptyListText?: string;
 } & React.HTMLAttributes<HTMLDivElement>;
-export declare const List: <
-  T extends {
+export declare const List: <T extends {
     [key: string]: any;
-  },
->({
-  items,
-  renderItem,
-  renderHeader,
-  columns,
-  emptyListText,
-  ...props
-}: Props<T>) => React.JSX.Element;
+}>({ items, renderItem, renderHeader, columns, emptyListText, ...props }: Props<T>) => React.JSX.Element;
 export {};

--- a/packages/ui/types/src/location/index.d.ts
+++ b/packages/ui/types/src/location/index.d.ts
@@ -1,22 +1,16 @@
 import React from 'react';
-
 import { PostcodeAutoFillLocation } from '../stem-begroot-and-resource-overview/filter';
 import './index.css';
-
 type Props = {
-  onValueChange: (location: PostcodeAutoFillLocation) => void;
-  locationDefault: PostcodeAutoFillLocation;
-  zipCodeAutofillApiUrl?: string;
-  zipCodeApiUrl?: string;
-  proximityOptions?: {
-    label: string;
-    value: string;
-  }[];
-  proximityDefault?: string;
+    onValueChange: (location: PostcodeAutoFillLocation) => void;
+    locationDefault: PostcodeAutoFillLocation;
+    zipCodeAutofillApiUrl?: string;
+    zipCodeApiUrl?: string;
+    proximityOptions?: {
+        label: string;
+        value: string;
+    }[];
+    proximityDefault?: string;
 };
-export default function PostcodeAutoFill({
-  onValueChange,
-  locationDefault,
-  ...props
-}: Props): React.JSX.Element;
+export default function PostcodeAutoFill({ onValueChange, locationDefault, ...props }: Props): React.JSX.Element;
 export {};

--- a/packages/ui/types/src/multiselect/index.d.ts
+++ b/packages/ui/types/src/multiselect/index.d.ts
@@ -1,25 +1,16 @@
 import '@utrecht/component-library-css';
 import '@utrecht/design-tokens/dist/root.css';
 import React from 'react';
-
 import './index.css';
-
-export declare function MultiSelect({
-  label,
-  onItemSelected,
-  defaultOpen,
-  options,
-  inlineOptions,
-  id,
-}: {
-  label?: string;
-  options: Array<{
-    value: string;
-    label: string;
-    checked?: boolean;
-  }>;
-  defaultOpen?: boolean;
-  id: string;
-  onItemSelected: (optionValue: string, optionLabel?: string) => void;
-  inlineOptions?: boolean;
+export declare function MultiSelect({ label, onItemSelected, defaultOpen, options, inlineOptions, id, }: {
+    label?: string;
+    options: Array<{
+        value: string;
+        label: string;
+        checked?: boolean;
+    }>;
+    defaultOpen?: boolean;
+    id: string;
+    onItemSelected: (optionValue: string, optionLabel?: string) => void;
+    inlineOptions?: boolean;
 }): React.JSX.Element;

--- a/packages/ui/types/src/paginator/index.d.ts
+++ b/packages/ui/types/src/paginator/index.d.ts
@@ -1,17 +1,10 @@
 import React from 'react';
-
 import '../index.css';
 import './index.css';
-
-declare const Paginator: ({
-  page,
-  totalPages,
-  visiblePages,
-  onPageChange,
-}: React.HTMLAttributes<HTMLDivElement> & {
-  page: number;
-  totalPages: number;
-  visiblePages?: number;
-  onPageChange: (page: number) => void;
+declare const Paginator: ({ page, totalPages, visiblePages, onPageChange, }: React.HTMLAttributes<HTMLDivElement> & {
+    page: number;
+    totalPages: number;
+    visiblePages?: number;
+    onPageChange: (page: number) => void;
 }) => React.JSX.Element;
 export { Paginator };

--- a/packages/ui/types/src/pill/index.d.ts
+++ b/packages/ui/types/src/pill/index.d.ts
@@ -1,13 +1,7 @@
 import React from 'react';
-
 import './index.css';
-
-export declare const Pill: ({
-  text,
-  rounded,
-  light,
-}: {
-  text: string;
-  rounded?: boolean;
-  light?: boolean;
+export declare const Pill: ({ text, rounded, light, }: {
+    text: string;
+    rounded?: boolean;
+    light?: boolean;
 }) => React.JSX.Element;

--- a/packages/ui/types/src/progressbar/index.d.ts
+++ b/packages/ui/types/src/progressbar/index.d.ts
@@ -1,11 +1,7 @@
 import React from 'react';
-
 import '../index.css';
 import './index.css';
-
-declare const ProgressBar: (
-  props: React.HTMLAttributes<HTMLDivElement> & {
+declare const ProgressBar: (props: React.HTMLAttributes<HTMLDivElement> & {
     progress: number;
-  }
-) => React.JSX.Element;
+}) => React.JSX.Element;
 export { ProgressBar };

--- a/packages/ui/types/src/rangeslider/index.d.ts
+++ b/packages/ui/types/src/rangeslider/index.d.ts
@@ -1,16 +1,11 @@
 import React from 'react';
-
 import './index.css';
-
-declare const RangeSlider: React.ForwardRefExoticComponent<
-  {
+declare const RangeSlider: React.ForwardRefExoticComponent<{
     onValueChange?: (value: string) => void;
     initialvalue: string;
     min: string;
     max: string;
     step: string;
     labels?: Array<string | React.JSX.Element>;
-  } & React.SelectHTMLAttributes<HTMLInputElement> &
-    React.RefAttributes<HTMLInputElement>
->;
+} & React.SelectHTMLAttributes<HTMLInputElement> & React.RefAttributes<HTMLInputElement>>;
 export { RangeSlider };

--- a/packages/ui/types/src/select/index.d.ts
+++ b/packages/ui/types/src/select/index.d.ts
@@ -1,18 +1,13 @@
 import '@utrecht/component-library-css';
 import '@utrecht/design-tokens/dist/root.css';
 import React from 'react';
-
 import './index.css';
-
-declare const Select: React.ForwardRefExoticComponent<
-  {
+declare const Select: React.ForwardRefExoticComponent<{
     onValueChange?: (resource: any, label?: string) => void;
     options?: Array<{
-      value: string;
-      label: string;
+        value: string;
+        label: string;
     }>;
     disableDefaultOption?: boolean;
-  } & React.SelectHTMLAttributes<HTMLSelectElement> &
-    React.RefAttributes<HTMLSelectElement>
->;
+} & React.SelectHTMLAttributes<HTMLSelectElement> & React.RefAttributes<HTMLSelectElement>>;
 export { Select };

--- a/packages/ui/types/src/separator/index.d.ts
+++ b/packages/ui/types/src/separator/index.d.ts
@@ -1,11 +1,4 @@
 import * as SeparatorPrimitive from '@radix-ui/react-separator';
 import * as React from 'react';
-
-declare const Separator: React.ForwardRefExoticComponent<
-  Omit<
-    SeparatorPrimitive.SeparatorProps & React.RefAttributes<HTMLDivElement>,
-    'ref'
-  > &
-    React.RefAttributes<HTMLDivElement>
->;
+declare const Separator: React.ForwardRefExoticComponent<Omit<SeparatorPrimitive.SeparatorProps & React.RefAttributes<HTMLDivElement>, "ref"> & React.RefAttributes<HTMLDivElement>>;
 export { Separator };

--- a/packages/ui/types/src/spacer/index.d.ts
+++ b/packages/ui/types/src/spacer/index.d.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-
 import './index.css';
-
-export declare function Spacer({ size }: { size?: number }): React.JSX.Element;
+export declare function Spacer({ size }: {
+    size?: number;
+}): React.JSX.Element;

--- a/packages/ui/types/src/stem-begroot-and-resource-overview/filter/index.d.ts
+++ b/packages/ui/types/src/stem-begroot-and-resource-overview/filter/index.d.ts
@@ -1,78 +1,59 @@
 import '@utrecht/component-library-css';
 import '@utrecht/design-tokens/dist/root.css';
 import React from 'react';
-
 import './index.css';
-
 type Filter = {
-  tags: Array<number>;
-  search: {
-    text: string;
-  };
-  sort: string;
-  page: number;
-  pageSize: number;
-  location: PostcodeAutoFillLocation;
+    tags: Array<number>;
+    search: {
+        text: string;
+    };
+    sort: string;
+    page: number;
+    pageSize: number;
+    location: PostcodeAutoFillLocation;
 };
-export type PostcodeAutoFillLocation =
-  | {
-      lat: string;
-      lng: string;
-      proximity?: number;
-    }
-  | undefined;
+export type PostcodeAutoFillLocation = {
+    lat: string;
+    lng: string;
+    proximity?: number;
+} | undefined;
 type Props = {
-  className?: string;
-  dataStore: any;
-  resources: any;
-  onUpdateFilter?: (filter: Filter) => void;
-  sorting: Array<{
-    value: string;
-    label: string;
-  }>;
-  displaySorting: boolean;
-  defaultSorting: string;
-  autoApply?: boolean;
-  displaySearch: boolean;
-  itemsPerPage?: number;
-  displayTagFilters: boolean;
-  tagGroups?: Array<{
-    type: string;
-    label?: string;
-    multiple: boolean;
-    projectId?: any;
-    inlineOptions?: boolean;
-  }>;
-  tagsLimitation?:
-    | Array<number>
-    | {
+    className?: string;
+    dataStore: any;
+    resources: any;
+    onUpdateFilter?: (filter: Filter) => void;
+    sorting: Array<{
+        value: string;
+        label: string;
+    }>;
+    displaySorting: boolean;
+    defaultSorting: string;
+    autoApply?: boolean;
+    displaySearch: boolean;
+    itemsPerPage?: number;
+    displayTagFilters: boolean;
+    tagGroups?: Array<{
+        type: string;
+        label?: string;
+        multiple: boolean;
+        projectId?: any;
+        inlineOptions?: boolean;
+    }>;
+    tagsLimitation?: Array<number> | {
         [key: string]: number[];
-      };
-  searchPlaceholder: string;
-  resetText: string;
-  applyText: string;
-  showActiveTags?: boolean;
-  preFilterTags?: Array<{
-    id: number;
-    type: string;
-    label: string;
-    name: string;
-  }>;
-  displayLocationFilter?: boolean;
-  displayCollapsibleFilter?: boolean;
+    };
+    searchPlaceholder: string;
+    resetText: string;
+    applyText: string;
+    showActiveTags?: boolean;
+    preFilterTags?: Array<{
+        id: number;
+        type: string;
+        label: string;
+        name: string;
+    }>;
+    displayLocationFilter?: boolean;
+    displayCollapsibleFilter?: boolean;
 };
-export declare function Filters({
-  dataStore,
-  resources,
-  sorting,
-  tagGroups,
-  tagsLimitation,
-  onUpdateFilter,
-  className,
-  showActiveTags,
-  preFilterTags,
-  displayCollapsibleFilter,
-  autoApply,
-  ...props
-}: Props): React.JSX.Element | null;
+export declare function Filters({ dataStore, resources, sorting, tagGroups, tagsLimitation, onUpdateFilter, className, showActiveTags, preFilterTags, displayCollapsibleFilter, autoApply, ...props }: Props): React.JSX.Element | null;
 export {};

--- a/packages/ui/types/src/stem-begroot-and-resource-overview/filter/multiselect-tag-filter.d.ts
+++ b/packages/ui/types/src/stem-begroot-and-resource-overview/filter/multiselect-tag-filter.d.ts
@@ -1,30 +1,15 @@
 import React from 'react';
-
 type Props = {
-  dataStore: any;
-  tagType: string;
-  placeholder?: string;
-  selected?: number[];
-  onUpdateFilter?: (
-    filter: any,
-    label?: string,
-    forceSelected?: boolean
-  ) => void;
-  onlyIncludeIds?: number[];
-  tagGroupProjectId?: any;
-  preFilterTags?: Array<number>;
-  parentStopUsingDefaultValue?: boolean;
-  inlineOptions?: boolean;
+    dataStore: any;
+    tagType: string;
+    placeholder?: string;
+    selected?: number[];
+    onUpdateFilter?: (filter: any, label?: string, forceSelected?: boolean) => void;
+    onlyIncludeIds?: number[];
+    tagGroupProjectId?: any;
+    preFilterTags?: Array<number>;
+    parentStopUsingDefaultValue?: boolean;
+    inlineOptions?: boolean;
 };
-declare const MultiSelectTagFilter: ({
-  dataStore,
-  tagType,
-  onUpdateFilter,
-  selected,
-  onlyIncludeIds,
-  preFilterTags,
-  parentStopUsingDefaultValue,
-  inlineOptions,
-  ...props
-}: Props) => false | React.JSX.Element;
+declare const MultiSelectTagFilter: ({ dataStore, tagType, onUpdateFilter, selected, onlyIncludeIds, preFilterTags, parentStopUsingDefaultValue, inlineOptions, ...props }: Props) => false | React.JSX.Element;
 export { MultiSelectTagFilter };

--- a/packages/ui/types/src/stem-begroot-and-resource-overview/filter/select-tag-filter.d.ts
+++ b/packages/ui/types/src/stem-begroot-and-resource-overview/filter/select-tag-filter.d.ts
@@ -1,22 +1,19 @@
 import React from 'react';
-
 type Props = {
-  dataStore: any;
-  tagType: string;
-  placeholder?: string;
-  onlyIncludeIds?: number[];
-  onUpdateFilter?: (filter: any, label?: string) => void;
-  title: string;
-  tagGroupProjectId?: any;
-  preFilterTags?: Array<number>;
-  parentStopUsingDefaultValue?: boolean;
-  inlineOptions?: boolean;
-  valueSelected?: string;
-  removeActiveTag?: (tagType: string, tagId: number) => void;
-  resetCounter: number;
-  setResetCounter: React.Dispatch<React.SetStateAction<number>>;
+    dataStore: any;
+    tagType: string;
+    placeholder?: string;
+    onlyIncludeIds?: number[];
+    onUpdateFilter?: (filter: any, label?: string) => void;
+    title: string;
+    tagGroupProjectId?: any;
+    preFilterTags?: Array<number>;
+    parentStopUsingDefaultValue?: boolean;
+    inlineOptions?: boolean;
+    valueSelected?: string;
+    removeActiveTag?: (tagType: string, tagId: number) => void;
+    resetCounter: number;
+    setResetCounter: React.Dispatch<React.SetStateAction<number>>;
 };
-declare const SelectTagFilter: React.ForwardRefExoticComponent<
-  Props & React.RefAttributes<HTMLSelectElement>
->;
+declare const SelectTagFilter: React.ForwardRefExoticComponent<Props & React.RefAttributes<HTMLSelectElement>>;
 export { SelectTagFilter };

--- a/packages/ui/types/src/stepper/index.d.ts
+++ b/packages/ui/types/src/stepper/index.d.ts
@@ -1,14 +1,12 @@
 import '@utrecht/component-library-css';
 import '@utrecht/design-tokens/dist/root.css';
 import React from 'react';
-
 import '../index.css';
 import './index.css';
-
 type Props = {
-  steps: Array<string>;
-  currentStep?: number;
-  isSimpleView?: boolean;
+    steps: Array<string>;
+    currentStep?: number;
+    isSimpleView?: boolean;
 } & React.HTMLAttributes<HTMLDivElement>;
 declare const Stepper: (props: Props) => React.JSX.Element;
 export { Stepper };


### PR DESCRIPTION
## Summary
- Commits Prettier-formatted `.d.ts` files in `packages/ui/types/` to prevent recurring unstaged changes after `npm install`
- No functional changes — purely whitespace/formatting normalization

## Context
TypeScript generates `.d.ts` files in multi-line format, but Prettier reformats them to single-line. This causes 42 files to show up as modified after every `npm install`. Committing the Prettier output eliminates this noise.