### PR TITLE
fix(prettier): ignore TypeScript definition files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,6 +14,7 @@ charts/
 operations/
 *.iife.js
 *.less
+*.d.ts
 
 apps/cms-server/data
 apps/cms-server/public/uploads


### PR DESCRIPTION
These files are constantly regenerated throughout different packages /apps, so reformatting them constantly is not necessary. They are also not meant for human readability per se, so the default TypeScript definition format is fine.