### PR TITLE
style: move Statistieken below Authenticatie in project sidenav

### DIFF
--- a/apps/admin-server/src/components/ui/sidenav-project.tsx
+++ b/apps/admin-server/src/components/ui/sidenav-project.tsx
@@ -38,14 +38,6 @@ export function SidenavProject({ className }: { className?: string }) {
         </Link>
       </div>
       <div className="p-4 flex flex-col gap-2">
-        <Link href={`/projects/${project}/statistics`}>
-          <Button
-            variant={location.includes('/statistics') ? 'secondary' : 'ghost'}
-            size="default"
-            className="w-full flex justify-start">
-            <span className="truncate">Statistieken</span>
-          </Button>
-        </Link>
         <Link href={`/projects/${project}/widgets`}>
           <Button
             variant={location.endsWith('/widgets') ? 'secondary' : 'ghost'}
@@ -276,6 +268,14 @@ export function SidenavProject({ className }: { className?: string }) {
             </Link>
           </>
         ) : null}
+        <Link href={`/projects/${project}/statistics`}>
+          <Button
+            variant={location.includes('/statistics') ? 'secondary' : 'ghost'}
+            size="default"
+            className="w-full flex justify-start">
+            <span className="truncate">Statistieken</span>
+          </Button>
+        </Link>
         <Link href={`/projects/${project}/resources`}>
           <Button
             variant={location.includes('/resources') ? 'secondary' : 'ghost'}


### PR DESCRIPTION
'Statistieken' was at the top of the project navigation, which didn't match the logical flow. It now sits between 'Authenticatie' and 'Inzendingen'.