### PR TITLE
feat(xls-extractor): translate headers for every row before processing

### DIFF
--- a/apps/admin-server/src/components/importButton/xls-extractor.js
+++ b/apps/admin-server/src/components/importButton/xls-extractor.js
@@ -34,10 +34,10 @@ export async function getXlsData(file, inputConfig = {}) {
 export function processXlsData(data) {
   if (!data || !data.length) return data;
 
-  // translate headers of the first row only
-  data[0] = translateHeaders(data[0]);
-
-  return data.map((row) => processXlsRow(row));
+  // Translate every row before flattening dot notation keys into nested objects.
+  return data
+    .map((row) => translateHeaders(row))
+    .map((row) => processXlsRow(row));
 }
 
 export function processXlsRow(row) {


### PR DESCRIPTION
The issue we had was that location didn’t import properly for all resources. Only the first row in the Excel file got a correct location, while the rest were imported without location data.

This happened because the import logic only converted the location columns correctly for the first row. We changed it so that same conversion now runs for every row, which means location is now imported correctly for all resources, not just the first one.