### PR TITLE
fix: await updateConfig before reloading in choiceguide items save

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/items.tsx
@@ -683,7 +683,7 @@ export default function WidgetChoiceGuideItems(
     setDimensions(finalDimensions);
   }, [form.watch('type')]);
 
-  function handleSaveItems() {
+  async function handleSaveItems() {
     const updatedProps = { ...props };
 
     Object.keys(updatedProps).forEach((key: string) => {
@@ -693,7 +693,7 @@ export default function WidgetChoiceGuideItems(
       }
     });
 
-    props.updateConfig({ ...updatedProps, items });
+    await props.updateConfig({ ...updatedProps, items });
     setMatrixOptions(matrixDefault);
     window.location.reload();
   }


### PR DESCRIPTION
`handleSaveItems` fired a page reload before `updateConfig` finished, occasionally aborting the save. Adding await fixes the race. The bug was timing-dependent so it didn't happen often.