### PR TITLE
fix: fetch only needed areas instead of all areas globally

### DIFF
--- a/apps/api-server/src/routes/api/area.js
+++ b/apps/api-server/src/routes/api/area.js
@@ -9,6 +9,7 @@ const express = require('express');
 const router = express.Router({ mergeParams: true });
 var createError = require('http-errors');
 const rateLimiter = require('@openstad-headless/lib/rateLimiter');
+const { Op } = require('sequelize');
 
 // scopes: for all get requests
 router.all('*', function (req, res, next) {
@@ -23,6 +24,27 @@ router
   .get(pagination.init)
   .get(function (req, res, next) {
     let { dbQuery } = req;
+
+    // Support ?ids=1,2,3 to fetch specific areas
+    if (req.query.ids) {
+      const ids = [
+        ...new Set(
+          req.query.ids
+            .split(',')
+            .map(Number)
+            .filter((id) => !isNaN(id) && id > 0)
+        ),
+      ].slice(0, 100);
+
+      if (ids.length > 0) {
+        dbQuery.where = dbQuery.where || {};
+        dbQuery.where.id = { [Op.in]: ids };
+      } else {
+        req.results = [];
+        req.dbQuery.count = 0;
+        return next();
+      }
+    }
 
     return db.Area.scope('includeTags')
       .findAndCountAll(dbQuery)

--- a/packages/data-store/src/api/area.js
+++ b/packages/data-store/src/api/area.js
@@ -1,6 +1,6 @@
 export default {
-  fetch: async function ({ projectId }) {
-    let url = `/api/project/${projectId}/area`;
+  fetch: async function ({ areaId }) {
+    let url = `/api/area/${areaId}`;
     return this.fetch(url);
   },
 };

--- a/packages/data-store/src/api/areas.js
+++ b/packages/data-store/src/api/areas.js
@@ -1,6 +1,9 @@
 export default {
-  fetch: async function () {
+  fetch: async function ({ ids } = {}) {
     let url = `/api/area`;
+    if (ids && ids.length > 0) {
+      url += `?ids=${ids.join(',')}`;
+    }
     return this.fetch(url);
   },
 };

--- a/packages/data-store/src/hooks/use-area.js
+++ b/packages/data-store/src/hooks/use-area.js
@@ -1,9 +1,12 @@
-export default function useArea({ projectId, areaId }) {
+export default function useArea({ areaId }) {
   let self = this;
 
-  const { data, error, isLoading } = self.useSWR({ projectId }, 'area.fetch');
+  const { data, error, isLoading } = self.useSWR(
+    areaId ? { areaId } : null,
+    'area.fetch'
+  );
 
-  let area = data || [];
+  let area = data || null;
 
   if (error) {
     const event = new window.CustomEvent('osc-error', {

--- a/packages/data-store/src/hooks/use-areas.js
+++ b/packages/data-store/src/hooks/use-areas.js
@@ -1,7 +1,10 @@
-export default function useAreas() {
+export default function useAreas({ ids } = {}) {
   let self = this;
 
-  const { data, error, isLoading } = self.useSWR({}, 'areas.fetch');
+  const { data, error, isLoading } = self.useSWR(
+    ids && ids.length > 0 ? { ids } : null,
+    'areas.fetch'
+  );
 
   let areas = data || [];
   if (error) {

--- a/packages/data-store/src/index.js
+++ b/packages/data-store/src/index.js
@@ -84,6 +84,11 @@ function DataStore(props = {}) {
       fetcher = self.api[fetcherAsString];
     }
 
+    // Allow hooks to pass null to skip the fetch entirely
+    if (props === null) {
+      return useSWR(null, null);
+    }
+
     let key = self.createKey(props, fetcherAsString);
 
     windowGlobal.OpenStadSWR[JSON.stringify(key, null, 2)] = true;

--- a/packages/leaflet-map/src/area.tsx
+++ b/packages/leaflet-map/src/area.tsx
@@ -146,9 +146,10 @@ export function Area({
   ...props
 }: BaseProps & AreaProps) {
   const datastore = new DataStore({});
-  const { data: allAreas } = datastore.useArea({
-    projectId: props.projectId,
-  });
+  const areaIds = areas?.map((item: { id: number }) => item.id);
+  const { data: fetchedAreas } = datastore.useAreas(
+    areaIds && areaIds.length > 0 ? { ids: areaIds } : undefined
+  );
 
   interface Area {
     id: number;
@@ -190,13 +191,9 @@ export function Area({
   }, [area, areaRenderMode]);
 
   const multiPolygon: any[] = [];
-  const areaIds = areas?.map((item: Area) => item.id);
-  const safeAllAreas = Array.isArray(allAreas) ? allAreas : [];
-  const filteredAreas = safeAllAreas.filter((item: any) =>
-    areaIds?.includes(item.id)
-  );
+  const safeFetchedAreas = Array.isArray(fetchedAreas) ? fetchedAreas : [];
 
-  filteredAreas.forEach((item: any) => {
+  safeFetchedAreas.forEach((item: any) => {
     multiPolygon.push({
       title: item.name,
       polygon: item.polygon,

--- a/packages/leaflet-map/src/resource-detail-map.tsx
+++ b/packages/leaflet-map/src/resource-detail-map.tsx
@@ -57,15 +57,9 @@ const ResourceDetailMap = ({
     currentCenter = { ...resource.location };
   }
 
-  const { data: areas } = datastore.useArea({
-    projectId: props.projectId,
-  });
-
   let areaId = props?.map?.areaId || false;
-  const polygon =
-    areaId && Array.isArray(areas) && areas.length > 0
-      ? (areas.find((area) => area.id.toString() === areaId) || {}).polygon
-      : [];
+  const { data: areaData } = datastore.useArea({ areaId });
+  const polygon = areaData?.polygon || [];
 
   const zoom = {
     minZoom: props?.map?.minZoom ? parseInt(props.map.minZoom) : 7,

--- a/packages/leaflet-map/src/resource-overview-map.tsx
+++ b/packages/leaflet-map/src/resource-overview-map.tsx
@@ -236,15 +236,9 @@ const ResourceOverviewMap = ({
     );
   }
 
-  const { data: areas } = datastore.useArea({
-    projectId: props.projectId,
-  });
-
   let areaId = props?.map?.areaId || false;
-  const polygon =
-    areaId && Array.isArray(areas) && areas.length > 0
-      ? (areas.find((area) => area.id.toString() === areaId) || {}).polygon
-      : [];
+  const { data: areaData } = datastore.useArea({ areaId });
+  const polygon = areaData?.polygon || [];
 
   function calculateCenter(polygon: Point[] | Point[][] | Point[][][]) {
     if (!polygon || polygon.length === 0) {
@@ -277,7 +271,7 @@ const ResourceOverviewMap = ({
     if (!!polygon) {
       setCenter(calculateCenter(polygon));
     }
-  }, [polygon, areas]);
+  }, [areaData]);
 
   const zoom = {
     minZoom: props?.map?.minZoom ? parseInt(props.map.minZoom) : 7,
@@ -309,7 +303,7 @@ const ResourceOverviewMap = ({
       }
     : props?.resourceOverviewMapWidget || {};
 
-  return (polygon && center) || !Number(areaId) ? (
+  return (polygon.length > 0 && center) || !Number(areaId) ? (
     <div className="map-container--buttons">
       <Button
         appearance="primary-action-button"

--- a/packages/ui/src/form-elements/map/index.tsx
+++ b/packages/ui/src/form-elements/map/index.tsx
@@ -111,14 +111,22 @@ const MapField: FC<MapProps> = ({
     config: { api: props.api },
   });
 
-  const { data: areas } = datastore.useArea({
-    projectId: props.projectId,
-  });
-
   const areaId = props?.map?.areaId;
   const allowedPolygonIds = (props?.allowedPolygons || []).map(
     (poly) => poly.id
   );
+
+  const { data: projectArea } = datastore.useArea({ areaId });
+  const { data: allowedAreasData } = datastore.useAreas(
+    allowedPolygonIds.length > 0 ? { ids: allowedPolygonIds } : undefined
+  );
+
+  const areas =
+    allowedPolygonIds.length > 0
+      ? allowedAreasData
+      : projectArea
+        ? [projectArea]
+        : [];
   const {
     safeAreas,
     hasAllowedPolygons,


### PR DESCRIPTION
Map widgets loaded every area in the database on every page load. Now `useArea` fetches a single area by ID and `useAreas` accepts specific IDs via `?ids= `query param. Adds null-key support to the SWR wrapper so hooks can skip fetching entirely.