### PR TITLE
Enforce unique project URLs

### DIFF
--- a/apps/admin-server/src/hooks/use-project.tsx
+++ b/apps/admin-server/src/hooks/use-project.tsx
@@ -69,33 +69,29 @@ export function useProject(scopes?: Array<string>) {
   }
 
   async function updateProject(config: any, name?: any, url?: any) {
+    const body: { config: any; name?: string; url?: string } = { config };
     if (name) {
-      const res = await fetch(`/api/openstad/api/project/${projectNumber}`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ config, name, url }),
-      });
-      const data = await res.json();
-
-      projectSwr.mutate(data);
-
-      return await data;
-    } else {
-      const res = await fetch(`/api/openstad/api/project/${projectNumber}`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ config }),
-      });
-      const data = await res.json();
-
-      projectSwr.mutate(data);
-
-      return await data;
+      body.name = name;
+      body.url = url;
     }
+
+    const res = await fetch(`/api/openstad/api/project/${projectNumber}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await res.json();
+
+    if (!res.ok) {
+      return { error: data.message || 'Er is helaas iets mis gegaan.' };
+    }
+
+    projectSwr.mutate(data);
+
+    return data;
   }
 
   async function updateProjectEmails(emailConfig: any) {

--- a/apps/admin-server/src/pages/projects/[project]/settings/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/settings/index.tsx
@@ -138,13 +138,16 @@ export default function ProjectSettings() {
         values.name,
         values.url
       );
-      if (project) {
+      if (project?.error) {
+        toast.error(project.error);
+      } else if (project) {
         toast.success('Project aangepast!');
       } else {
         toast.error('Er is helaas iets mis gegaan.');
       }
     } catch (error) {
       console.error('could not update', error);
+      toast.error('Er is helaas iets mis gegaan.');
     }
   }
 

--- a/apps/api-server/migrations/106-add-unique-index-project-url.js
+++ b/apps/api-server/migrations/106-add-unique-index-project-url.js
@@ -1,0 +1,64 @@
+module.exports = {
+  async up({ context: queryInterface }) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      // Set empty strings to NULL for proper unique constraint behavior
+      await queryInterface.sequelize.query(
+        `UPDATE projects SET url = NULL WHERE url = '';`,
+        { transaction }
+      );
+
+      // Check for duplicates (case-insensitive, ignoring protocol, www, and trailing slashes)
+      const [duplicates] = await queryInterface.sequelize.query(
+        `
+        SELECT
+          LOWER(TRIM(TRAILING '/' FROM REPLACE(REPLACE(REPLACE(url, 'https://', ''), 'http://', ''), 'www.', ''))) as normalized_url,
+          GROUP_CONCAT(id ORDER BY id) as project_ids,
+          COUNT(*) as cnt
+        FROM projects
+        WHERE url IS NOT NULL
+        GROUP BY normalized_url
+        HAVING cnt > 1;
+        `,
+        { transaction }
+      );
+
+      if (duplicates.length > 0) {
+        const details = duplicates
+          .map(
+            (dup) =>
+              `  URL: ${dup.normalized_url} — Project IDs: ${dup.project_ids}`
+          )
+          .join('\n');
+        throw new Error(
+          'Cannot add unique index: duplicate project URLs exist.\n' +
+            'Resolve these duplicates manually, then re-run migrations:\n' +
+            details
+        );
+      }
+
+      // No duplicates found, safe to add unique index.
+      // MySQL allows multiple NULLs in a unique index.
+      // Note: this index enforces exact uniqueness on the raw `url` column.
+      // Normalized uniqueness (e.g. www.example.com == example.com) is enforced
+      // at the application level by the checkUniqueUrl middleware.
+      await queryInterface.addIndex('projects', ['url'], {
+        unique: true,
+        name: 'projects_url_unique',
+        transaction,
+      });
+    });
+  },
+
+  async down({ context: queryInterface }) {
+    // Note: does not restore NULLs back to empty strings — NULL is more correct
+    // for "no URL" and the application already handles both.
+    try {
+      await queryInterface.removeIndex('projects', 'projects_url_unique');
+    } catch (err) {
+      // Defensive: index may not exist if a previous partial run was cleaned up manually
+      console.warn(
+        'Index projects_url_unique does not exist, skipping removal.'
+      );
+    }
+  },
+};

--- a/apps/api-server/src/routes/api/project.js
+++ b/apps/api-server/src/routes/api/project.js
@@ -30,11 +30,13 @@ const rateLimiter = require('@openstad-headless/lib/rateLimiter');
 function checkUniqueUrl(req, res, next) {
   if (!req.body.url) return next();
 
-  const normalizedUrl = req.body.url
+  let normalizedUrl = req.body.url
     .trim()
     .toLowerCase()
-    .replace(/^www\./, '')
-    .replace(/\/+$/, '');
+    .replace(/^www\./, '');
+  while (normalizedUrl.endsWith('/')) {
+    normalizedUrl = normalizedUrl.slice(0, -1);
+  }
 
   if (!normalizedUrl) return next();
 

--- a/apps/api-server/src/routes/api/project.js
+++ b/apps/api-server/src/routes/api/project.js
@@ -23,6 +23,50 @@ let router = express.Router({ mergeParams: true });
 const { Op } = require('sequelize');
 const rateLimiter = require('@openstad-headless/lib/rateLimiter');
 
+// Middleware: reject duplicate project URLs (case-insensitive, ignoring www and trailing slashes).
+// `removeProtocolFromUrl` already strips the protocol from req.body.url before this runs.
+// The DB index (`projects_url_unique`) enforces exact uniqueness; this middleware enforces
+// normalized uniqueness (e.g. www.example.com/ == example.com).
+function checkUniqueUrl(req, res, next) {
+  if (!req.body.url) return next();
+
+  const normalizedUrl = req.body.url
+    .trim()
+    .toLowerCase()
+    .replace(/^www\./, '')
+    .replace(/\/+$/, '');
+
+  if (!normalizedUrl) return next();
+
+  const excludeId = req.params.projectId
+    ? parseInt(req.params.projectId)
+    : null;
+
+  const normalizedColumn = Sequelize.literal(
+    "LOWER(TRIM(TRAILING '/' FROM REPLACE(REPLACE(REPLACE(`url`, 'https://', ''), 'http://', ''), 'www.', '')))"
+  );
+
+  const whereClause = excludeId
+    ? {
+        [Op.and]: [
+          Sequelize.where(normalizedColumn, normalizedUrl),
+          { id: { [Op.ne]: excludeId } },
+        ],
+      }
+    : Sequelize.where(normalizedColumn, normalizedUrl);
+
+  db.Project.findOne({ where: whereClause })
+    .then((existing) => {
+      if (existing) {
+        return next(
+          createError(409, 'Deze URL is al in gebruik door een ander project.')
+        );
+      }
+      return next();
+    })
+    .catch(next);
+}
+
 async function getProject(req, res, next, include = []) {
   const projectId = req.params.projectId;
   let query = { where: { id: parseInt(projectId) }, include: include };
@@ -510,6 +554,7 @@ router
   // -----------
   .post(auth.can('Project', 'create'))
   .post(removeProtocolFromUrl)
+  .post(checkUniqueUrl)
   .post(rateLimiter(), async function (req, res, next) {
     req.widgets = req.body.widgets || [];
     req.tags = req.body.tags || [];
@@ -787,6 +832,7 @@ router
   // -----------
   .put(auth.useReqUser)
   .put(removeProtocolFromUrl)
+  .put(checkUniqueUrl)
   .put(rateLimiter(), async function (req, res, next) {
     // update certain parts of config to the oauth client
     const project = await db.Project.findOne({ where: { id: req.results.id } });


### PR DESCRIPTION
## Summary

Closes #1409

- Add `checkUniqueUrl` middleware that normalizes URLs (case-insensitive, strips `www.` and trailing slashes) and rejects duplicates on both project create and update
- Surface API error messages in the admin UI via toast notifications
- Add database migration with unique index on the `url` column (wrapped in a transaction, fails loudly on existing duplicates)

## Test plan

- [ ] Create a project with a URL, then try to create another project with the same URL — should show error toast
- [ ] Update an existing project's URL to one already used by another project — should show error toast
- [ ] Verify variations are caught: `www.example.com` vs `example.com`, `example.com/` vs `example.com`
- [ ] Run migration on a clean database — index should be created
- [ ] Run migration on a database with duplicate URLs — should fail with details of the duplicates