### PR TITLE
fix: normalize www. in CORS allowed domain checks

### DIFF
--- a/apps/api-server/src/middleware/security-headers.js
+++ b/apps/api-server/src/middleware/security-headers.js
@@ -15,7 +15,13 @@ module.exports = function (req, res, next) {
     config.allowedDomains;
   allowedDomains = prefillAllowedDomains(allowedDomains || []);
 
-  if (!allowedDomains || allowedDomains.indexOf(domain) === -1) {
+  const stripWww = (d) => (d && d.startsWith('www.') ? d.slice(4) : d);
+  const normalizedDomain = stripWww(domain);
+  const isDomainAllowed =
+    allowedDomains &&
+    allowedDomains.some((d) => stripWww(d) === normalizedDomain);
+
+  if (!isDomainAllowed) {
     url = config.url || req.protocol + '://' + req.host;
 
     // Exception for URLs without project - we allow all origins

--- a/apps/auth-server/middleware/security-headers.js
+++ b/apps/auth-server/middleware/security-headers.js
@@ -16,7 +16,13 @@ module.exports = function (req, res, next) {
     ? allowedDomains
     : (allowedDomains || '').split(',');
 
-  if (whitelist.includes(domain)) {
+  const stripWww = (d) => (d && d.startsWith('www.') ? d.slice(4) : d);
+  const normalizedDomain = stripWww(domain);
+  const isDomainAllowed = whitelist.some(
+    (d) => stripWww(d) === normalizedDomain
+  );
+
+  if (isDomainAllowed) {
     res.header('Access-Control-Allow-Origin', origin);
   } else if (
     config.dev &&


### PR DESCRIPTION
CORS middleware in api-server and auth-server did exact domain matching, so www.example.com wouldn't match if only example.com was in allowedDomains. Now both sides are normalized before comparing, matching how `isRedirectAllowed` already worked.