### PR TITLE
feat(projects): selective export and full import with rollback

### DIFF
--- a/apps/admin-server/src/lib/import-export/transform-export-to-import.test.ts
+++ b/apps/admin-server/src/lib/import-export/transform-export-to-import.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ExportData,
+  transformExportToImport,
+} from './transform-export-to-import';
+
+describe('transformExportToImport', () => {
+  const baseExport: ExportData = {
+    id: 1,
+    name: 'Test Project',
+    title: 'Test Title',
+    config: { project: { projectHasEnded: false } },
+    emailConfig: { smtp: 'test' },
+    areaId: 1,
+    hostStatus: 'live',
+    widgets: [
+      { id: 10, projectId: 1, type: 'resourceoverview', config: {} },
+      { id: 11, projectId: 1, type: 'enquete', config: {} },
+    ],
+    tags: [
+      { id: 20, projectId: 1, name: 'Tag A', type: 'theme' },
+      { id: 21, projectId: 1, name: 'Tag B', type: 'area' },
+    ],
+    statuses: [
+      { id: 30, projectId: 1, name: 'Open' },
+      { id: 31, projectId: 1, name: 'Closed' },
+    ],
+    resources: [
+      { id: 40, projectId: 1, title: 'Resource 1', userId: 5 },
+      { id: 41, projectId: 1, title: 'Resource 2', userId: 6 },
+    ],
+  };
+
+  it('uses the new name instead of the exported name', () => {
+    const result = transformExportToImport(baseExport, 'New Project Name');
+    expect(result.name).toBe('New Project Name');
+  });
+
+  it('preserves title, emailConfig, areaId, hostStatus', () => {
+    const result = transformExportToImport(baseExport, 'Test');
+    expect(result.title).toBe('Test Title');
+    expect(result.emailConfig).toEqual({ smtp: 'test' });
+    expect(result.areaId).toBe(1);
+    expect(result.hostStatus).toBe('live');
+  });
+
+  it('strips id and projectId, sets originalId on all entities', () => {
+    const result = transformExportToImport(baseExport, 'Test');
+
+    for (const widget of result.widgets) {
+      expect(widget.id).toBeUndefined();
+      expect(widget.projectId).toBeUndefined();
+      expect(widget.originalId).toBeDefined();
+    }
+    expect(result.widgets[0].originalId).toBe(10);
+    expect(result.widgets[1].originalId).toBe(11);
+
+    for (const tag of result.tags) {
+      expect(tag.id).toBeUndefined();
+      expect(tag.projectId).toBeUndefined();
+      expect(tag.originalId).toBeDefined();
+    }
+    expect(result.tags[0].originalId).toBe(20);
+
+    for (const status of result.statuses) {
+      expect(status.id).toBeUndefined();
+      expect(status.projectId).toBeUndefined();
+      expect(status.originalId).toBeDefined();
+    }
+
+    for (const resource of result.resources) {
+      expect(resource.id).toBeUndefined();
+      expect(resource.projectId).toBeUndefined();
+      expect(resource.originalId).toBeDefined();
+    }
+  });
+
+  it('filters out items with deletedAt', () => {
+    const exportWithDeleted: ExportData = {
+      ...baseExport,
+      widgets: [
+        { id: 10, projectId: 1, type: 'active', config: {} },
+        {
+          id: 11,
+          projectId: 1,
+          type: 'deleted',
+          config: {},
+          deletedAt: '2024-01-01',
+        },
+      ],
+      tags: [
+        { id: 20, projectId: 1, name: 'Active Tag' },
+        { id: 21, projectId: 1, name: 'Deleted Tag', deletedAt: '2024-01-01' },
+      ],
+    };
+    const result = transformExportToImport(exportWithDeleted, 'Test');
+    expect(result.widgets).toHaveLength(1);
+    expect(result.widgets[0].type).toBe('active');
+    expect(result.tags).toHaveLength(1);
+    expect(result.tags[0].name).toBe('Active Tag');
+  });
+
+  it('removes uniqueId from config', () => {
+    const exportWithUniqueId: ExportData = {
+      ...baseExport,
+      config: { uniqueId: 'abc-123', project: {} },
+    };
+    const result = transformExportToImport(exportWithUniqueId, 'Test');
+    expect(result.config.uniqueId).toBeUndefined();
+    expect(result.config.project).toBeDefined();
+  });
+
+  it('relaxes resource validation when resources exist', () => {
+    const result = transformExportToImport(baseExport, 'Test');
+    expect(result.config.resources.canAddNewResources).toBe(true);
+    expect(result.config.resources.titleMaxLength).toBe(10000);
+    expect(result.config.resources.titleMinLength).toBe(1);
+    expect(result.config.resources.summaryMaxLength).toBe(10000);
+    expect(result.config.resources.summaryMinLength).toBe(1);
+    expect(result.config.resources.descriptionMaxLength).toBe(10000);
+    expect(result.config.resources.descriptionMinLength).toBe(1);
+  });
+
+  it('does not relax validation when there are no resources', () => {
+    const noResources: ExportData = {
+      ...baseExport,
+      resources: [],
+    };
+    const result = transformExportToImport(noResources, 'Test');
+    expect(result.config.resources?.canAddNewResources).toBeUndefined();
+  });
+
+  it('sets skipDefaultStatuses to true', () => {
+    const result = transformExportToImport(baseExport, 'Test');
+    expect(result.skipDefaultStatuses).toBe(true);
+  });
+
+  it('handles missing widgets array (old export format)', () => {
+    const oldExport: ExportData = {
+      ...baseExport,
+      widgets: undefined,
+    };
+    const result = transformExportToImport(oldExport, 'Test');
+    expect(result.widgets).toEqual([]);
+  });
+
+  it('handles completely empty export', () => {
+    const emptyExport: ExportData = {
+      name: 'Empty',
+    };
+    const result = transformExportToImport(emptyExport, 'New Empty');
+    expect(result.name).toBe('New Empty');
+    expect(result.widgets).toEqual([]);
+    expect(result.tags).toEqual([]);
+    expect(result.statuses).toEqual([]);
+    expect(result.resources).toEqual([]);
+    expect(result.skipDefaultStatuses).toBe(true);
+  });
+
+  it('stores original resourceSettings before relaxing validation', () => {
+    const exportWithResourceConfig: ExportData = {
+      ...baseExport,
+      config: {
+        resources: {
+          canAddNewResources: false,
+          titleMaxLength: 50,
+          titleMinLength: 10,
+        },
+      },
+    };
+    const result = transformExportToImport(exportWithResourceConfig, 'Test');
+    expect(result.resourceSettings).toEqual({
+      canAddNewResources: false,
+      titleMaxLength: 50,
+      titleMinLength: 10,
+    });
+  });
+
+  it('filters out null items from entities', () => {
+    const exportWithNulls: ExportData = {
+      ...baseExport,
+      tags: [null as any, { id: 20, projectId: 1, name: 'Valid Tag' }],
+    };
+    const result = transformExportToImport(exportWithNulls, 'Test');
+    expect(result.tags).toHaveLength(1);
+    expect(result.tags[0].name).toBe('Valid Tag');
+  });
+});

--- a/apps/admin-server/src/lib/import-export/transform-export-to-import.ts
+++ b/apps/admin-server/src/lib/import-export/transform-export-to-import.ts
@@ -1,0 +1,80 @@
+export interface ExportData {
+  id?: number;
+  name: string;
+  title?: string;
+  config?: any;
+  emailConfig?: any;
+  areaId?: number;
+  hostStatus?: any;
+  resources?: any[];
+  tags?: any[];
+  statuses?: any[];
+  widgets?: any[];
+}
+
+export interface ImportPayload {
+  name: string;
+  title?: string;
+  config: any;
+  emailConfig: any;
+  areaId?: number;
+  hostStatus?: any;
+  widgets: any[];
+  tags: any[];
+  statuses: any[];
+  resources: any[];
+  resourceSettings: any;
+  skipDefaultStatuses: boolean;
+}
+
+function transformEntities(items: any[] | undefined): any[] {
+  return (items || [])
+    .filter((item) => item && !item.deletedAt)
+    .map((item) => {
+      const transformed = { ...item };
+      transformed.originalId = transformed.id;
+      delete transformed.id;
+      delete transformed.projectId;
+      return transformed;
+    });
+}
+
+export function transformExportToImport(
+  exportData: ExportData,
+  newName: string
+): ImportPayload {
+  const config = { ...(exportData.config || {}) };
+
+  if (config.uniqueId) {
+    delete config.uniqueId;
+  }
+
+  const resources = transformEntities(exportData.resources);
+  const resourceSettings = JSON.parse(JSON.stringify(config?.resources || {}));
+
+  if (resources.length > 0) {
+    config.resources = config.resources || {};
+    config.resources.canAddNewResources = true;
+    config.resources.titleMaxLength = 10000;
+    config.resources.titleMinLength = 1;
+    config.resources.summaryMaxLength = 10000;
+    config.resources.summaryMinLength = 1;
+    config.resources.descriptionMaxLength = 10000;
+    config.resources.descriptionMinLength = 1;
+  }
+
+  return {
+    name: newName,
+    title: exportData.title,
+    config,
+    emailConfig: exportData.emailConfig,
+    areaId: exportData.areaId,
+    hostStatus: exportData.hostStatus,
+    widgets: transformEntities(exportData.widgets),
+    tags: transformEntities(exportData.tags),
+    statuses: transformEntities(exportData.statuses),
+    resources,
+    resourceSettings,
+    skipDefaultStatuses: true,
+  };
+}

--- a/apps/admin-server/src/pages/projects/[project]/export.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/export.tsx
@@ -1,19 +1,107 @@
+import { Checkbox } from '@/components/ui/checkbox';
 import { Separator } from '@/components/ui/separator';
 import { Heading } from '@/components/ui/typography';
 import useExport from '@/hooks/use-export';
 import { useRouter } from 'next/router';
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Button } from '../../../components/ui/button';
 import { PageLayout } from '../../../components/ui/page-layout';
+
+type ExportOption = {
+  key: string;
+  label: string;
+  filterFn: (data: any) => any;
+};
+
+const EXPORT_OPTIONS: ExportOption[] = [
+  {
+    key: 'resources',
+    label: 'Plannen',
+    filterFn: (data) => {
+      delete data.resources;
+      return data;
+    },
+  },
+  {
+    key: 'comments',
+    label: 'Comments per plan',
+    filterFn: (data) => {
+      if (data.resources) {
+        data.resources = data.resources.map((r: any) => {
+          const { commentsFor, commentsAgainst, commentsNoSentiment, ...rest } =
+            r;
+          return rest;
+        });
+      }
+      return data;
+    },
+  },
+  {
+    key: 'polls',
+    label: 'Polls per plan',
+    filterFn: (data) => {
+      if (data.resources) {
+        data.resources = data.resources.map((r: any) => {
+          const { poll, ...rest } = r;
+          return rest;
+        });
+      }
+      return data;
+    },
+  },
+  {
+    key: 'votes',
+    label: 'Stemmen per plan',
+    filterFn: (data) => {
+      if (data.resources) {
+        data.resources = data.resources.map((r: any) => {
+          const { votes, ...rest } = r;
+          return rest;
+        });
+      }
+      return data;
+    },
+  },
+  {
+    key: 'tags',
+    label: 'Tags',
+    filterFn: (data) => {
+      delete data.tags;
+      return data;
+    },
+  },
+  {
+    key: 'statuses',
+    label: 'Statussen',
+    filterFn: (data) => {
+      delete data.statuses;
+      return data;
+    },
+  },
+  {
+    key: 'widgets',
+    label: 'Widgets',
+    filterFn: (data) => {
+      delete data.widgets;
+      return data;
+    },
+  },
+];
 
 export default function ProjectExport() {
   const router = useRouter();
   const { project } = router.query;
 
-  // Function to export data as a file
-  const exportData = (data: BlobPart, fileName: string, type: string) => {
-    // Create a link and download the file
+  const [checkedOptions, setCheckedOptions] = useState<Record<string, boolean>>(
+    () =>
+      EXPORT_OPTIONS.reduce(
+        (acc, opt) => ({ ...acc, [opt.key]: true }),
+        {} as Record<string, boolean>
+      )
+  );
+
+  const exportDataAsFile = (data: BlobPart, fileName: string, type: string) => {
     const blob = new Blob([data], { type });
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -22,11 +110,24 @@ export default function ProjectExport() {
     a.click();
     window.URL.revokeObjectURL(url);
   };
+
   const { data, isLoading } = useExport(project as string);
 
   function transform() {
-    const jsonData = JSON.stringify(data);
-    exportData(jsonData, `${data.name}.json`, 'application/json');
+    let filtered = JSON.parse(JSON.stringify(data));
+
+    for (const option of EXPORT_OPTIONS) {
+      if (!checkedOptions[option.key]) {
+        filtered = option.filterFn(filtered);
+      }
+    }
+
+    const jsonData = JSON.stringify(filtered);
+    exportDataAsFile(jsonData, `${data.name}.json`, 'application/json');
+  }
+
+  function toggleOption(key: string) {
+    setCheckedOptions((prev) => ({ ...prev, [key]: !prev[key] }));
   }
 
   return (
@@ -48,22 +149,36 @@ export default function ProjectExport() {
             <Separator className="my-4" />
             <div className="grid grid-cols-2 gap-x-4 gap-y-8 w-fit">
               <div className="col-span-full">
-                <div>
-                  De volgende gegevens worden geëxporteerd.
-                  <ul className="list-disc">
-                    <li className="ml-4">Projectgegevens</li>
-                    <li className="ml-4">Plannen</li>
-                    <li className="ml-4">Comments per plan</li>
-                    <li className="ml-4">Polls per plan</li>
-                    <li className="ml-4">Stemmen per plan</li>
-                    <li className="ml-4">Tags</li>
-                    <li className="ml-4">Actions</li>
-                  </ul>
-                </div>
+                <p className="mb-4">
+                  Selecteer welke gegevens je wilt exporteren.
+                </p>
+                <ul className="space-y-3">
+                  <li className="flex items-center gap-2 text-muted-foreground">
+                    <Checkbox checked disabled id="export-projectgegevens" />
+                    <label htmlFor="export-projectgegevens">
+                      Projectgegevens
+                    </label>
+                  </li>
+                  {EXPORT_OPTIONS.map((option) => (
+                    <li key={option.key} className="flex items-center gap-2">
+                      <Checkbox
+                        id={`export-${option.key}`}
+                        checked={checkedOptions[option.key]}
+                        onCheckedChange={() => toggleOption(option.key)}
+                      />
+                      <label
+                        htmlFor={`export-${option.key}`}
+                        className="cursor-pointer">
+                        {option.label}
+                      </label>
+                    </li>
+                  ))}
+                </ul>
               </div>
               <Button
                 className="w-fit col-span-full mt-4"
                 type="submit"
+                disabled={isLoading || !data}
                 onClick={transform}>
                 Opslaan
               </Button>

--- a/apps/admin-server/src/pages/projects/create.tsx
+++ b/apps/admin-server/src/pages/projects/create.tsx
@@ -12,9 +12,14 @@ import { PageLayout } from '@/components/ui/page-layout';
 import { Separator } from '@/components/ui/separator';
 import { Heading } from '@/components/ui/typography';
 import { useProject } from '@/hooks/use-project';
+import {
+  ExportData,
+  transformExportToImport,
+} from '@/lib/import-export/transform-export-to-import';
 import { zodResolver } from '@hookform/resolvers/zod';
 import router from 'next/router';
 import * as React from 'react';
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import toast from 'react-hot-toast';
 import * as z from 'zod';
@@ -32,8 +37,19 @@ const importFormSchema = z.object({
 });
 
 export default function CreateProject() {
-  const { createProject, importProject } = useProject();
-  const [file, setFile] = React.useState('');
+  const { createProject } = useProject();
+  const [file, setFile] = useState('');
+  const [parsedData, setParsedData] = useState<ExportData | null>(null);
+  const [importingInProgress, setImportingInProgress] = useState(false);
+  const [errors, setErrors] = useState<Array<{ step: string; error: string }>>(
+    []
+  );
+  const [isErrorsVisible, setIsErrorsVisible] = useState(false);
+  const [duplicatedData, setDuplicatedData] = useState<any>(null);
+  const [
+    removePreviousDuplicatedDataInProgress,
+    setRemovePreviousDuplicatedDataInProgress,
+  ] = useState(false);
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver<any>(formSchema),
@@ -50,7 +66,16 @@ export default function CreateProject() {
     fileReader.readAsText(e.target.files[0], 'UTF-8');
     fileReader.onload = (e) => {
       if (typeof e?.target?.result === 'string') {
-        setFile(e.target?.result);
+        setFile(e.target.result);
+        try {
+          const data = JSON.parse(e.target.result);
+          setParsedData(data);
+          if (data.name) {
+            importForm.setValue('importedProjectName', data.name);
+          }
+        } catch {
+          setParsedData(null);
+        }
       }
     };
   }
@@ -73,22 +98,89 @@ export default function CreateProject() {
     }
   }
 
+  const removePreviousDuplicatedData = async () => {
+    setRemovePreviousDuplicatedDataInProgress(true);
+
+    try {
+      const response = await fetch(
+        '/api/openstad/api/project/delete-duplicated-data',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ ...duplicatedData }),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error('Failed to delete duplicated data');
+      }
+
+      toast.success(
+        'Geïmporteerd project en geïmporteerde data is verwijderd.'
+      );
+    } catch (error) {
+      toast.error(
+        'Verwijderen niet gelukt. Neem contact op met de beheerders.'
+      );
+    } finally {
+      setRemovePreviousDuplicatedDataInProgress(false);
+      setErrors([]);
+      setIsErrorsVisible(false);
+      setDuplicatedData(null);
+    }
+  };
+
   async function onImport(values: z.infer<typeof importFormSchema>) {
     try {
       const data = JSON.parse(file);
-      const project = await importProject(
-        values.importedProjectName,
-        data.title,
-        data.config,
-        data.emailConfig
-      );
-      if (project) {
-        toast.success('Project aangemaakt!');
-        router.push(`/projects/${project.id}/settings`);
-      } else {
-        toast.error('De file die geüpload is bevat onjuiste data.');
+      const payload = transformExportToImport(data, values.importedProjectName);
+
+      setImportingInProgress(true);
+      setDuplicatedData(null);
+      setErrors([]);
+
+      const response = await fetch('/api/openstad/api/project', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      setImportingInProgress(false);
+
+      if (!response.ok) {
+        const responseJSON = await response.json();
+        setErrors(
+          responseJSON.errors || [
+            {
+              error: 'Er is een fout opgetreden bij het importeren',
+              step: 'Importeer project',
+            },
+          ]
+        );
+        setDuplicatedData(responseJSON.duplicatedData || null);
+        toast.error(
+          'Er is een fout opgetreden bij het importeren van het project.'
+        );
+        return;
       }
+
+      const newId = await response.json();
+      toast.success(
+        'Het project is geïmporteerd. Je wordt nu doorgestuurd naar het project.',
+        { duration: 5000 }
+      );
+
+      setTimeout(() => {
+        if (newId) {
+          router.push(`/projects/${newId}/widgets`);
+        }
+      }, 4000);
     } catch (e) {
+      setImportingInProgress(false);
       toast.error('Alleen JSON files worden geaccepteerd!');
     }
   }
@@ -136,6 +228,28 @@ export default function CreateProject() {
             <form
               onSubmit={importForm.handleSubmit(onImport)}
               className="lg:w-2/3 grid grid-cols-1 gap-x-4 gap-y-8">
+              <p>
+                Upload een geëxporteerd JSON-bestand om een project te
+                importeren met alle bijbehorende data (widgets, plannen, tags,
+                statussen).
+              </p>
+              <Input type="file" accept=".json" onChange={handleChange} />
+              {parsedData && (
+                <div className="p-4 bg-gray-50 rounded-md">
+                  <p className="font-semibold mb-2">
+                    Inhoud van het exportbestand:
+                  </p>
+                  <ul className="list-disc ml-4 space-y-1">
+                    <li>
+                      Project: <strong>{parsedData.name}</strong>
+                    </li>
+                    <li>Plannen: {parsedData.resources?.length ?? 0}</li>
+                    <li>Tags: {parsedData.tags?.length ?? 0}</li>
+                    <li>Statussen: {parsedData.statuses?.length ?? 0}</li>
+                    <li>Widgets: {parsedData.widgets?.length ?? 0}</li>
+                  </ul>
+                </div>
+              )}
               <FormField
                 control={importForm.control}
                 name="importedProjectName"
@@ -149,11 +263,63 @@ export default function CreateProject() {
                   </FormItem>
                 )}
               />
-              <Input type="file" onChange={handleChange} />
-              <Button variant="default" type="submit" className="w-fit">
-                Importeren
+              <Button
+                variant="default"
+                type="submit"
+                className="w-fit"
+                disabled={importingInProgress || !file}>
+                {importingInProgress ? 'Bezig met importeren...' : 'Importeren'}
               </Button>
             </form>
+            {errors.length > 0 && (
+              <div className="mt-4">
+                <br />
+                <Separator className="my-4" />
+                <Heading size="lg">
+                  Er is een fout opgetreden bij het importeren van het project.
+                </Heading>
+                <div className="mt-4">
+                  <p>
+                    De data is al (deels) geïmporteerd. Als je de data wilt
+                    verwijderen, klik dan op de knop hieronder.
+                  </p>
+
+                  <div className="flex mt-4">
+                    {duplicatedData && (
+                      <Button
+                        variant={'default'}
+                        disabled={removePreviousDuplicatedDataInProgress}
+                        onClick={() => removePreviousDuplicatedData()}
+                        style={{ marginRight: '15px' }}>
+                        {removePreviousDuplicatedDataInProgress
+                          ? 'Bezig met verwijderen'
+                          : 'Verwijder geïmporteerd project'}
+                      </Button>
+                    )}
+                    <Button
+                      style={{ backgroundColor: 'red', color: 'white' }}
+                      onClick={() => setIsErrorsVisible(!isErrorsVisible)}>
+                      {isErrorsVisible ? 'Verberg fouten' : 'Toon fouten'}
+                    </Button>
+                  </div>
+                  {isErrorsVisible && (
+                    <div className="mt-2 text-red-600">
+                      <p style={{ color: 'black', marginBottom: '10px' }}>
+                        Er zijn fouten opgetreden. Als de fouten niet duidelijk
+                        zijn, neem dan contact op met de beheerders.
+                      </p>
+                      <ul>
+                        {errors.map((error, index) => (
+                          <li
+                            key={index}>{`${error.step} - ${error.error}`}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+            <br />
           </Form>
         </div>
       </PageLayout>

--- a/apps/api-server/src/models/Project.js
+++ b/apps/api-server/src/models/Project.js
@@ -300,6 +300,8 @@ module.exports = function (db, sequelize, DataTypes) {
       onDelete: 'CASCADE',
       hooks: true,
     });
+    this.hasMany(models.Tag, { onDelete: 'CASCADE', hooks: true });
+    this.hasMany(models.Widget, { onDelete: 'CASCADE', hooks: true });
     this.belongsTo(models.Area, { onDelete: 'CASCADE' });
   };
 

--- a/apps/api-server/src/routes/api/project.js
+++ b/apps/api-server/src/routes/api/project.js
@@ -1025,6 +1025,7 @@ router
       },
       { model: db.Tag },
       { model: db.Status },
+      { model: db.Widget },
     ]);
   })
 


### PR DESCRIPTION
## Summary
- Export page now has checkboxes so users can pick which data to include (resources, comments, polls, votes, tags, statuses, widgets)
- Import flow rewritten: parses uploaded JSON to show a preview, transforms export data for the API (strips IDs, relaxes validation), shows progress/errors, and supports rolling back partial imports
- Widget and Tag associations added to the Project model so they're included in the export query

Closes #1441

## Test plan
- [ ] Export a project with all options checked — verify JSON contains all data
- [ ] Export with some options unchecked — verify excluded data is absent from JSON
- [ ] Import the exported JSON into a new project — verify all data is recreated
- [ ] Trigger an import error (e.g. malformed file) — verify error display and rollback button work
- [ ] Run `npm run test:unit:admin` — verify transform unit tests pass