### PR TITLE
fix(agenda): rename active toggle label to "Markeer item"

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/agenda/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/agenda/[id]/items.tsx
@@ -484,7 +484,7 @@ export default function WidgetAgendaItems(
                         name="active"
                         render={({ field }) => (
                           <FormItem>
-                            <FormLabel>Actief</FormLabel>
+                            <FormLabel>Markeer item</FormLabel>
                             <Switch.Root
                               className="block w-[50px] h-[25px] bg-stone-300 rounded-full relative focus:shadow-[0_0_0_2px] focus:shadow-black data-[state=checked]:bg-primary outline-none cursor-default"
                               onCheckedChange={(e: boolean) => {


### PR DESCRIPTION
## Summary
- Rename the agenda item toggle label from "Actief" to "Markeer item" in the admin widget configuration

Closes #1418