### PR TITLE
Fix/enquete item state reset

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/items.tsx
@@ -534,13 +534,7 @@ export default function WidgetEnqueteItems(
   }
 
   // Sets form to selected item values when item is selected
-  useEffect(() => {
-    if (selectedItem) {
-      form.reset(buildFormValues(selectedItem));
-      setOptions(selectedItem.options || []);
-      setMatrixOptions(selectedItem.matrix || matrixDefault);
-    }
-  }, [selectedItem, form]);
+  // Item selection is handled directly in the click handler (no useEffect needed)
 
   useEffect(() => {
     if (selectedOption) {

--- a/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/items.tsx
@@ -469,73 +469,74 @@ export default function WidgetEnqueteItems(
     onFieldChanged('items', items);
   }, [items]);
 
+  function buildFormValues(item: Item) {
+    let images = item.images || [];
+    if ((!images || images.length === 0) && item.image) {
+      images = [
+        {
+          url: item.image,
+          imageAlt: item.imageAlt || '',
+          imageDescription: item.imageDescription || '',
+        },
+      ];
+    }
+
+    return {
+      trigger: item.trigger,
+      title: item.title || '',
+      fieldKey: item.fieldKey || '',
+      description: item.description || '',
+      questionType: item.questionType || '',
+      minCharacters: item.minCharacters || '',
+      maxCharacters: item.maxCharacters || '',
+      nextPageText: item.nextPageText || '',
+      prevPageText: item.prevPageText || '',
+      variant: item.variant || '',
+      options: item.options || [],
+      multiple: item.multiple || false,
+      randomizeItems: item.randomizeItems || false,
+      infoBlockStyle: item.infoBlockStyle || 'default',
+      infoBlockShareButton: item.infoBlockShareButton || false,
+      infoBlockExtraButton: item.infoBlockExtraButton || '',
+      infoBlockExtraButtonTitle: item.infoBlockExtraButtonTitle || '',
+      fieldRequired: item.fieldRequired || false,
+      createImageSlider: item.createImageSlider || false,
+      imageClickable: item.imageClickable || false,
+      maxChoices: item.maxChoices || '',
+      maxChoicesMessage: item.maxChoicesMessage || '',
+      showSmileys: item.showSmileys || false,
+      defaultValue: item.defaultValue || '',
+      placeholder: item.placeholder || '',
+      matrix: item.matrix || matrixDefault,
+      matrixMultiple: item.matrixMultiple || false,
+      routingInitiallyHide: item.routingInitiallyHide || false,
+      numberingStyle: item.numberingStyle || 'none',
+      routingSelectedQuestion: item.routingSelectedQuestion || '',
+      routingSelectedAnswer: item.routingSelectedAnswer || '',
+      infoField: item.infoField || '',
+      infofieldExplanation: item.infofieldExplanation || false,
+      videoUrl: item.videoUrl || '',
+      videoSubtitle: item.videoSubtitle || false,
+      videoLang: item.videoLang || '',
+      images,
+
+      // Keeping these for backwards compatibility
+      image1: item.image1 || '',
+      text1: item.text1 || '',
+      key1: item.key1 || '',
+      image2: item.image2 || '',
+      text2: item.text2 || '',
+      key2: item.key2 || '',
+      image: '',
+      imageAlt: '',
+      imageDescription: '',
+    };
+  }
+
   // Sets form to selected item values when item is selected
   useEffect(() => {
     if (selectedItem) {
-      // Migrate fallback image fields to images array if needed
-      let images = selectedItem.images || [];
-      if ((!images || images.length === 0) && selectedItem.image) {
-        images = [
-          {
-            url: selectedItem.image,
-            imageAlt: selectedItem.imageAlt || '',
-            imageDescription: selectedItem.imageDescription || '',
-          },
-        ];
-      }
-
-      const formValues = {
-        trigger: selectedItem.trigger,
-        title: selectedItem.title || '',
-        fieldKey: selectedItem.fieldKey || '',
-        description: selectedItem.description || '',
-        questionType: selectedItem.questionType || '',
-        minCharacters: selectedItem.minCharacters || '',
-        maxCharacters: selectedItem.maxCharacters || '',
-        nextPageText: selectedItem.nextPageText || '',
-        prevPageText: selectedItem.prevPageText || '',
-        variant: selectedItem.variant || '',
-        options: selectedItem.options || [],
-        multiple: selectedItem.multiple || false,
-        randomizeItems: selectedItem.randomizeItems || false,
-        infoBlockStyle: selectedItem.infoBlockStyle || 'default',
-        infoBlockShareButton: selectedItem.infoBlockShareButton || false,
-        infoBlockExtraButton: selectedItem.infoBlockExtraButton || '',
-        infoBlockExtraButtonTitle: selectedItem.infoBlockExtraButtonTitle || '',
-        fieldRequired: selectedItem.fieldRequired || false,
-        createImageSlider: selectedItem.createImageSlider || false,
-        imageClickable: selectedItem.imageClickable || false,
-        maxChoices: selectedItem.maxChoices || '',
-        maxChoicesMessage: selectedItem.maxChoicesMessage || '',
-        showSmileys: selectedItem.showSmileys || false,
-        defaultValue: selectedItem.defaultValue || '',
-        placeholder: selectedItem.placeholder || '',
-        matrix: selectedItem.matrix || matrixDefault,
-        matrixMultiple: selectedItem.matrixMultiple || false,
-        routingInitiallyHide: selectedItem.routingInitiallyHide || false,
-        numberingStyle: selectedItem.numberingStyle || 'none',
-        routingSelectedQuestion: selectedItem.routingSelectedQuestion || '',
-        routingSelectedAnswer: selectedItem.routingSelectedAnswer || '',
-        infoField: selectedItem.infoField || '',
-        infofieldExplanation: selectedItem.infofieldExplanation || false,
-        videoUrl: selectedItem.videoUrl || '',
-        videoSubtitle: selectedItem.videoSubtitle || false,
-        videoLang: selectedItem.videoLang || '',
-        images,
-
-        // Keeping these for backwards compatibility
-        image1: selectedItem.image1 || '',
-        text1: selectedItem.text1 || '',
-        key1: selectedItem.key1 || '',
-        image2: selectedItem.image2 || '',
-        text2: selectedItem.text2 || '',
-        key2: selectedItem.key2 || '',
-        image: '',
-        imageAlt: '',
-        imageDescription: '',
-      };
-
-      form.reset(formValues);
+      form.reset(buildFormValues(selectedItem));
       setOptions(selectedItem.options || []);
       setMatrixOptions(selectedItem.matrix || matrixDefault);
     }
@@ -700,6 +701,7 @@ export default function WidgetEnqueteItems(
   function handleSaveOptions() {
     form.setValue('options', options);
     setSettingOptions(false);
+    setOption(null);
   }
 
   function handleSaveMatrixOptions() {
@@ -798,10 +800,12 @@ export default function WidgetEnqueteItems(
                             <span
                               className="gap-2 py-3 px-2 w-full"
                               onClick={() => {
+                                form.reset(buildFormValues(item));
                                 setItem(item);
-                                setOptions([]);
-                                setMatrixOptions(matrixDefault);
+                                setOptions(item.options || []);
+                                setMatrixOptions(item.matrix || matrixDefault);
                                 setSettingOptions(false);
+                                setOption(null);
                               }}
                               dangerouslySetInnerHTML={{
                                 __html: `${


### PR DESCRIPTION
When clicking a different item in the enquete sidebar, the form could show options and matrix data from the previous item. The click handler was setting options to empty instead of loading the selected item's data, and a useEffect race made it worse.

Now the click handler resets the form directly with the correct item data and the redundant useEffect is removed.