### PR TITLE
feat: allow multiple image uploads on resource form

### DIFF
--- a/apps/admin-server/src/components/resource-form.tsx
+++ b/apps/admin-server/src/components/resource-form.tsx
@@ -461,6 +461,7 @@ export default function ResourceForm({ onFormSubmit }: Props) {
             project={project as string}
             fieldName="image"
             allowedTypes={['image/*']}
+            allowMultiple={true}
             onImageUploaded={(imageResult) => {
               let array = [...(form.getValues('images') || [])];
               array.push(imageResult);


### PR DESCRIPTION
## Summary

- Enable multi-image selection in the file picker by adding `allowMultiple={true}` to the `ImageUploader` component in the resource form

Closes #1415

## Test plan

- [ ] Open a resource in the admin panel (`/projects/:id/resources/:id`)
- [ ] Click the image upload button
- [ ] Verify the file picker allows selecting multiple images at once
- [ ] Verify all selected images appear in the image gallery below
- [ ] Verify reordering, deleting, and adding descriptions still work