### PR TITLE
Fix/field triggers after delete

### DIFF
--- a/apps/admin-server/src/lib/export-helpers/choiceguide-export.tsx
+++ b/apps/admin-server/src/lib/export-helpers/choiceguide-export.tsx
@@ -123,12 +123,15 @@ export const exportChoiceGuideToCSV = async (
           item.options.length > 0
         ) {
           item.options.forEach(
-            (option: {
-              titles: [
-                { key?: string; title?: string; isOtherOption?: boolean },
-              ];
-              trigger: string;
-            }) => {
+            (
+              option: {
+                titles: [
+                  { key?: string; title?: string; isOtherOption?: boolean },
+                ];
+                trigger: string;
+              },
+              index: number
+            ) => {
               if (
                 !!option.titles &&
                 Array.isArray(option.titles) &&
@@ -140,9 +143,19 @@ export const exportChoiceGuideToCSV = async (
                   option.titles[0].title ||
                   'Anders, namelijk'
                 }`;
-                const otherKey = `${newKey}_${option.trigger}_other`;
+                const triggerKey = `${newKey}_${option.trigger}_other`;
+                const indexKey = `${newKey}_${index}_other`;
+                const possibleKeys =
+                  triggerKey === indexKey
+                    ? [triggerKey]
+                    : [triggerKey, indexKey];
 
-                fieldKeyToTitleMap.set(otherKey, otherTitle);
+                possibleKeys.forEach((key) => {
+                  const hasData = data.some((row: any) => !!row?.result?.[key]);
+                  if (hasData) {
+                    fieldKeyToTitleMap.set(key, otherTitle);
+                  }
+                });
               }
             }
           );

--- a/apps/admin-server/src/lib/export-helpers/submissions-export.tsx
+++ b/apps/admin-server/src/lib/export-helpers/submissions-export.tsx
@@ -137,17 +137,22 @@ export const exportSubmissionsToCSV = async (
             titles.length > 0 &&
             titles[0].isOtherOption
           ) {
-            const otherKey = `${item.fieldKey}_${index}_other`;
-
-            const hasOtherData = data.some(
-              (row: any) => !!row?.submittedData?.[otherKey]
-            );
-
             const otherTitle =
               titles[0].key || titles[0].title || 'Anders, namelijk';
-            if (hasOtherData && otherTitle) {
-              fieldKeyToTitleMap.set(otherKey, otherTitle);
-            }
+
+            const triggerKey = `${item.fieldKey}_${option.trigger}_other`;
+            const indexKey = `${item.fieldKey}_${index}_other`;
+            const possibleKeys =
+              triggerKey === indexKey ? [triggerKey] : [triggerKey, indexKey];
+
+            possibleKeys.forEach((key) => {
+              const hasData = data.some(
+                (row: any) => !!row?.submittedData?.[key]
+              );
+              if (hasData) {
+                fieldKeyToTitleMap.set(key, otherTitle);
+              }
+            });
           }
         });
       }

--- a/packages/ui/src/form-elements/checkbox/index.tsx
+++ b/packages/ui/src/form-elements/checkbox/index.tsx
@@ -34,6 +34,7 @@ export type CheckboxFieldProps = {
     label: string;
     isOtherOption?: boolean;
     defaultValue?: boolean;
+    trigger?: string;
   }[];
   fieldRequired?: boolean;
   requiredWarning?: string;
@@ -150,6 +151,17 @@ const CheckboxField: FC<CheckboxFieldProps> = ({
   }, [choices, fieldKey, randomizeItems]);
 
   useEffect(() => {
+    const initialOtherOptionValues: { [key: string]: string } = {};
+    displayChoices?.forEach((choice, index) => {
+      if (choice?.isOtherOption) {
+        const id = choice.trigger || `${index}`;
+        initialOtherOptionValues[`${fieldKey}_${id}_other`] = '';
+      }
+    });
+    setOtherOptionValues(initialOtherOptionValues);
+  }, [displayChoices, fieldKey]);
+
+  useEffect(() => {
     if (onChange) {
       onChange({
         name: fieldKey,
@@ -167,7 +179,7 @@ const CheckboxField: FC<CheckboxFieldProps> = ({
 
   const handleChoiceChange = (
     event: React.ChangeEvent<HTMLInputElement>,
-    index: number
+    trigger: string
   ): void => {
     const choiceValue = event.target.value;
     if (event.target.checked) {
@@ -176,13 +188,13 @@ const CheckboxField: FC<CheckboxFieldProps> = ({
       setSelectedChoices(
         selectedChoices.filter((choice) => choice !== choiceValue)
       );
-      if (otherOptionValues.hasOwnProperty(`${fieldKey}_${index}_other`)) {
-        otherOptionValues[`${fieldKey}_${index}_other`] = '';
+      if (otherOptionValues.hasOwnProperty(`${fieldKey}_${trigger}_other`)) {
+        otherOptionValues[`${fieldKey}_${trigger}_other`] = '';
         setOtherOptionValues({ ...otherOptionValues });
         if (onChange) {
           onChange(
             {
-              name: `${fieldKey}_${index}_other`,
+              name: `${fieldKey}_${trigger}_other`,
               value: '',
             },
             false
@@ -221,6 +233,7 @@ const CheckboxField: FC<CheckboxFieldProps> = ({
         label: string;
         isOtherOption?: boolean;
         defaultValue?: boolean;
+        trigger?: string;
       },
     ];
   }
@@ -329,7 +342,9 @@ const CheckboxField: FC<CheckboxFieldProps> = ({
                         ? selectedChoices.includes(choice.value)
                         : false
                     }
-                    onChange={(e) => handleChoiceChange(e, index)}
+                    onChange={(e) =>
+                      handleChoiceChange(e, choice.trigger || `${index}`)
+                    }
                     disabled={
                       disabled ||
                       (maxReached && !selectedChoices.includes(choice.value))
@@ -348,11 +363,15 @@ const CheckboxField: FC<CheckboxFieldProps> = ({
                   onChange={(e: { name: string; value: string }) =>
                     handleOtherOptionChange(e)
                   }
-                  fieldKey={`${fieldKey}_${index}_other`}
+                  fieldKey={`${fieldKey}_${choice.trigger || index}_other`}
                   title=""
-                  defaultValue={otherOptionValues[`${fieldKey}_${index}_other`]}
+                  defaultValue={
+                    otherOptionValues[
+                      `${fieldKey}_${choice.trigger || index}_other`
+                    ]
+                  }
                   fieldInvalid={false}
-                  randomId={`${fieldKey}_${index}`}
+                  randomId={`${fieldKey}_${choice.trigger || index}`}
                 />
               </div>
             )}

--- a/packages/ui/src/form-elements/radio/index.tsx
+++ b/packages/ui/src/form-elements/radio/index.tsx
@@ -35,6 +35,7 @@ export type RadioboxFieldProps = {
     label: string;
     isOtherOption?: boolean;
     defaultValue?: boolean;
+    trigger?: string;
   }[];
   fieldRequired?: boolean;
   requiredWarning?: string;
@@ -136,7 +137,8 @@ const RadioboxField: FC<RadioboxFieldProps> = ({
     const initialOtherOptionValues: { [key: string]: string } = {};
     displayChoices?.forEach((choice, index) => {
       if (choice?.isOtherOption) {
-        initialOtherOptionValues[`${fieldKey}_${index}_other`] = '';
+        const id = choice.trigger || `${index}`;
+        initialOtherOptionValues[`${fieldKey}_${id}_other`] = '';
       }
     });
     setOtherOptionValues(initialOtherOptionValues);
@@ -149,7 +151,7 @@ const RadioboxField: FC<RadioboxFieldProps> = ({
     }
   }, [fieldRequired, initialValue, selectedOption]);
 
-  const handleRadioChange = (value: string, index: number) => {
+  const handleRadioChange = (value: string, trigger: string) => {
     setSelectedOption(value);
     setCheckInvalid(false);
     if (onChange) {
@@ -159,7 +161,7 @@ const RadioboxField: FC<RadioboxFieldProps> = ({
       });
     }
     Object.keys(otherOptionValues).forEach((key) => {
-      if (key !== `${fieldKey}_${index}_other`) {
+      if (key !== `${fieldKey}_${trigger}_other`) {
         otherOptionValues[key] = '';
         if (onChange) {
           onChange(
@@ -254,7 +256,10 @@ const RadioboxField: FC<RadioboxFieldProps> = ({
                     name={fieldKey}
                     required={fieldRequired}
                     onChange={() => {
-                      (handleRadioChange(choice.value, index),
+                      (handleRadioChange(
+                        choice.value,
+                        choice.trigger || `${index}`
+                      ),
                         setCheckInvalid(false));
                     }}
                     disabled={disabled}
@@ -273,10 +278,10 @@ const RadioboxField: FC<RadioboxFieldProps> = ({
                   onChange={(e: { name: string; value: string }) =>
                     handleOtherOptionChange(e)
                   }
-                  fieldKey={`${fieldKey}_${index}_other`}
+                  fieldKey={`${fieldKey}_${choice.trigger || index}_other`}
                   title=""
                   fieldInvalid={false}
-                  randomId={`${fieldKey}_${index}`}
+                  randomId={`${fieldKey}_${choice.trigger || index}`}
                 />
               </div>
             )}

--- a/packages/ui/types/src/form-elements/checkbox/index.d.ts
+++ b/packages/ui/types/src/form-elements/checkbox/index.d.ts
@@ -9,6 +9,7 @@ export type CheckboxFieldProps = {
         label: string;
         isOtherOption?: boolean;
         defaultValue?: boolean;
+        trigger?: string;
     }[];
     fieldRequired?: boolean;
     requiredWarning?: string;

--- a/packages/ui/types/src/form-elements/radio/index.d.ts
+++ b/packages/ui/types/src/form-elements/radio/index.d.ts
@@ -9,6 +9,7 @@ export type RadioboxFieldProps = {
         label: string;
         isOtherOption?: boolean;
         defaultValue?: boolean;
+        trigger?: string;
     }[];
     fieldRequired?: boolean;
     requiredWarning?: string;


### PR DESCRIPTION
Radio and checkbox components used the array index to build the "other" field key. Deleting an option shifted indexes, so new submissions stored data under a different key than old ones and exports couldn't find the right column. Now uses the option's trigger instead. Exports check both trigger-based and index-based keys so old submissions still show up.