### PR TITLE
feat(admin): show total vote count on votes page

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/votes.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/votes.tsx
@@ -87,7 +87,7 @@ export default function ProjectResources() {
     fetchResults(page).then((results) => {
       if (results) {
         const data = results?.records || [];
-        const totalCount = results?.metadata?.totalCount || 50;
+        const totalCount = results?.metadata?.totalCount ?? 0;
 
         const pageCount = Math.ceil(totalCount / pageLimit);
         setTotalPages(pageCount);
@@ -142,6 +142,11 @@ export default function ProjectResources() {
           </div>
         }>
         <div className="container py-6">
+          <div className="mb-2">
+            <span className="text-sm text-muted-foreground">
+              {`${totalCount} ${totalCount === 1 ? 'stem' : 'stemmen'}`}
+            </span>
+          </div>
           <div className="float-right mb-4 flex gap-4">
             <p className="text-xs font-medium text-muted-foreground self-center">
               Filter op:


### PR DESCRIPTION
## Summary
- Display the total vote count (e.g. "3 stemmen" / "1 stem") above the filter controls on the admin votes page
- Fix `totalCount` fallback from `|| 50` to `?? 0` so projects with zero votes show the correct count instead of 50

Closes #1435

## Test plan
- [ ] Open a project with votes → verify count matches the number of rows
- [ ] Open a project with 0 votes → verify it shows "0 stemmen"
- [ ] Open a project with 1 vote → verify it shows "1 stem" (singular)