### PR TITLE
fix(image-server): allow extensionless files in S3 image serving path

### DIFF
--- a/apps/image-server/package.json
+++ b/apps/image-server/package.json
@@ -25,6 +25,7 @@
     "@openstad-headless/lib": "*",
     "dotenv": "^6.0.0",
     "express": "^4.17.1",
+    "file-type": "^21.3.0",
     "hat": "0.0.3",
     "image-steam": "https://github.com/asilvas/node-image-steam#336cf2fd39463a24965707e6d92c3dce01d3ba40",
     "image-steam-s3": "^1.1.0",

--- a/apps/image-server/server.js
+++ b/apps/image-server/server.js
@@ -25,6 +25,12 @@ async function detectImageMimeType(response, extension) {
   const reader = response.clone().body.getReader();
   const { value } = await reader.read();
   reader.cancel();
+
+  if (!value) {
+    const ct = response.headers.get('content-type');
+    return ct && ct.startsWith('image/') ? ct : 'application/octet-stream';
+  }
+
   // 4100 bytes is the minimum needed by file-type to detect all supported formats
   // See https://github.com/sindresorhus/file-type?tab=readme-ov-file#samplesize
   const buf = Buffer.from(
@@ -38,7 +44,8 @@ async function detectImageMimeType(response, extension) {
 
   if (detected && ALLOWED_EXTENSIONS.includes(detected.ext))
     return detected.mime;
-  return response.headers.get('content-type') || 'application/octet-stream';
+  const ct = response.headers.get('content-type');
+  return ct && ct.startsWith('image/') ? ct : 'application/octet-stream';
 }
 const { createFilename, sanitizeFileName, getFileUrl } = require('./utils');
 const fs = require('node:fs');

--- a/apps/image-server/server.js
+++ b/apps/image-server/server.js
@@ -9,6 +9,37 @@ const s3 = require('./s3');
 const rateLimiter = require('@openstad-headless/lib/rateLimiter');
 const mime = require('mime-types');
 
+const ALLOWED_EXTENSIONS = ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp', 'tiff'];
+
+/**
+ * Detect image MIME type from a fetch Response.
+ * Uses extension-based lookup first, falls back to magic-byte detection via file-type.
+ * Only returns image types that match the allowed extensions list.
+ */
+async function detectImageMimeType(response, extension) {
+  if (extension) {
+    const fromExt = mime.lookup(extension);
+    if (fromExt) return fromExt;
+  }
+
+  const reader = response.clone().body.getReader();
+  const { value } = await reader.read();
+  reader.cancel();
+  // 4100 bytes is the minimum needed by file-type to detect all supported formats
+  // See https://github.com/sindresorhus/file-type?tab=readme-ov-file#samplesize
+  const buf = Buffer.from(
+    value.buffer,
+    value.byteOffset,
+    Math.min(value.byteLength, 4100)
+  );
+  const mod = await import('file-type');
+  const detect = mod.fileTypeFromBuffer || mod.default?.fromBuffer;
+  const detected = detect ? await detect(buf) : null;
+
+  if (detected && ALLOWED_EXTENSIONS.includes(detected.ext))
+    return detected.mime;
+  return response.headers.get('content-type') || 'application/octet-stream';
+}
 const { createFilename, sanitizeFileName, getFileUrl } = require('./utils');
 const fs = require('node:fs');
 const path = require('path');
@@ -183,16 +214,6 @@ app.get('/image/*', rateLimiter(), async function (req, res, next) {
     req.url = req.url.replace(/^\/image\//, '');
 
     // SSRF mitigation: Validate and sanitize image path
-    // Only allow filenames with safe characters and common image extensions
-    const ALLOWED_EXTENSIONS = [
-      'jpg',
-      'jpeg',
-      'png',
-      'gif',
-      'bmp',
-      'webp',
-      'tiff',
-    ];
     const safeImageNamePattern = /^[a-zA-Z0-9_\-\.]+$/;
     const unsafePath = req.url;
 
@@ -209,8 +230,6 @@ app.get('/image/*', rateLimiter(), async function (req, res, next) {
     ) {
       return res.status(400).send('Invalid image filename or path');
     }
-
-    const mimeType = hasExtension ? mime.lookup(extension) : null;
 
     const endpoint = process.env.S3_ENDPOINT.replace(
       'https://',
@@ -245,10 +264,7 @@ app.get('/image/*', rateLimiter(), async function (req, res, next) {
           .send('File not found');
       }
 
-      const contentType =
-        mimeType ||
-        response.headers.get('content-type') ||
-        'application/octet-stream';
+      const contentType = await detectImageMimeType(response, extension);
       res.setHeader('Content-Type', contentType);
       const contentLength = response.headers.get('content-length');
       if (contentLength) res.setHeader('Content-Length', contentLength);

--- a/apps/image-server/server.js
+++ b/apps/image-server/server.js
@@ -198,16 +198,19 @@ app.get('/image/*', rateLimiter(), async function (req, res, next) {
 
     // Prevent directory traversal or illegal characters
     const baseName = path.basename(unsafePath); // strips directory components
-    const extension = baseName.split('.').pop().toLowerCase();
+    const hasExtension = baseName.includes('.');
+    const extension = hasExtension
+      ? baseName.split('.').pop().toLowerCase()
+      : null;
     if (
       baseName !== unsafePath || // directory component detected
       !safeImageNamePattern.test(baseName) || // unsafe chars present
-      !ALLOWED_EXTENSIONS.includes(extension) // extension not allowed
+      (hasExtension && !ALLOWED_EXTENSIONS.includes(extension)) // extension present but not allowed
     ) {
       return res.status(400).send('Invalid image filename or path');
     }
 
-    const mimeType = mime.lookup(extension);
+    const mimeType = hasExtension ? mime.lookup(extension) : null;
 
     const endpoint = process.env.S3_ENDPOINT.replace(
       'https://',
@@ -242,7 +245,11 @@ app.get('/image/*', rateLimiter(), async function (req, res, next) {
           .send('File not found');
       }
 
-      res.setHeader('Content-Type', mimeType);
+      const contentType =
+        mimeType ||
+        response.headers.get('content-type') ||
+        'application/octet-stream';
+      res.setHeader('Content-Type', contentType);
       const contentLength = response.headers.get('content-length');
       if (contentLength) res.setHeader('Content-Length', contentLength);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -637,6 +637,7 @@
         "@openstad-headless/lib": "*",
         "dotenv": "^6.0.0",
         "express": "^4.17.1",
+        "file-type": "^21.3.0",
         "hat": "0.0.3",
         "image-steam": "https://github.com/asilvas/node-image-steam#336cf2fd39463a24965707e6d92c3dce01d3ba40",
         "image-steam-s3": "^1.1.0",
@@ -654,6 +655,24 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "apps/image-server/node_modules/file-type": {
+      "version": "21.3.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.0.tgz",
+      "integrity": "sha512-8kPJMIGz1Yt/aPEwOsrR97ZyZaD1Iqm8PClb1nYFclUCkBi0Ma5IsYNQzvSFS9ib51lWyIw5mIT9rWzI/xjpzA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/@aikidosec/safe-chain": {
@@ -2822,6 +2841,16 @@
       "version": "0.2.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.1.tgz",
+      "integrity": "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
     },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.20.0",
@@ -11044,6 +11073,29 @@
         "@tiptap/pm": "^2.7.0",
         "vue": "^3.0.0"
       }
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
@@ -30051,6 +30103,22 @@
       ],
       "license": "MIT"
     },
+    "node_modules/strtok3": {
+      "version": "10.3.4",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
+      "integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/stubs": {
       "version": "3.0.0",
       "license": "MIT",
@@ -31041,6 +31109,24 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/toposort-class": {
       "version": "1.0.1",
       "license": "MIT"
@@ -31773,6 +31859,18 @@
     "node_modules/uid2": {
       "version": "0.0.4",
       "license": "MIT"
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/umzug": {
       "version": "3.8.2",


### PR DESCRIPTION
The SSRF validation in the S3 code path rejected extensionless filenames (md5 hashes) because `.split('.').pop()` returned the full filename which never matched ALLOWED_EXTENSIONS. The local filesystem path did not have this check, so images worked before migrating to S3.

- Only enforce extension allowlist when file actually has an extension
- Fall back to S3 response Content-Type header for extensionless files