### PR TITLE
fix(comments): make resourceId required in admin config

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/comments/[id]/general.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/comments/[id]/general.tsx
@@ -32,7 +32,7 @@ import * as z from 'zod';
 import { ArgumentWidgetTabProps } from '.';
 
 const formSchema = z.object({
-  resourceId: z.string().optional(),
+  resourceId: z.string().min(1, 'Selecteer een inzending'),
   sentiment: z.string(),
   useSentiments: z.string().optional(),
   itemsPerPage: z.coerce.number(),
@@ -71,7 +71,7 @@ export default function ArgumentsGeneral({
   const form = useForm<finalSchemaInfer>({
     resolver: zodResolver<any>(finalSchema),
     defaultValues: {
-      resourceId: props.resourceId,
+      resourceId: props.resourceId ?? '',
       sentiment: props.sentiment || 'for',
       useSentiments: JSON.stringify(props.useSentiments || ['for', 'against']),
       itemsPerPage: props?.itemsPerPage || 9999,
@@ -114,7 +114,6 @@ export default function ArgumentsGeneral({
               keyForValue="id"
               label={(resource) => `${resource.id} ${resource.title}`}
               onFieldChanged={props.onFieldChanged}
-              noSelection="Niet koppelen (gebruik queryparam openstadResourceId)"
             />
           )}
 


### PR DESCRIPTION
Closes #1406

Make `resourceId` a required field in the comments widget admin configuration to prevent misconfiguration.