### PR TITLE
Fix agenda items button layout

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/agenda/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/agenda/[id]/items.tsx
@@ -441,7 +441,7 @@ export default function WidgetAgendaItems(
                 </div>
               </div>
             ) : (
-              <div className="p-6 bg-white rounded-md flex flex-col justify-between col-span-2">
+              <div className="p-6 bg-white rounded-md flex flex-col col-span-2">
                 <div>
                   <Heading size="xl">Agenda items</Heading>
                   <Separator className="my-4" />


### PR DESCRIPTION
## Summary
- Remove `justify-between` from the agenda items panel so the "Voeg item toe aan lijst" button appears directly below the form fields instead of being pushed to the bottom of the container

## Test plan
- [ ] Open admin → Widgets → Agenda → Items tab
- [ ] Verify the "Voeg item toe aan lijst" button sits directly under the "Pas website links" button
- [ ] Verify layout still looks correct with many items in the left panel

Closes #1411