### PR TITLE
Feat/routing extras or fixes

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/form.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/form.tsx
@@ -170,18 +170,6 @@ export default function ChoicesSelectorForm(
           className="w-fit lg:w-2/3 grid grid-cols-1 lg:grid-cols-2 gap-4">
           <FormField
             control={form.control}
-            name="noOfQuestionsToShow"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Aantal vragen per pagina</FormLabel>
-                <FormControl>
-                  <Input type="number" {...field} />
-                </FormControl>
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
             name="showPageCountAndCurrentPageInButton"
             render={({ field }) => (
               <FormItem>

--- a/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/items.tsx
@@ -1,6 +1,7 @@
 import ImageGalleryStyle from '@/components/image-gallery-style';
 import { ImageUploader } from '@/components/image-uploader';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   Form,
   FormControl,
@@ -79,6 +80,8 @@ const formSchema = z.object({
   maxChoicesMessage: z.string().optional(),
   variant: z.string().optional(),
   multiple: z.boolean().optional(),
+  prevPageText: z.string().optional(),
+  nextPageText: z.string().optional(),
   options: z
     .array(
       z.object({
@@ -138,7 +141,7 @@ const formSchema = z.object({
   createImageSlider: z.boolean().optional(),
   imageClickable: z.boolean().optional(),
   routingSelectedQuestion: z.string().optional(),
-  routingSelectedAnswer: z.string().optional(),
+  routingSelectedAnswer: z.union([z.string(), z.array(z.string())]).optional(),
   imageOptionUpload: z.string().optional(),
   images: z
     .array(
@@ -253,12 +256,37 @@ export default function WidgetChoiceGuideItems(
         mergedWeights
       );
 
+      const oldOptions = selectedItem.options || [];
+      const newOptions = options || [];
+      const triggerMap: Record<string, string> = {};
+      for (let i = 0; i < Math.min(oldOptions.length, newOptions.length); i++) {
+        if (oldOptions[i].trigger !== newOptions[i].trigger) {
+          triggerMap[oldOptions[i].trigger] = newOptions[i].trigger;
+        }
+      }
+      const hasTriggerChanges = Object.keys(triggerMap).length > 0;
+
       setItems((currentItems) =>
-        currentItems.map((item) =>
-          item.trigger === selectedItem.trigger
-            ? { ...item, ...values, weights: normalizedMergedWeights }
-            : item
-        )
+        currentItems.map((item) => {
+          if (item.trigger === selectedItem.trigger) {
+            return { ...item, ...values, weights: normalizedMergedWeights };
+          }
+          if (
+            hasTriggerChanges &&
+            item.routingSelectedQuestion === selectedItem.trigger
+          ) {
+            const answers = Array.isArray(item.routingSelectedAnswer)
+              ? item.routingSelectedAnswer
+              : item.routingSelectedAnswer
+                ? [item.routingSelectedAnswer]
+                : [];
+            const updated = answers.map(
+              (answer) => triggerMap[answer] || answer
+            );
+            return { ...item, routingSelectedAnswer: updated };
+          }
+          return item;
+        })
       );
       setItem(null);
     } else {
@@ -291,6 +319,8 @@ export default function WidgetChoiceGuideItems(
           imageA: values.imageA || '',
           imageB: values.imageB || '',
           placeholder: values.placeholder || '',
+          prevPageText: values.prevPageText || '',
+          nextPageText: values.nextPageText || '',
           maxChoices: values.maxChoices || '',
           maxChoicesMessage: values.maxChoicesMessage || '',
           defaultValue: values.defaultValue || '',
@@ -434,6 +464,8 @@ export default function WidgetChoiceGuideItems(
     maxCharacters: '',
     variant: 'text input',
     multiple: false,
+    prevPageText: '',
+    nextPageText: '',
     options: [],
     showMoreInfo: false,
     moreInfoButton: '',
@@ -522,6 +554,8 @@ export default function WidgetChoiceGuideItems(
         explanationA: selectedItem.explanationA || '',
         explanationB: selectedItem.explanationB || '',
         placeholder: selectedItem.placeholder || '',
+        prevPageText: selectedItem.prevPageText || '',
+        nextPageText: selectedItem.nextPageText || '',
         imageA: selectedItem.imageA || '',
         imageB: selectedItem.imageB || '',
         maxChoices: selectedItem.maxChoices || '',
@@ -585,11 +619,30 @@ export default function WidgetChoiceGuideItems(
   ) => {
     if (isItemAction) {
       setItems((currentItems) => {
-        return handleMovementOrDeletion(
+        const index = currentItems.findIndex(
+          (entry) => entry.trigger === clickedTrigger
+        );
+        const swapIndex = actionType === 'moveUp' ? index - 1 : index + 1;
+        const triggerA = currentItems[index]?.trigger;
+        const triggerB = currentItems[swapIndex]?.trigger;
+
+        const newItems = handleMovementOrDeletion(
           currentItems,
           actionType,
           clickedTrigger
         ) as Item[];
+
+        if (actionType !== 'delete' && triggerA && triggerB) {
+          for (const item of newItems) {
+            if (item.routingSelectedQuestion === triggerA) {
+              item.routingSelectedQuestion = triggerB;
+            } else if (item.routingSelectedQuestion === triggerB) {
+              item.routingSelectedQuestion = triggerA;
+            }
+          }
+        }
+
+        return newItems;
       });
     } else if (isMatrixAction) {
       let newMatrixOptions: Matrix;
@@ -671,6 +724,7 @@ export default function WidgetChoiceGuideItems(
       'imageUpload',
       'documentUpload',
       'text',
+      'pagination',
     ].includes(chosenType);
 
     const finalDimensions =
@@ -995,7 +1049,10 @@ export default function WidgetChoiceGuideItems(
                               }}>
                               <span
                                 dangerouslySetInnerHTML={{
-                                  __html: item.title || 'Geen titel',
+                                  __html:
+                                    item.type === 'pagination'
+                                      ? '--- Nieuwe pagina ---'
+                                      : item.title || 'Geen titel',
                                 }}
                               />
                             </span>
@@ -1536,680 +1593,227 @@ export default function WidgetChoiceGuideItems(
                                 <SelectItem value="images">
                                   Antwoordopties met afbeeldingen
                                 </SelectItem>
+                                <SelectItem value="pagination">
+                                  Voeg pagina toe
+                                </SelectItem>
                               </SelectContent>
                             </Select>
                             <FormMessage />
                           </FormItem>
                         )}></FormField>
-                      <FormField
-                        control={form.control}
-                        name="title"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Titel/Vraag</FormLabel>
-                            <FormControl>
-                              <TrixEditor
-                                value={field.value || ''}
-                                onChange={(val) => field.onChange(val)}
-                              />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-                      <FormField
-                        control={form.control}
-                        name="description"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Beschrijving</FormLabel>
-                            <FormControl>
-                              <TrixEditor
-                                value={field.value || ''}
-                                onChange={(val) => field.onChange(val)}
-                              />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
+                      {form.watch('type') === 'pagination' && (
+                        <>
+                          <FormField
+                            control={form.control}
+                            name="prevPageText"
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormLabel>Tekst voor: Vorige pagina</FormLabel>
+                                <Input {...field} />
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
+                          <FormField
+                            control={form.control}
+                            name="nextPageText"
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormLabel>
+                                  Tekst voor: Volgende pagina
+                                </FormLabel>
+                                <Input {...field} />
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
+                        </>
+                      )}
+                      {form.watch('type') !== 'pagination' && (
+                        <>
+                          <FormField
+                            control={form.control}
+                            name="title"
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormLabel>Titel/Vraag</FormLabel>
+                                <FormControl>
+                                  <TrixEditor
+                                    value={field.value || ''}
+                                    onChange={(val) => field.onChange(val)}
+                                  />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
+                          <FormField
+                            control={form.control}
+                            name="description"
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormLabel>Beschrijving</FormLabel>
+                                <FormControl>
+                                  <TrixEditor
+                                    value={field.value || ''}
+                                    onChange={(val) => field.onChange(val)}
+                                  />
+                                </FormControl>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
 
-                      <>
-                        <ImageUploader
-                          form={form}
-                          project={project as string}
-                          fieldName="uploadInfoImage"
-                          imageLabel="Afbeeldingen uploaden boven de vraag"
-                          description="Je kunt hier meerdere afbeeldingen tegelijk uploaden. Klik na het uploaden op een afbeelding om extra informatie toe te voegen, zoals een beschrijving of alternatieve tekst voor schermlezers."
-                          allowedTypes={['image/*']}
-                          allowMultiple={true}
-                          onImageUploaded={(imageResult) => {
-                            let defaultImageArr: ImageArray[] = [];
+                          <>
+                            <ImageUploader
+                              form={form}
+                              project={project as string}
+                              fieldName="uploadInfoImage"
+                              imageLabel="Afbeeldingen uploaden boven de vraag"
+                              description="Je kunt hier meerdere afbeeldingen tegelijk uploaden. Klik na het uploaden op een afbeelding om extra informatie toe te voegen, zoals een beschrijving of alternatieve tekst voor schermlezers."
+                              allowedTypes={['image/*']}
+                              allowMultiple={true}
+                              onImageUploaded={(imageResult) => {
+                                let defaultImageArr: ImageArray[] = [];
 
-                            if (!!form.watch('infoImage')) {
-                              defaultImageArr = [
-                                {
-                                  url: form.getValues('infoImage') || '',
-                                  name: '',
-                                  imageAlt: '',
-                                  imageDescription: '',
-                                },
-                              ];
+                                if (!!form.watch('infoImage')) {
+                                  defaultImageArr = [
+                                    {
+                                      url: form.getValues('infoImage') || '',
+                                      name: '',
+                                      imageAlt: '',
+                                      imageDescription: '',
+                                    },
+                                  ];
 
-                              form.setValue('infoImage', '');
-                            }
+                                  form.setValue('infoImage', '');
+                                }
 
-                            let array = [
-                              ...(form.getValues('images') || defaultImageArr),
-                            ];
-                            array.push(imageResult);
-                            form.setValue('images', array);
-                            form.resetField('uploadInfoImage');
-                            form.trigger('images');
-                          }}
-                        />
+                                let array = [
+                                  ...(form.getValues('images') ||
+                                    defaultImageArr),
+                                ];
+                                array.push(imageResult);
+                                form.setValue('images', array);
+                                form.resetField('uploadInfoImage');
+                                form.trigger('images');
+                              }}
+                            />
 
-                        <div className="space-y-2 col-span-full md:col-span-1 flex flex-col">
-                          {imageFields.length > 0 && (
-                            <div className="grid">
-                              <section className="grid col-span-full grid-cols-3 gap-y-8 gap-x-8 mb-4">
-                                {imageFields.map(({ id, url }, index) => {
-                                  return (
-                                    <div
-                                      key={id}
-                                      className={`relative grid ${
-                                        index === imageIndexOpen
-                                          ? 'col-span-full'
-                                          : 'tile'
-                                      } gap-x-4 items-center image-gallery`}
-                                      style={{
-                                        gridTemplateColumns:
-                                          index === imageIndexOpen
-                                            ? '1fr 2fr 40px'
-                                            : '1fr',
-                                      }}>
-                                      <div className="image-container">
-                                        <img
-                                          src={url}
-                                          alt={url}
-                                          onClick={() => {
-                                            if (index === imageIndexOpen) {
-                                              setImageIndexOpen(-1);
-                                            } else {
-                                              setImageIndexOpen(index);
-                                            }
-                                          }}
-                                        />
-                                      </div>
-                                      <Button
-                                        color="red"
-                                        onClick={() => {
-                                          removeImage(index);
-                                        }}
-                                        className="absolute left-0 top-0">
-                                        <X size={24} />
-                                      </Button>
-
-                                      <div
-                                        className="grid gap-y-4 items-center"
-                                        style={{
-                                          display:
+                            <div className="space-y-2 col-span-full md:col-span-1 flex flex-col">
+                              {imageFields.length > 0 && (
+                                <div className="grid">
+                                  <section className="grid col-span-full grid-cols-3 gap-y-8 gap-x-8 mb-4">
+                                    {imageFields.map(({ id, url }, index) => {
+                                      return (
+                                        <div
+                                          key={id}
+                                          className={`relative grid ${
                                             index === imageIndexOpen
-                                              ? 'grid'
-                                              : 'none',
-                                        }}>
-                                        <FormField
-                                          control={form.control}
-                                          name={`images.${index}.imageAlt`}
-                                          render={({ field }) => (
-                                            <FormItem className="col-span-full sm:col-span-2 md:col-span-2 lg:col-span-2">
-                                              <FormLabel>
-                                                Afbeelding beschrijving voor
-                                                screenreaders
-                                              </FormLabel>
-                                              <FormControl>
-                                                <Input {...field} />
-                                              </FormControl>
-                                              <FormMessage />
-                                            </FormItem>
-                                          )}
-                                        />
+                                              ? 'col-span-full'
+                                              : 'tile'
+                                          } gap-x-4 items-center image-gallery`}
+                                          style={{
+                                            gridTemplateColumns:
+                                              index === imageIndexOpen
+                                                ? '1fr 2fr 40px'
+                                                : '1fr',
+                                          }}>
+                                          <div className="image-container">
+                                            <img
+                                              src={url}
+                                              alt={url}
+                                              onClick={() => {
+                                                if (index === imageIndexOpen) {
+                                                  setImageIndexOpen(-1);
+                                                } else {
+                                                  setImageIndexOpen(index);
+                                                }
+                                              }}
+                                            />
+                                          </div>
+                                          <Button
+                                            color="red"
+                                            onClick={() => {
+                                              removeImage(index);
+                                            }}
+                                            className="absolute left-0 top-0">
+                                            <X size={24} />
+                                          </Button>
 
-                                        <FormField
-                                          control={form.control}
-                                          name={`images.${index}.imageDescription`}
-                                          render={({ field }) => (
-                                            <FormItem className="col-span-full sm:col-span-2 md:col-span-2 lg:col-span-2">
-                                              <FormLabel>
-                                                Beschrijving afbeelding
-                                              </FormLabel>
-                                              <FormControl>
-                                                <Input {...field} />
-                                              </FormControl>
-                                              <FormMessage />
-                                            </FormItem>
+                                          <div
+                                            className="grid gap-y-4 items-center"
+                                            style={{
+                                              display:
+                                                index === imageIndexOpen
+                                                  ? 'grid'
+                                                  : 'none',
+                                            }}>
+                                            <FormField
+                                              control={form.control}
+                                              name={`images.${index}.imageAlt`}
+                                              render={({ field }) => (
+                                                <FormItem className="col-span-full sm:col-span-2 md:col-span-2 lg:col-span-2">
+                                                  <FormLabel>
+                                                    Afbeelding beschrijving voor
+                                                    screenreaders
+                                                  </FormLabel>
+                                                  <FormControl>
+                                                    <Input {...field} />
+                                                  </FormControl>
+                                                  <FormMessage />
+                                                </FormItem>
+                                              )}
+                                            />
+
+                                            <FormField
+                                              control={form.control}
+                                              name={`images.${index}.imageDescription`}
+                                              render={({ field }) => (
+                                                <FormItem className="col-span-full sm:col-span-2 md:col-span-2 lg:col-span-2">
+                                                  <FormLabel>
+                                                    Beschrijving afbeelding
+                                                  </FormLabel>
+                                                  <FormControl>
+                                                    <Input {...field} />
+                                                  </FormControl>
+                                                  <FormMessage />
+                                                </FormItem>
+                                              )}
+                                            />
+                                          </div>
+                                          {imageFields.length > 1 && (
+                                            <span className="grid gap-2 py-3 px-2 col-span-full justify-between arrow-container">
+                                              <ArrowLeft
+                                                className="cursor-pointer"
+                                                onClick={() =>
+                                                  moveUpImage(index)
+                                                }
+                                              />
+                                              <ArrowRight
+                                                className="cursor-pointer"
+                                                onClick={() =>
+                                                  moveDownImage(index)
+                                                }
+                                              />
+                                            </span>
                                           )}
-                                        />
-                                      </div>
-                                      {imageFields.length > 1 && (
-                                        <span className="grid gap-2 py-3 px-2 col-span-full justify-between arrow-container">
-                                          <ArrowLeft
-                                            className="cursor-pointer"
-                                            onClick={() => moveUpImage(index)}
-                                          />
-                                          <ArrowRight
-                                            className="cursor-pointer"
-                                            onClick={() => moveDownImage(index)}
-                                          />
-                                        </span>
-                                      )}
-                                    </div>
-                                  );
-                                })}
-                              </section>
+                                        </div>
+                                      );
+                                    })}
+                                  </section>
+                                </div>
+                              )}
                             </div>
-                          )}
-                        </div>
 
-                        <FormField
-                          control={form.control}
-                          name="createImageSlider"
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel>
-                                Wil je van de afbeeldingen een slider maken?
-                              </FormLabel>
-                              <Select
-                                onValueChange={(e: string) =>
-                                  field.onChange(e === 'true')
-                                }
-                                value={field.value ? 'true' : 'false'}>
-                                <FormControl>
-                                  <SelectTrigger>
-                                    <SelectValue placeholder="Kies een optie" />
-                                  </SelectTrigger>
-                                </FormControl>
-                                <SelectContent>
-                                  <SelectItem value="false">Nee</SelectItem>
-                                  <SelectItem value="true">Ja</SelectItem>
-                                </SelectContent>
-                              </Select>
-                              <FormMessage />
-                            </FormItem>
-                          )}
-                        />
-
-                        <FormField
-                          control={form.control}
-                          name="imageClickable"
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel>
-                                Moeten de afbeeldingen uitvergroot worden als
-                                erop geklikt wordt?
-                              </FormLabel>
-                              <Select
-                                onValueChange={(e: string) =>
-                                  field.onChange(e === 'true')
-                                }
-                                value={field.value ? 'true' : 'false'}>
-                                <FormControl>
-                                  <SelectTrigger>
-                                    <SelectValue placeholder="Kies een optie" />
-                                  </SelectTrigger>
-                                </FormControl>
-                                <SelectContent>
-                                  <SelectItem value="false">Nee</SelectItem>
-                                  <SelectItem value="true">Ja</SelectItem>
-                                </SelectContent>
-                              </Select>
-                              <FormMessage />
-                            </FormItem>
-                          )}
-                        />
-                      </>
-
-                      <FormField
-                        control={form.control}
-                        name="showMoreInfo"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>Extra info</FormLabel>
-                            <FormDescription>
-                              Wil je een blok met uitklapbare tekst toevoegen?
-                              (bijvoorbeeld met extra uitleg)
-                            </FormDescription>
-                            <Select
-                              onValueChange={(e: string) =>
-                                field.onChange(e === 'true')
-                              }
-                              value={field.value ? 'true' : 'false'}>
-                              <FormControl>
-                                <SelectTrigger>
-                                  <SelectValue placeholder="Kies een optie" />
-                                </SelectTrigger>
-                              </FormControl>
-                              <SelectContent>
-                                <SelectItem value="true">Ja</SelectItem>
-                                <SelectItem value="false">Nee</SelectItem>
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-
-                      {form.watch('showMoreInfo') && (
-                        <>
-                          <FormField
-                            control={form.control}
-                            name="moreInfoButton"
-                            render={({ field }) => (
-                              <FormItem>
-                                <FormLabel>
-                                  Meer informatie knop tekst
-                                </FormLabel>
-                                <Input {...field} />
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-
-                          <FormField
-                            control={form.control}
-                            name="moreInfoContent"
-                            render={({ field }) => (
-                              <FormItem>
-                                <FormLabel>Meer informatie tekst</FormLabel>
-                                <Textarea rows={5} {...field} />
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-                        </>
-                      )}
-
-                      {!['none', 'a-b-slider', 'sort', 'scale'].includes(
-                        form.watch('type') || ''
-                      ) && (
-                        <FormField
-                          control={form.control}
-                          name="fieldRequired"
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel>Is dit veld verplicht?</FormLabel>
-                              {form.watch('type') === 'matrix' && (
-                                <FormDescription>
-                                  Als je het veld <b>verplicht</b> maakt moeten
-                                  gebruikers bij elke rij een antwoord
-                                  selecteren. Als je het veld{' '}
-                                  <b>niet verplicht</b> maakt kunnen gebruikers
-                                  elke rij overslaan en invullen wat ze willen.
-                                </FormDescription>
-                              )}
-                              <Select
-                                onValueChange={(e: string) =>
-                                  field.onChange(e === 'true')
-                                }
-                                value={field.value ? 'true' : 'false'}>
-                                <FormControl>
-                                  <SelectTrigger>
-                                    <SelectValue placeholder="Kies een optie" />
-                                  </SelectTrigger>
-                                </FormControl>
-                                <SelectContent>
-                                  <SelectItem value="true">Ja</SelectItem>
-                                  <SelectItem value="false">Nee</SelectItem>
-                                </SelectContent>
-                              </Select>
-                              <FormMessage />
-                            </FormItem>
-                          )}
-                        />
-                      )}
-                      {form.watch('type') === 'text' && (
-                        <>
-                          <FormField
-                            control={form.control}
-                            name="variant"
-                            render={({ field }) => (
-                              <FormItem>
-                                <FormLabel>
-                                  Is het veld qua grootte 1 regel of een
-                                  tekstvak?
-                                </FormLabel>
-                                <Select
-                                  value={field.value || 'text input'}
-                                  onValueChange={field.onChange}>
-                                  <FormControl>
-                                    <SelectTrigger>
-                                      <SelectValue placeholder="Kies een optie" />
-                                    </SelectTrigger>
-                                  </FormControl>
-                                  <SelectContent>
-                                    <SelectItem value="text input">
-                                      1 regel
-                                    </SelectItem>
-                                    <SelectItem value="textarea">
-                                      Tekstvak
-                                    </SelectItem>
-                                  </SelectContent>
-                                </Select>
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-
-                          <FormField
-                            control={form.control}
-                            name="placeholder"
-                            render={({ field }) => (
-                              <FormItem>
-                                <FormLabel>Placeholder</FormLabel>
-                                <Input {...field} />
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-
-                          <FormField
-                            control={form.control}
-                            name="minCharacters"
-                            render={({ field }) => (
-                              <FormItem>
-                                <FormLabel>Minimaal aantal tekens</FormLabel>
-                                <Input {...field} />
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-
-                          <FormField
-                            control={form.control}
-                            name="maxCharacters"
-                            render={({ field }) => (
-                              <FormItem>
-                                <FormLabel>Maximaal aantal tekens</FormLabel>
-                                <Input {...field} />
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-                        </>
-                      )}
-
-                      {form.watch('type') === 'matrix' && (
-                        <FormField
-                          control={form.control}
-                          name="matrixMultiple"
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel>
-                                Mogen er meerdere antwoorden per rij worden
-                                geselecteerd?
-                              </FormLabel>
-                              <Select
-                                onValueChange={(e: string) =>
-                                  field.onChange(e === 'true')
-                                }
-                                value={field.value ? 'true' : 'false'}>
-                                <FormControl>
-                                  <SelectTrigger>
-                                    <SelectValue placeholder="Kies een optie" />
-                                  </SelectTrigger>
-                                </FormControl>
-                                <SelectContent>
-                                  <SelectItem value="false">Nee</SelectItem>
-                                  <SelectItem value="true">Ja</SelectItem>
-                                </SelectContent>
-                              </Select>
-                              <FormMessage />
-                            </FormItem>
-                          )}
-                        />
-                      )}
-
-                      {(form.watch('type') === 'imageUpload' ||
-                        form.watch('type') === 'images' ||
-                        form.watch('type') === 'documentUpload') && (
-                        <FormField
-                          control={form.control}
-                          name="multiple"
-                          render={({ field }) => (
-                            <FormItem>
-                              {form.watch('type') === 'imageUpload' ||
-                              form.watch('type') === 'documentUpload' ? (
-                                <FormLabel>
-                                  Mogen er meerdere{' '}
-                                  {form.watch('type') === 'documentUpload'
-                                    ? 'documenten'
-                                    : 'afbeeldingen'}{' '}
-                                  tegelijkertijd geüpload worden?
-                                </FormLabel>
-                              ) : (
-                                <FormLabel>
-                                  Mogen er meerdere afbeeldingen geselecteerd
-                                  worden?
-                                </FormLabel>
-                              )}
-                              <Select
-                                onValueChange={(e: string) =>
-                                  field.onChange(e === 'true')
-                                }
-                                value={field.value ? 'true' : 'false'}>
-                                <FormControl>
-                                  <SelectTrigger>
-                                    <SelectValue placeholder="Kies een optie" />
-                                  </SelectTrigger>
-                                </FormControl>
-                                <SelectContent>
-                                  <SelectItem value="true">Ja</SelectItem>
-                                  <SelectItem value="false">Nee</SelectItem>
-                                </SelectContent>
-                              </Select>
-                              <FormMessage />
-                            </FormItem>
-                          )}
-                        />
-                      )}
-
-                      {form.watch('type') === 'a-b-slider' && (
-                        <div className="col-span-full grid-cols-2 grid gap-4 gap-y-4">
-                          <FormField
-                            control={form.control}
-                            name="labelA"
-                            render={({ field }) => (
-                              <FormItem>
-                                <FormLabel>Label voor A</FormLabel>
-                                <FormControl>
-                                  <Input {...field} />
-                                </FormControl>
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-
-                          <FormField
-                            control={form.control}
-                            name="labelB"
-                            render={({ field }) => (
-                              <FormItem>
-                                <FormLabel>Label voor B</FormLabel>
-                                <FormControl>
-                                  <Input {...field} />
-                                </FormControl>
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-
-                          <FormField
-                            control={form.control}
-                            name="sliderTitleUnderA"
-                            render={({ field }) => (
-                              <FormItem>
-                                <FormLabel>Uitleg bij A</FormLabel>
-                                <FormControl>
-                                  <Input {...field} />
-                                </FormControl>
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-
-                          <FormField
-                            control={form.control}
-                            name="sliderTitleUnderB"
-                            render={({ field }) => (
-                              <FormItem>
-                                <FormLabel>Uitleg bij B</FormLabel>
-                                <FormControl>
-                                  <Input {...field} />
-                                </FormControl>
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-
-                          <FormField
-                            control={form.control}
-                            name="explanationA"
-                            render={({ field }) => (
-                              <FormItem>
-                                <FormLabel>Label onder slider A</FormLabel>
-                                <FormControl>
-                                  <Input {...field} />
-                                </FormControl>
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-
-                          <FormField
-                            control={form.control}
-                            name="explanationB"
-                            render={({ field }) => (
-                              <FormItem>
-                                <FormLabel>Label onder slider B</FormLabel>
-                                <FormControl>
-                                  <Input {...field} />
-                                </FormControl>
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-
-                          <div className="col-span-full md:col-span-1 flex flex-col">
-                            <ImageUploader
-                              form={form}
-                              project={project as string}
-                              imageLabel="Upload hier afbeelding A"
-                              fieldName="imageUploadA"
-                              allowedTypes={['image/*']}
-                              onImageUploaded={(imageResult) => {
-                                const result =
-                                  typeof imageResult.url !== 'undefined'
-                                    ? imageResult.url
-                                    : '';
-                                form.setValue('imageA', result);
-                                form.resetField('imageUploadA');
-                              }}
-                            />
-                          </div>
-
-                          <div className="col-span-full md:col-span-1 flex flex-col">
-                            <ImageUploader
-                              form={form}
-                              project={project as string}
-                              imageLabel="Upload hier afbeelding B"
-                              fieldName="imageUploadB"
-                              allowedTypes={['image/*']}
-                              onImageUploaded={(imageResult) => {
-                                const result =
-                                  typeof imageResult.url !== 'undefined'
-                                    ? imageResult.url
-                                    : '';
-                                form.setValue('imageB', result);
-                                form.resetField('imageUploadB');
-                              }}
-                            />
-                          </div>
-
-                          <div className="col-span-full md:col-span-1 flex flex-col my-2">
-                            {!!form.watch('imageA') && (
-                              <>
-                                <label className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-                                  Afbeelding A
-                                </label>
-                                <section className="grid col-span-full grid-cols-3 gap-x-4 gap-y-8 ">
-                                  <div style={{ position: 'relative' }}>
-                                    <img
-                                      src={form.watch('imageA')}
-                                      alt={form.watch('imageA')}
-                                    />
-                                    <Button
-                                      color="red"
-                                      onClick={() => {
-                                        form.setValue('imageA', '');
-                                      }}
-                                      style={{
-                                        position: 'absolute',
-                                        right: 0,
-                                        top: 0,
-                                      }}>
-                                      <X size={24} />
-                                    </Button>
-                                  </div>
-                                </section>
-                              </>
-                            )}
-                          </div>
-
-                          <div className="col-span-full md:col-span-1 flex flex-col my-2">
-                            {!!form.watch('imageB') && (
-                              <>
-                                <label className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-                                  Afbeelding B
-                                </label>
-                                <section className="grid col-span-full grid-cols-3 gap-x-4 gap-y-8 ">
-                                  <div style={{ position: 'relative' }}>
-                                    <img
-                                      src={form.watch('imageB')}
-                                      alt={form.watch('imageB')}
-                                    />
-                                    <Button
-                                      color="red"
-                                      onClick={() => {
-                                        form.setValue('imageB', '');
-                                      }}
-                                      style={{
-                                        position: 'absolute',
-                                        right: 0,
-                                        top: 0,
-                                      }}>
-                                      <X size={24} />
-                                    </Button>
-                                  </div>
-                                </section>
-                              </>
-                            )}
-                          </div>
-
-                          <div className="col-span-full md:col-span-1 flex flex-col gap-y-4 mb-4">
                             <FormField
                               control={form.control}
-                              name="skipQuestion"
+                              name="createImageSlider"
                               render={({ field }) => (
                                 <FormItem>
                                   <FormLabel>
-                                    Mogelijkheid om deze vraag over te slaan?
+                                    Wil je van de afbeeldingen een slider maken?
                                   </FormLabel>
-                                  <FormDescription>
-                                    Als je wil dat de gebruiker de vraag kan
-                                    overslaan, selecteer dan &apos;Ja&apos;. Als
-                                    de gebruiker de vraag overslaat, wordt de
-                                    vraag niet meegenomen in de weging.
-                                  </FormDescription>
                                   <Select
                                     onValueChange={(e: string) =>
                                       field.onChange(e === 'true')
@@ -2217,7 +1821,136 @@ export default function WidgetChoiceGuideItems(
                                     value={field.value ? 'true' : 'false'}>
                                     <FormControl>
                                       <SelectTrigger>
-                                        <SelectValue placeholder="Nee" />
+                                        <SelectValue placeholder="Kies een optie" />
+                                      </SelectTrigger>
+                                    </FormControl>
+                                    <SelectContent>
+                                      <SelectItem value="false">Nee</SelectItem>
+                                      <SelectItem value="true">Ja</SelectItem>
+                                    </SelectContent>
+                                  </Select>
+                                  <FormMessage />
+                                </FormItem>
+                              )}
+                            />
+
+                            <FormField
+                              control={form.control}
+                              name="imageClickable"
+                              render={({ field }) => (
+                                <FormItem>
+                                  <FormLabel>
+                                    Moeten de afbeeldingen uitvergroot worden
+                                    als erop geklikt wordt?
+                                  </FormLabel>
+                                  <Select
+                                    onValueChange={(e: string) =>
+                                      field.onChange(e === 'true')
+                                    }
+                                    value={field.value ? 'true' : 'false'}>
+                                    <FormControl>
+                                      <SelectTrigger>
+                                        <SelectValue placeholder="Kies een optie" />
+                                      </SelectTrigger>
+                                    </FormControl>
+                                    <SelectContent>
+                                      <SelectItem value="false">Nee</SelectItem>
+                                      <SelectItem value="true">Ja</SelectItem>
+                                    </SelectContent>
+                                  </Select>
+                                  <FormMessage />
+                                </FormItem>
+                              )}
+                            />
+                          </>
+
+                          <FormField
+                            control={form.control}
+                            name="showMoreInfo"
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormLabel>Extra info</FormLabel>
+                                <FormDescription>
+                                  Wil je een blok met uitklapbare tekst
+                                  toevoegen? (bijvoorbeeld met extra uitleg)
+                                </FormDescription>
+                                <Select
+                                  onValueChange={(e: string) =>
+                                    field.onChange(e === 'true')
+                                  }
+                                  value={field.value ? 'true' : 'false'}>
+                                  <FormControl>
+                                    <SelectTrigger>
+                                      <SelectValue placeholder="Kies een optie" />
+                                    </SelectTrigger>
+                                  </FormControl>
+                                  <SelectContent>
+                                    <SelectItem value="true">Ja</SelectItem>
+                                    <SelectItem value="false">Nee</SelectItem>
+                                  </SelectContent>
+                                </Select>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
+
+                          {form.watch('showMoreInfo') && (
+                            <>
+                              <FormField
+                                control={form.control}
+                                name="moreInfoButton"
+                                render={({ field }) => (
+                                  <FormItem>
+                                    <FormLabel>
+                                      Meer informatie knop tekst
+                                    </FormLabel>
+                                    <Input {...field} />
+                                    <FormMessage />
+                                  </FormItem>
+                                )}
+                              />
+
+                              <FormField
+                                control={form.control}
+                                name="moreInfoContent"
+                                render={({ field }) => (
+                                  <FormItem>
+                                    <FormLabel>Meer informatie tekst</FormLabel>
+                                    <Textarea rows={5} {...field} />
+                                    <FormMessage />
+                                  </FormItem>
+                                )}
+                              />
+                            </>
+                          )}
+
+                          {!['none', 'a-b-slider', 'sort', 'scale'].includes(
+                            form.watch('type') || ''
+                          ) && (
+                            <FormField
+                              control={form.control}
+                              name="fieldRequired"
+                              render={({ field }) => (
+                                <FormItem>
+                                  <FormLabel>Is dit veld verplicht?</FormLabel>
+                                  {form.watch('type') === 'matrix' && (
+                                    <FormDescription>
+                                      Als je het veld <b>verplicht</b> maakt
+                                      moeten gebruikers bij elke rij een
+                                      antwoord selecteren. Als je het veld{' '}
+                                      <b>niet verplicht</b> maakt kunnen
+                                      gebruikers elke rij overslaan en invullen
+                                      wat ze willen.
+                                    </FormDescription>
+                                  )}
+                                  <Select
+                                    onValueChange={(e: string) =>
+                                      field.onChange(e === 'true')
+                                    }
+                                    value={field.value ? 'true' : 'false'}>
+                                    <FormControl>
+                                      <SelectTrigger>
+                                        <SelectValue placeholder="Kies een optie" />
                                       </SelectTrigger>
                                     </FormControl>
                                     <SelectContent>
@@ -2229,33 +1962,356 @@ export default function WidgetChoiceGuideItems(
                                 </FormItem>
                               )}
                             />
-
-                            {form.watch('skipQuestion') && (
-                              <>
-                                <FormField
-                                  control={form.control}
-                                  name="skipQuestionLabel"
-                                  render={({ field }) => (
-                                    <FormItem>
-                                      <FormLabel>
-                                        Tekst bij de checkbox voor het overslaan
-                                      </FormLabel>
+                          )}
+                          {form.watch('type') === 'text' && (
+                            <>
+                              <FormField
+                                control={form.control}
+                                name="variant"
+                                render={({ field }) => (
+                                  <FormItem>
+                                    <FormLabel>
+                                      Is het veld qua grootte 1 regel of een
+                                      tekstvak?
+                                    </FormLabel>
+                                    <Select
+                                      value={field.value || 'text input'}
+                                      onValueChange={field.onChange}>
                                       <FormControl>
-                                        <Input {...field} />
+                                        <SelectTrigger>
+                                          <SelectValue placeholder="Kies een optie" />
+                                        </SelectTrigger>
                                       </FormControl>
-                                      <FormMessage />
-                                    </FormItem>
+                                      <SelectContent>
+                                        <SelectItem value="text input">
+                                          1 regel
+                                        </SelectItem>
+                                        <SelectItem value="textarea">
+                                          Tekstvak
+                                        </SelectItem>
+                                      </SelectContent>
+                                    </Select>
+                                    <FormMessage />
+                                  </FormItem>
+                                )}
+                              />
+
+                              <FormField
+                                control={form.control}
+                                name="placeholder"
+                                render={({ field }) => (
+                                  <FormItem>
+                                    <FormLabel>Placeholder</FormLabel>
+                                    <Input {...field} />
+                                    <FormMessage />
+                                  </FormItem>
+                                )}
+                              />
+
+                              <FormField
+                                control={form.control}
+                                name="minCharacters"
+                                render={({ field }) => (
+                                  <FormItem>
+                                    <FormLabel>
+                                      Minimaal aantal tekens
+                                    </FormLabel>
+                                    <Input {...field} />
+                                    <FormMessage />
+                                  </FormItem>
+                                )}
+                              />
+
+                              <FormField
+                                control={form.control}
+                                name="maxCharacters"
+                                render={({ field }) => (
+                                  <FormItem>
+                                    <FormLabel>
+                                      Maximaal aantal tekens
+                                    </FormLabel>
+                                    <Input {...field} />
+                                    <FormMessage />
+                                  </FormItem>
+                                )}
+                              />
+                            </>
+                          )}
+
+                          {form.watch('type') === 'matrix' && (
+                            <FormField
+                              control={form.control}
+                              name="matrixMultiple"
+                              render={({ field }) => (
+                                <FormItem>
+                                  <FormLabel>
+                                    Mogen er meerdere antwoorden per rij worden
+                                    geselecteerd?
+                                  </FormLabel>
+                                  <Select
+                                    onValueChange={(e: string) =>
+                                      field.onChange(e === 'true')
+                                    }
+                                    value={field.value ? 'true' : 'false'}>
+                                    <FormControl>
+                                      <SelectTrigger>
+                                        <SelectValue placeholder="Kies een optie" />
+                                      </SelectTrigger>
+                                    </FormControl>
+                                    <SelectContent>
+                                      <SelectItem value="false">Nee</SelectItem>
+                                      <SelectItem value="true">Ja</SelectItem>
+                                    </SelectContent>
+                                  </Select>
+                                  <FormMessage />
+                                </FormItem>
+                              )}
+                            />
+                          )}
+
+                          {(form.watch('type') === 'imageUpload' ||
+                            form.watch('type') === 'images' ||
+                            form.watch('type') === 'documentUpload') && (
+                            <FormField
+                              control={form.control}
+                              name="multiple"
+                              render={({ field }) => (
+                                <FormItem>
+                                  {form.watch('type') === 'imageUpload' ||
+                                  form.watch('type') === 'documentUpload' ? (
+                                    <FormLabel>
+                                      Mogen er meerdere{' '}
+                                      {form.watch('type') === 'documentUpload'
+                                        ? 'documenten'
+                                        : 'afbeeldingen'}{' '}
+                                      tegelijkertijd geüpload worden?
+                                    </FormLabel>
+                                  ) : (
+                                    <FormLabel>
+                                      Mogen er meerdere afbeeldingen
+                                      geselecteerd worden?
+                                    </FormLabel>
                                   )}
+                                  <Select
+                                    onValueChange={(e: string) =>
+                                      field.onChange(e === 'true')
+                                    }
+                                    value={field.value ? 'true' : 'false'}>
+                                    <FormControl>
+                                      <SelectTrigger>
+                                        <SelectValue placeholder="Kies een optie" />
+                                      </SelectTrigger>
+                                    </FormControl>
+                                    <SelectContent>
+                                      <SelectItem value="true">Ja</SelectItem>
+                                      <SelectItem value="false">Nee</SelectItem>
+                                    </SelectContent>
+                                  </Select>
+                                  <FormMessage />
+                                </FormItem>
+                              )}
+                            />
+                          )}
+
+                          {form.watch('type') === 'a-b-slider' && (
+                            <div className="col-span-full grid-cols-2 grid gap-4 gap-y-4">
+                              <FormField
+                                control={form.control}
+                                name="labelA"
+                                render={({ field }) => (
+                                  <FormItem>
+                                    <FormLabel>Label voor A</FormLabel>
+                                    <FormControl>
+                                      <Input {...field} />
+                                    </FormControl>
+                                    <FormMessage />
+                                  </FormItem>
+                                )}
+                              />
+
+                              <FormField
+                                control={form.control}
+                                name="labelB"
+                                render={({ field }) => (
+                                  <FormItem>
+                                    <FormLabel>Label voor B</FormLabel>
+                                    <FormControl>
+                                      <Input {...field} />
+                                    </FormControl>
+                                    <FormMessage />
+                                  </FormItem>
+                                )}
+                              />
+
+                              <FormField
+                                control={form.control}
+                                name="sliderTitleUnderA"
+                                render={({ field }) => (
+                                  <FormItem>
+                                    <FormLabel>Uitleg bij A</FormLabel>
+                                    <FormControl>
+                                      <Input {...field} />
+                                    </FormControl>
+                                    <FormMessage />
+                                  </FormItem>
+                                )}
+                              />
+
+                              <FormField
+                                control={form.control}
+                                name="sliderTitleUnderB"
+                                render={({ field }) => (
+                                  <FormItem>
+                                    <FormLabel>Uitleg bij B</FormLabel>
+                                    <FormControl>
+                                      <Input {...field} />
+                                    </FormControl>
+                                    <FormMessage />
+                                  </FormItem>
+                                )}
+                              />
+
+                              <FormField
+                                control={form.control}
+                                name="explanationA"
+                                render={({ field }) => (
+                                  <FormItem>
+                                    <FormLabel>Label onder slider A</FormLabel>
+                                    <FormControl>
+                                      <Input {...field} />
+                                    </FormControl>
+                                    <FormMessage />
+                                  </FormItem>
+                                )}
+                              />
+
+                              <FormField
+                                control={form.control}
+                                name="explanationB"
+                                render={({ field }) => (
+                                  <FormItem>
+                                    <FormLabel>Label onder slider B</FormLabel>
+                                    <FormControl>
+                                      <Input {...field} />
+                                    </FormControl>
+                                    <FormMessage />
+                                  </FormItem>
+                                )}
+                              />
+
+                              <div className="col-span-full md:col-span-1 flex flex-col">
+                                <ImageUploader
+                                  form={form}
+                                  project={project as string}
+                                  imageLabel="Upload hier afbeelding A"
+                                  fieldName="imageUploadA"
+                                  allowedTypes={['image/*']}
+                                  onImageUploaded={(imageResult) => {
+                                    const result =
+                                      typeof imageResult.url !== 'undefined'
+                                        ? imageResult.url
+                                        : '';
+                                    form.setValue('imageA', result);
+                                    form.resetField('imageUploadA');
+                                  }}
                                 />
+                              </div>
+
+                              <div className="col-span-full md:col-span-1 flex flex-col">
+                                <ImageUploader
+                                  form={form}
+                                  project={project as string}
+                                  imageLabel="Upload hier afbeelding B"
+                                  fieldName="imageUploadB"
+                                  allowedTypes={['image/*']}
+                                  onImageUploaded={(imageResult) => {
+                                    const result =
+                                      typeof imageResult.url !== 'undefined'
+                                        ? imageResult.url
+                                        : '';
+                                    form.setValue('imageB', result);
+                                    form.resetField('imageUploadB');
+                                  }}
+                                />
+                              </div>
+
+                              <div className="col-span-full md:col-span-1 flex flex-col my-2">
+                                {!!form.watch('imageA') && (
+                                  <>
+                                    <label className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+                                      Afbeelding A
+                                    </label>
+                                    <section className="grid col-span-full grid-cols-3 gap-x-4 gap-y-8 ">
+                                      <div style={{ position: 'relative' }}>
+                                        <img
+                                          src={form.watch('imageA')}
+                                          alt={form.watch('imageA')}
+                                        />
+                                        <Button
+                                          color="red"
+                                          onClick={() => {
+                                            form.setValue('imageA', '');
+                                          }}
+                                          style={{
+                                            position: 'absolute',
+                                            right: 0,
+                                            top: 0,
+                                          }}>
+                                          <X size={24} />
+                                        </Button>
+                                      </div>
+                                    </section>
+                                  </>
+                                )}
+                              </div>
+
+                              <div className="col-span-full md:col-span-1 flex flex-col my-2">
+                                {!!form.watch('imageB') && (
+                                  <>
+                                    <label className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+                                      Afbeelding B
+                                    </label>
+                                    <section className="grid col-span-full grid-cols-3 gap-x-4 gap-y-8 ">
+                                      <div style={{ position: 'relative' }}>
+                                        <img
+                                          src={form.watch('imageB')}
+                                          alt={form.watch('imageB')}
+                                        />
+                                        <Button
+                                          color="red"
+                                          onClick={() => {
+                                            form.setValue('imageB', '');
+                                          }}
+                                          style={{
+                                            position: 'absolute',
+                                            right: 0,
+                                            top: 0,
+                                          }}>
+                                          <X size={24} />
+                                        </Button>
+                                      </div>
+                                    </section>
+                                  </>
+                                )}
+                              </div>
+
+                              <div className="col-span-full md:col-span-1 flex flex-col gap-y-4 mb-4">
                                 <FormField
                                   control={form.control}
-                                  name="skipQuestionAllowExplanation"
+                                  name="skipQuestion"
                                   render={({ field }) => (
                                     <FormItem>
                                       <FormLabel>
-                                        Mogelijkheid voor de gebruiker om
-                                        toelichting te geven voor het overslaan?
+                                        Mogelijkheid om deze vraag over te
+                                        slaan?
                                       </FormLabel>
+                                      <FormDescription>
+                                        Als je wil dat de gebruiker de vraag kan
+                                        overslaan, selecteer dan &apos;Ja&apos;.
+                                        Als de gebruiker de vraag overslaat,
+                                        wordt de vraag niet meegenomen in de
+                                        weging.
+                                      </FormDescription>
                                       <Select
                                         onValueChange={(e: string) =>
                                           field.onChange(e === 'true')
@@ -2280,250 +2336,349 @@ export default function WidgetChoiceGuideItems(
                                   )}
                                 />
 
-                                {form.watch('skipQuestionAllowExplanation') && (
-                                  <FormField
-                                    control={form.control}
-                                    name="skipQuestionExplanation"
-                                    render={({ field }) => (
-                                      <FormItem>
-                                        <FormLabel>
-                                          Titel boven het tekstveld van de
-                                          toelichting
-                                        </FormLabel>
-                                        <FormControl>
-                                          <Input {...field} />
-                                        </FormControl>
-                                        <FormMessage />
-                                      </FormItem>
-                                    )}
-                                  />
-                                )}
-                              </>
-                            )}
-                          </div>
-                        </div>
-                      )}
+                                {form.watch('skipQuestion') && (
+                                  <>
+                                    <FormField
+                                      control={form.control}
+                                      name="skipQuestionLabel"
+                                      render={({ field }) => (
+                                        <FormItem>
+                                          <FormLabel>
+                                            Tekst bij de checkbox voor het
+                                            overslaan
+                                          </FormLabel>
+                                          <FormControl>
+                                            <Input {...field} />
+                                          </FormControl>
+                                          <FormMessage />
+                                        </FormItem>
+                                      )}
+                                    />
+                                    <FormField
+                                      control={form.control}
+                                      name="skipQuestionAllowExplanation"
+                                      render={({ field }) => (
+                                        <FormItem>
+                                          <FormLabel>
+                                            Mogelijkheid voor de gebruiker om
+                                            toelichting te geven voor het
+                                            overslaan?
+                                          </FormLabel>
+                                          <Select
+                                            onValueChange={(e: string) =>
+                                              field.onChange(e === 'true')
+                                            }
+                                            value={
+                                              field.value ? 'true' : 'false'
+                                            }>
+                                            <FormControl>
+                                              <SelectTrigger>
+                                                <SelectValue placeholder="Nee" />
+                                              </SelectTrigger>
+                                            </FormControl>
+                                            <SelectContent>
+                                              <SelectItem value="true">
+                                                Ja
+                                              </SelectItem>
+                                              <SelectItem value="false">
+                                                Nee
+                                              </SelectItem>
+                                            </SelectContent>
+                                          </Select>
+                                          <FormMessage />
+                                        </FormItem>
+                                      )}
+                                    />
 
-                      {form.watch('type') === 'text' && (
-                        <FormField
-                          control={form.control}
-                          name="defaultValue"
-                          render={({ field }) => (
-                            <FormItem>
-                              <FormLabel>Standaard ingevulde waarde</FormLabel>
-                              <Input {...field} />
-                              <FormMessage />
-                            </FormItem>
-                          )}
-                        />
-                      )}
-
-                      {(form.watch('type') === 'checkbox' ||
-                        (form.watch('type') === 'images' &&
-                          form.watch('multiple'))) && (
-                        <>
-                          <FormField
-                            control={form.control}
-                            name="maxChoices"
-                            render={({ field }) => (
-                              <FormItem>
-                                <FormLabel>
-                                  Maximaal te selecteren opties
-                                </FormLabel>
-                                <FormDescription>
-                                  <em className="text-xs">
-                                    Als je wilt dat er maximaal een aantal
-                                    opties geselecteerd kunnen worden, vul dan
-                                    hier het aantal in.
-                                  </em>
-                                </FormDescription>
-                                <Input {...field} />
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-                          <FormField
-                            control={form.control}
-                            name="maxChoicesMessage"
-                            render={({ field }) => (
-                              <FormItem>
-                                <FormLabel>
-                                  Maximaal aantal bereikt melding
-                                </FormLabel>
-                                <FormDescription>
-                                  <em className="text-xs">
-                                    Als het maximaal aantal opties is
-                                    geselecteerd, geef dan een melding aan de
-                                    gebruiker. Dit is optioneel.
-                                  </em>
-                                </FormDescription>
-                                <Input {...field} />
-                                <FormMessage />
-                              </FormItem>
-                            )}
-                          />
-                        </>
-                      )}
-
-                      <FormField
-                        control={form.control}
-                        name="routingInitiallyHide"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>
-                              Is deze vraag altijd zichtbaar?
-                            </FormLabel>
-                            <Select
-                              onValueChange={(e: string) =>
-                                field.onChange(e === 'true')
-                              }
-                              value={field.value ? 'true' : 'false'}>
-                              <FormControl>
-                                <SelectTrigger>
-                                  <SelectValue placeholder="Kies een optie" />
-                                </SelectTrigger>
-                              </FormControl>
-                              <SelectContent>
-                                {/* True and false are deliberately switched */}
-                                <SelectItem value="true">Nee</SelectItem>
-                                <SelectItem value="false">Ja</SelectItem>
-                              </SelectContent>
-                            </Select>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
-
-                      {form.watch('routingInitiallyHide') && (
-                        <>
-                          <FormField
-                            control={form.control}
-                            name="routingSelectedQuestion"
-                            render={({ field }) => {
-                              const formFields = items || [];
-                              let formMultipleChoiceFields = formFields.filter(
-                                (f: any) =>
-                                  (f.type === 'select' ||
-                                    f.type === 'radiobox' ||
-                                    f.type === 'images' ||
-                                    f.type === 'checkbox') &&
-                                  f.trigger !== form.watch('trigger')
-                              );
-
-                              return (
-                                <FormItem>
-                                  <FormLabel>
-                                    Welke vraag beïnvloedt de zichtbaarheid van
-                                    deze vraag?
-                                  </FormLabel>
-
-                                  {formMultipleChoiceFields.length === 0 ? (
-                                    <p
-                                      className="text-sm"
-                                      style={{
-                                        padding: '11px',
-                                        borderLeft: '4px solid red',
-                                        backgroundColor: '#ffdbd7',
-                                        borderTopRightRadius: '5px',
-                                        borderBottomRightRadius: '5px',
-                                        marginTop: '12px',
-                                      }}>
-                                      Je hebt nog geen meerkeuze, enkele keuze
-                                      of afbeelding keuze vragen toegevoegd.
-                                      Voeg deze eerst toe om deze vraag te
-                                      kunnen tonen op basis van een ander
-                                      antwoord.
-                                    </p>
-                                  ) : (
-                                    <Select
-                                      value={field.value}
-                                      onValueChange={field.onChange}>
-                                      <FormControl>
-                                        <SelectTrigger>
-                                          <SelectValue placeholder="Kies een vraag" />
-                                        </SelectTrigger>
-                                      </FormControl>
-                                      <SelectContent>
-                                        {formMultipleChoiceFields.map(
-                                          (f: any) => (
-                                            <SelectItem
-                                              key={f.trigger}
-                                              value={f.trigger}>
-                                              {f.title || f.fieldKey}
-                                            </SelectItem>
-                                          )
+                                    {form.watch(
+                                      'skipQuestionAllowExplanation'
+                                    ) && (
+                                      <FormField
+                                        control={form.control}
+                                        name="skipQuestionExplanation"
+                                        render={({ field }) => (
+                                          <FormItem>
+                                            <FormLabel>
+                                              Titel boven het tekstveld van de
+                                              toelichting
+                                            </FormLabel>
+                                            <FormControl>
+                                              <Input {...field} />
+                                            </FormControl>
+                                            <FormMessage />
+                                          </FormItem>
                                         )}
-                                      </SelectContent>
-                                    </Select>
-                                  )}
+                                      />
+                                    )}
+                                  </>
+                                )}
+                              </div>
+                            </div>
+                          )}
 
-                                  <FormMessage />
-                                </FormItem>
-                              );
-                            }}
-                          />
-
-                          {form.watch('routingSelectedQuestion') !== '' && (
+                          {form.watch('type') === 'text' && (
                             <FormField
                               control={form.control}
-                              name="routingSelectedAnswer"
-                              render={({ field }) => {
-                                const selectedQuestion = items?.find(
-                                  (i: any) =>
-                                    i.trigger ===
-                                    form.watch('routingSelectedQuestion')
-                                );
-                                const options = selectedQuestion?.options || [];
+                              name="defaultValue"
+                              render={({ field }) => (
+                                <FormItem>
+                                  <FormLabel>
+                                    Standaard ingevulde waarde
+                                  </FormLabel>
+                                  <Input {...field} />
+                                  <FormMessage />
+                                </FormItem>
+                              )}
+                            />
+                          )}
 
-                                return (
+                          {(form.watch('type') === 'checkbox' ||
+                            (form.watch('type') === 'images' &&
+                              form.watch('multiple'))) && (
+                            <>
+                              <FormField
+                                control={form.control}
+                                name="maxChoices"
+                                render={({ field }) => (
                                   <FormItem>
                                     <FormLabel>
-                                      Bij welk antwoord moet deze vraag getoond
-                                      worden?
+                                      Maximaal te selecteren opties
                                     </FormLabel>
-
-                                    {options.length === 0 ? (
-                                      <p
-                                        className="text-sm"
-                                        style={{
-                                          padding: '11px',
-                                          borderLeft: '4px solid red',
-                                          backgroundColor: '#ffdbd7',
-                                          borderTopRightRadius: '5px',
-                                          borderBottomRightRadius: '5px',
-                                          marginTop: '12px',
-                                        }}>
-                                        De geselecteerde vraag heeft nog geen
-                                        antwoordopties. Voeg deze eerst toe om
-                                        deze vraag te kunnen tonen op basis van
-                                        een ander antwoord.
-                                      </p>
-                                    ) : (
-                                      <Select
-                                        value={field.value}
-                                        onValueChange={field.onChange}>
-                                        <FormControl>
-                                          <SelectTrigger>
-                                            <SelectValue placeholder="Kies een antwoord" />
-                                          </SelectTrigger>
-                                        </FormControl>
-                                        <SelectContent>
-                                          {options.map((o: any) => (
-                                            <SelectItem
-                                              key={o.trigger}
-                                              value={o.trigger}>
-                                              {o.titles?.[0]?.key || o.trigger}
-                                            </SelectItem>
-                                          ))}
-                                        </SelectContent>
-                                      </Select>
-                                    )}
-
+                                    <FormDescription>
+                                      <em className="text-xs">
+                                        Als je wilt dat er maximaal een aantal
+                                        opties geselecteerd kunnen worden, vul
+                                        dan hier het aantal in.
+                                      </em>
+                                    </FormDescription>
+                                    <Input {...field} />
                                     <FormMessage />
                                   </FormItem>
-                                );
-                              }}
-                            />
+                                )}
+                              />
+                              <FormField
+                                control={form.control}
+                                name="maxChoicesMessage"
+                                render={({ field }) => (
+                                  <FormItem>
+                                    <FormLabel>
+                                      Maximaal aantal bereikt melding
+                                    </FormLabel>
+                                    <FormDescription>
+                                      <em className="text-xs">
+                                        Als het maximaal aantal opties is
+                                        geselecteerd, geef dan een melding aan
+                                        de gebruiker. Dit is optioneel.
+                                      </em>
+                                    </FormDescription>
+                                    <Input {...field} />
+                                    <FormMessage />
+                                  </FormItem>
+                                )}
+                              />
+                            </>
+                          )}
+
+                          <FormField
+                            control={form.control}
+                            name="routingInitiallyHide"
+                            render={({ field }) => (
+                              <FormItem>
+                                <FormLabel>
+                                  Is deze vraag altijd zichtbaar?
+                                </FormLabel>
+                                <Select
+                                  onValueChange={(e: string) =>
+                                    field.onChange(e === 'true')
+                                  }
+                                  value={field.value ? 'true' : 'false'}>
+                                  <FormControl>
+                                    <SelectTrigger>
+                                      <SelectValue placeholder="Kies een optie" />
+                                    </SelectTrigger>
+                                  </FormControl>
+                                  <SelectContent>
+                                    {/* True and false are deliberately switched */}
+                                    <SelectItem value="true">Nee</SelectItem>
+                                    <SelectItem value="false">Ja</SelectItem>
+                                  </SelectContent>
+                                </Select>
+                                <FormMessage />
+                              </FormItem>
+                            )}
+                          />
+
+                          {form.watch('routingInitiallyHide') && (
+                            <>
+                              <FormField
+                                control={form.control}
+                                name="routingSelectedQuestion"
+                                render={({ field }) => {
+                                  const formFields = items || [];
+                                  let formMultipleChoiceFields =
+                                    formFields.filter(
+                                      (f: any) =>
+                                        (f.type === 'select' ||
+                                          f.type === 'radiobox' ||
+                                          f.type === 'images' ||
+                                          f.type === 'checkbox') &&
+                                        f.trigger !== form.watch('trigger')
+                                    );
+
+                                  return (
+                                    <FormItem>
+                                      <FormLabel>
+                                        Welke vraag beïnvloedt de zichtbaarheid
+                                        van deze vraag?
+                                      </FormLabel>
+
+                                      {formMultipleChoiceFields.length === 0 ? (
+                                        <p
+                                          className="text-sm"
+                                          style={{
+                                            padding: '11px',
+                                            borderLeft: '4px solid red',
+                                            backgroundColor: '#ffdbd7',
+                                            borderTopRightRadius: '5px',
+                                            borderBottomRightRadius: '5px',
+                                            marginTop: '12px',
+                                          }}>
+                                          Je hebt nog geen meerkeuze, enkele
+                                          keuze of afbeelding keuze vragen
+                                          toegevoegd. Voeg deze eerst toe om
+                                          deze vraag te kunnen tonen op basis
+                                          van een ander antwoord.
+                                        </p>
+                                      ) : (
+                                        <Select
+                                          value={field.value}
+                                          onValueChange={(value) => {
+                                            field.onChange(value);
+                                            form.setValue(
+                                              'routingSelectedAnswer',
+                                              []
+                                            );
+                                          }}>
+                                          <FormControl>
+                                            <SelectTrigger>
+                                              <SelectValue placeholder="Kies een vraag" />
+                                            </SelectTrigger>
+                                          </FormControl>
+                                          <SelectContent>
+                                            {formMultipleChoiceFields.map(
+                                              (f: any) => (
+                                                <SelectItem
+                                                  key={f.trigger}
+                                                  value={f.trigger}>
+                                                  {f.title || f.fieldKey}
+                                                </SelectItem>
+                                              )
+                                            )}
+                                          </SelectContent>
+                                        </Select>
+                                      )}
+
+                                      <FormMessage />
+                                    </FormItem>
+                                  );
+                                }}
+                              />
+
+                              {form.watch('routingSelectedQuestion') !== '' && (
+                                <FormField
+                                  control={form.control}
+                                  name="routingSelectedAnswer"
+                                  render={({ field }) => {
+                                    const selectedQuestion = items?.find(
+                                      (i: any) =>
+                                        i.trigger ===
+                                        form.watch('routingSelectedQuestion')
+                                    );
+                                    const options =
+                                      selectedQuestion?.options || [];
+
+                                    const optionTriggers = options.map(
+                                      (o: any) => o.trigger
+                                    );
+                                    const rawValues = Array.isArray(field.value)
+                                      ? field.value
+                                      : field.value
+                                        ? [field.value]
+                                        : [];
+                                    const selectedValues = rawValues.filter(
+                                      (v: string) => optionTriggers.includes(v)
+                                    );
+
+                                    if (
+                                      selectedValues.length !== rawValues.length
+                                    ) {
+                                      field.onChange(selectedValues);
+                                    }
+
+                                    const toggleValue = (trigger: string) => {
+                                      const next = selectedValues.includes(
+                                        trigger
+                                      )
+                                        ? selectedValues.filter(
+                                            (v: string) => v !== trigger
+                                          )
+                                        : [...selectedValues, trigger];
+                                      field.onChange(next);
+                                    };
+
+                                    return (
+                                      <FormItem>
+                                        <FormLabel>
+                                          Bij welk antwoord moet deze vraag
+                                          getoond worden?
+                                        </FormLabel>
+
+                                        {options.length === 0 ? (
+                                          <p
+                                            className="text-sm"
+                                            style={{
+                                              padding: '11px',
+                                              borderLeft: '4px solid red',
+                                              backgroundColor: '#ffdbd7',
+                                              borderTopRightRadius: '5px',
+                                              borderBottomRightRadius: '5px',
+                                              marginTop: '12px',
+                                            }}>
+                                            De geselecteerde vraag heeft nog
+                                            geen antwoordopties. Voeg deze eerst
+                                            toe om deze vraag te kunnen tonen op
+                                            basis van een ander antwoord.
+                                          </p>
+                                        ) : (
+                                          <div className="flex flex-col gap-2 mt-2">
+                                            {options.map((o: any) => (
+                                              <label
+                                                key={o.trigger}
+                                                className="flex items-center gap-2 cursor-pointer">
+                                                <Checkbox
+                                                  checked={selectedValues.includes(
+                                                    o.trigger
+                                                  )}
+                                                  onCheckedChange={() =>
+                                                    toggleValue(o.trigger)
+                                                  }
+                                                />
+                                                <span className="text-sm">
+                                                  {o.titles?.[0]?.key ||
+                                                    o.trigger}
+                                                </span>
+                                              </label>
+                                            ))}
+                                          </div>
+                                        )}
+
+                                        <FormMessage />
+                                      </FormItem>
+                                    );
+                                  }}
+                                />
+                              )}
+                            </>
                           )}
                         </>
                       )}

--- a/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/items.tsx
@@ -1,6 +1,7 @@
 import ImageGalleryStyle from '@/components/image-gallery-style';
 import { ImageUploader } from '@/components/image-uploader';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   Form,
   FormControl,
@@ -125,7 +126,7 @@ const formSchema = z.object({
   matrixMultiple: z.boolean().optional(),
   routingInitiallyHide: z.boolean().optional(),
   routingSelectedQuestion: z.string().optional(),
-  routingSelectedAnswer: z.string().optional(),
+  routingSelectedAnswer: z.union([z.string(), z.array(z.string())]).optional(),
   infoBlockStyle: z.string().optional(),
   infoBlockShareButton: z.boolean().optional(),
   infoBlockExtraButton: z.string().optional(),
@@ -220,10 +221,37 @@ export default function WidgetEnqueteItems(
     }
 
     if (selectedItem) {
+      const oldOptions = selectedItem.options || [];
+      const newOptions = options || [];
+      const triggerMap: Record<string, string> = {};
+      for (let i = 0; i < Math.min(oldOptions.length, newOptions.length); i++) {
+        if (oldOptions[i].trigger !== newOptions[i].trigger) {
+          triggerMap[oldOptions[i].trigger] = newOptions[i].trigger;
+        }
+      }
+      const hasTriggerChanges = Object.keys(triggerMap).length > 0;
+
       setItems((currentItems) =>
-        currentItems.map((item) =>
-          item.trigger === selectedItem.trigger ? { ...item, ...values } : item
-        )
+        currentItems.map((item) => {
+          if (item.trigger === selectedItem.trigger) {
+            return { ...item, ...values };
+          }
+          if (
+            hasTriggerChanges &&
+            item.routingSelectedQuestion === selectedItem.trigger
+          ) {
+            const answers = Array.isArray(item.routingSelectedAnswer)
+              ? item.routingSelectedAnswer
+              : item.routingSelectedAnswer
+                ? [item.routingSelectedAnswer]
+                : [];
+            const updated = answers.map(
+              (answer) => triggerMap[answer] || answer
+            );
+            return { ...item, routingSelectedAnswer: updated };
+          }
+          return item;
+        })
       );
       setItem(null);
     } else {
@@ -573,11 +601,30 @@ export default function WidgetEnqueteItems(
   ) => {
     if (isItemAction) {
       setItems((currentItems) => {
-        return handleMovementOrDeletion(
+        const index = currentItems.findIndex(
+          (entry) => entry.trigger === clickedTrigger
+        );
+        const swapIndex = actionType === 'moveUp' ? index - 1 : index + 1;
+        const triggerA = currentItems[index]?.trigger;
+        const triggerB = currentItems[swapIndex]?.trigger;
+
+        const newItems = handleMovementOrDeletion(
           currentItems,
           actionType,
           clickedTrigger
         ) as Item[];
+
+        if (actionType !== 'delete' && triggerA && triggerB) {
+          for (const item of newItems) {
+            if (item.routingSelectedQuestion === triggerA) {
+              item.routingSelectedQuestion = triggerB;
+            } else if (item.routingSelectedQuestion === triggerB) {
+              item.routingSelectedQuestion = triggerA;
+            }
+          }
+        }
+
+        return newItems;
       });
     } else if (isMatrixAction) {
       let newMatrixOptions: Matrix;
@@ -2394,7 +2441,8 @@ export default function WidgetEnqueteItems(
                                 (f.questionType === 'multiplechoice' ||
                                   f.questionType === 'multiple' ||
                                   f.questionType === 'images' ||
-                                  f.questionType === 'select') &&
+                                  f.questionType === 'select' ||
+                                  f.questionType === 'scale') &&
                                 f.trigger !== form.watch('trigger')
                             );
 
@@ -2424,7 +2472,13 @@ export default function WidgetEnqueteItems(
                                 ) : (
                                   <Select
                                     value={field.value}
-                                    onValueChange={field.onChange}>
+                                    onValueChange={(value) => {
+                                      field.onChange(value);
+                                      form.setValue(
+                                        'routingSelectedAnswer',
+                                        []
+                                      );
+                                    }}>
                                     <FormControl>
                                       <SelectTrigger>
                                         <SelectValue placeholder="Kies een vraag" />
@@ -2460,7 +2514,40 @@ export default function WidgetEnqueteItems(
                                   i.trigger ===
                                   form.watch('routingSelectedQuestion')
                               );
-                              const options = selectedQuestion?.options || [];
+
+                              const isScale =
+                                selectedQuestion?.questionType === 'scale';
+                              const options = isScale
+                                ? [1, 2, 3, 4, 5].map((n) => ({
+                                    trigger: `scale-${n}`,
+                                    titles: [{ key: `${n}` }],
+                                  }))
+                                : selectedQuestion?.options || [];
+
+                              const optionTriggers = options.map(
+                                (o: any) => o.trigger
+                              );
+                              const rawValues = Array.isArray(field.value)
+                                ? field.value
+                                : field.value
+                                  ? [field.value]
+                                  : [];
+                              const selectedValues = rawValues.filter(
+                                (v: string) => optionTriggers.includes(v)
+                              );
+
+                              if (selectedValues.length !== rawValues.length) {
+                                field.onChange(selectedValues);
+                              }
+
+                              const toggleValue = (trigger: string) => {
+                                const next = selectedValues.includes(trigger)
+                                  ? selectedValues.filter(
+                                      (v: string) => v !== trigger
+                                    )
+                                  : [...selectedValues, trigger];
+                                field.onChange(next);
+                              };
 
                               return (
                                 <FormItem>
@@ -2486,24 +2573,25 @@ export default function WidgetEnqueteItems(
                                       een ander antwoord.
                                     </p>
                                   ) : (
-                                    <Select
-                                      value={field.value}
-                                      onValueChange={field.onChange}>
-                                      <FormControl>
-                                        <SelectTrigger>
-                                          <SelectValue placeholder="Kies een antwoord" />
-                                        </SelectTrigger>
-                                      </FormControl>
-                                      <SelectContent>
-                                        {options.map((o: any) => (
-                                          <SelectItem
-                                            key={o.trigger}
-                                            value={o.trigger}>
+                                    <div className="flex flex-col gap-2 mt-2">
+                                      {options.map((o: any) => (
+                                        <label
+                                          key={o.trigger}
+                                          className="flex items-center gap-2 cursor-pointer">
+                                          <Checkbox
+                                            checked={selectedValues.includes(
+                                              o.trigger
+                                            )}
+                                            onCheckedChange={() =>
+                                              toggleValue(o.trigger)
+                                            }
+                                          />
+                                          <span className="text-sm">
                                             {o.titles?.[0]?.key || o.trigger}
-                                          </SelectItem>
-                                        ))}
-                                      </SelectContent>
-                                    </Select>
+                                          </span>
+                                        </label>
+                                      ))}
+                                    </div>
                                   )}
 
                                   <FormMessage />

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourceform/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourceform/[id]/items.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   Form,
   FormControl,
@@ -113,7 +114,7 @@ const formSchema = z.object({
   matrixMultiple: z.boolean().optional(),
   routingInitiallyHide: z.boolean().optional(),
   routingSelectedQuestion: z.string().optional(),
-  routingSelectedAnswer: z.string().optional(),
+  routingSelectedAnswer: z.union([z.string(), z.array(z.string())]).optional(),
   selectAll: z.boolean().optional(),
   selectAllLabel: z.string().optional(),
 });
@@ -167,10 +168,37 @@ export default function WidgetResourceFormItems(
   // adds item to items array if no item is selected, otherwise updates the selected item
   async function onSubmit(values: FormData) {
     if (selectedItem) {
+      const oldOptions = selectedItem.options || [];
+      const newOptions = options || [];
+      const triggerMap: Record<string, string> = {};
+      for (let i = 0; i < Math.min(oldOptions.length, newOptions.length); i++) {
+        if (oldOptions[i].trigger !== newOptions[i].trigger) {
+          triggerMap[oldOptions[i].trigger] = newOptions[i].trigger;
+        }
+      }
+      const hasTriggerChanges = Object.keys(triggerMap).length > 0;
+
       setItems((currentItems) =>
-        currentItems.map((item) =>
-          item.trigger === selectedItem.trigger ? { ...item, ...values } : item
-        )
+        currentItems.map((item) => {
+          if (item.trigger === selectedItem.trigger) {
+            return { ...item, ...values };
+          }
+          if (
+            hasTriggerChanges &&
+            item.routingSelectedQuestion === selectedItem.trigger
+          ) {
+            const answers = Array.isArray(item.routingSelectedAnswer)
+              ? item.routingSelectedAnswer
+              : item.routingSelectedAnswer
+                ? [item.routingSelectedAnswer]
+                : [];
+            const updated = answers.map(
+              (answer) => triggerMap[answer] || answer
+            );
+            return { ...item, routingSelectedAnswer: updated };
+          }
+          return item;
+        })
       );
       setItem(null);
     } else {
@@ -442,11 +470,30 @@ export default function WidgetResourceFormItems(
   ) => {
     if (isItemAction) {
       setItems((currentItems) => {
-        return handleMovementOrDeletion(
+        const index = currentItems.findIndex(
+          (entry) => entry.trigger === clickedTrigger
+        );
+        const swapIndex = actionType === 'moveUp' ? index - 1 : index + 1;
+        const triggerA = currentItems[index]?.trigger;
+        const triggerB = currentItems[swapIndex]?.trigger;
+
+        const newItems = handleMovementOrDeletion(
           currentItems,
           actionType,
           clickedTrigger
         ) as Item[];
+
+        if (actionType !== 'delete' && triggerA && triggerB) {
+          for (const item of newItems) {
+            if (item.routingSelectedQuestion === triggerA) {
+              item.routingSelectedQuestion = triggerB;
+            } else if (item.routingSelectedQuestion === triggerB) {
+              item.routingSelectedQuestion = triggerA;
+            }
+          }
+        }
+
+        return newItems;
       });
     } else if (isMatrixAction) {
       let newMatrixOptions: Matrix;
@@ -1844,7 +1891,13 @@ export default function WidgetResourceFormItems(
                                 ) : (
                                   <Select
                                     value={field.value}
-                                    onValueChange={field.onChange}>
+                                    onValueChange={(value) => {
+                                      field.onChange(value);
+                                      form.setValue(
+                                        'routingSelectedAnswer',
+                                        []
+                                      );
+                                    }}>
                                     <FormControl>
                                       <SelectTrigger>
                                         <SelectValue placeholder="Kies een vraag" />
@@ -1894,6 +1947,31 @@ export default function WidgetResourceFormItems(
                                   }));
                               }
 
+                              const optionTriggers = options.map(
+                                (o: any) => o.trigger
+                              );
+                              const rawValues = Array.isArray(field.value)
+                                ? field.value
+                                : field.value
+                                  ? [field.value]
+                                  : [];
+                              const selectedValues = rawValues.filter(
+                                (v: string) => optionTriggers.includes(v)
+                              );
+
+                              if (selectedValues.length !== rawValues.length) {
+                                field.onChange(selectedValues);
+                              }
+
+                              const toggleValue = (trigger: string) => {
+                                const next = selectedValues.includes(trigger)
+                                  ? selectedValues.filter(
+                                      (v: string) => v !== trigger
+                                    )
+                                  : [...selectedValues, trigger];
+                                field.onChange(next);
+                              };
+
                               return (
                                 <FormItem>
                                   <FormLabel>
@@ -1918,24 +1996,25 @@ export default function WidgetResourceFormItems(
                                       een ander antwoord.
                                     </p>
                                   ) : (
-                                    <Select
-                                      value={field.value}
-                                      onValueChange={field.onChange}>
-                                      <FormControl>
-                                        <SelectTrigger>
-                                          <SelectValue placeholder="Kies een antwoord" />
-                                        </SelectTrigger>
-                                      </FormControl>
-                                      <SelectContent>
-                                        {options.map((o: any) => (
-                                          <SelectItem
-                                            key={o.trigger}
-                                            value={o.trigger}>
+                                    <div className="flex flex-col gap-2 mt-2">
+                                      {options.map((o: any) => (
+                                        <label
+                                          key={o.trigger}
+                                          className="flex items-center gap-2 cursor-pointer">
+                                          <Checkbox
+                                            checked={selectedValues.includes(
+                                              o.trigger
+                                            )}
+                                            onCheckedChange={() =>
+                                              toggleValue(o.trigger)
+                                            }
+                                          />
+                                          <span className="text-sm">
                                             {o.titles?.[0]?.key || o.trigger}
-                                          </SelectItem>
-                                        ))}
-                                      </SelectContent>
-                                    </Select>
+                                          </span>
+                                        </label>
+                                      ))}
+                                    </div>
                                   )}
 
                                   <FormMessage />

--- a/packages/choiceguide/src/choiceguide.tsx
+++ b/packages/choiceguide/src/choiceguide.tsx
@@ -62,7 +62,13 @@ function ChoiceGuide(props: ChoiceGuideProps) {
     typeof loginRequired !== 'undefined' && loginRequired;
   const showForm = onlyShowForUsers ? !!hasRole(currentUser, 'member') : true;
 
-  const formFields = InitializeFormFields(items, props, showForm);
+  const questionsPerPage = Number(noOfQuestionsToShow) || 100;
+  const formFields = InitializeFormFields(
+    items,
+    props,
+    showForm,
+    questionsPerPage
+  );
 
   const defaultAnswers = formFields.reduce((acc, item) => {
     acc[item.fieldKey] = item?.defaultValue;
@@ -162,17 +168,15 @@ function ChoiceGuide(props: ChoiceGuideProps) {
     }
   };
 
-  const questionsPerPage = Number(noOfQuestionsToShow) || 100;
-  const totalPages = Math.ceil(formFields.length / questionsPerPage);
+  const paginationFieldPositions = formFields
+    .map((field, idx) => (field.type === 'pagination' ? idx : -1))
+    .filter((idx) => idx !== -1);
 
-  const paginationFieldPositions: number[] = [];
-  for (let i = 0; i < totalPages - 1; i++) {
-    const endIndex = (i + 1) * questionsPerPage;
-    paginationFieldPositions.push(endIndex);
-  }
-
-  // Add start and end indices for slicing
-  const pageFieldStartPositions = [0, ...paginationFieldPositions];
+  const totalPages = paginationFieldPositions.length + 1;
+  const pageFieldStartPositions = [
+    0,
+    ...paginationFieldPositions.map((idx) => idx + 1),
+  ];
   const pageFieldEndPositions = [
     ...paginationFieldPositions,
     formFields.length,

--- a/packages/choiceguide/src/parts/init-fields.tsx
+++ b/packages/choiceguide/src/parts/init-fields.tsx
@@ -9,7 +9,12 @@ const getMinMaxByField = (key, data) => {
     : '';
 };
 
-export const InitializeFormFields = (items, data, showForm = true) => {
+export const InitializeFormFields = (
+  items,
+  data,
+  showForm = true,
+  questionsPerPage = 100
+) => {
   const formFields: FieldProps[] = [];
 
   if (typeof items === 'object' && items.length > 0) {
@@ -190,10 +195,35 @@ export const InitializeFormFields = (items, data, showForm = true) => {
           fieldData['matrixMultiple'] = item?.matrixMultiple || false;
           fieldData['defaultValue'] = [];
           break;
+        case 'pagination':
+          fieldData['type'] = 'pagination';
+          break;
       }
 
       formFields.push(fieldData);
     }
+  }
+
+  if (questionsPerPage < formFields.length) {
+    const result: FieldProps[] = [];
+    let count = 0;
+
+    for (const field of formFields) {
+      if (field.type === 'pagination') {
+        result.push(field);
+        count = 0;
+        continue;
+      }
+
+      if (count > 0 && count % questionsPerPage === 0) {
+        result.push({ type: 'pagination' } as any);
+      }
+
+      result.push(field);
+      count++;
+    }
+
+    return result;
   }
 
   return formFields;

--- a/packages/choiceguide/src/props.ts
+++ b/packages/choiceguide/src/props.ts
@@ -118,6 +118,8 @@ export type Item = {
   defaultValue?: string;
   maxChoices?: string;
   maxChoicesMessage?: string;
+  prevPageText?: string;
+  nextPageText?: string;
   skipQuestion?: boolean;
   skipQuestionAllowExplanation?: boolean;
   skipQuestionExplanation?: string;
@@ -126,7 +128,7 @@ export type Item = {
   matrixMultiple?: boolean;
   routingInitiallyHide?: boolean;
   routingSelectedQuestion?: string;
-  routingSelectedAnswer?: string;
+  routingSelectedAnswer?: string | string[];
   imageOptionUpload?: string;
   placeholder?: string;
   images?: Array<{

--- a/packages/enquete/src/enquete.tsx
+++ b/packages/enquete/src/enquete.tsx
@@ -517,6 +517,15 @@ function Enquete(props: EnqueteWidgetProps) {
             };
           });
 
+          fieldData['choices'] = labelOptions.map((label, index) => {
+            const currentValue = index + 1;
+            return {
+              value: currentValue.toString(),
+              label: currentValue.toString(),
+              trigger: `scale-${currentValue}`,
+            };
+          });
+
           // TickmarkSlider uses overrideDefaultValue (string) for its initial value
           if (
             draftValue !== undefined &&

--- a/packages/enquete/src/types/enquete-props.ts
+++ b/packages/enquete/src/types/enquete-props.ts
@@ -61,7 +61,7 @@ export type Item = {
   matrixMultiple?: boolean;
   routingInitiallyHide?: boolean;
   routingSelectedQuestion?: string;
-  routingSelectedAnswer?: string;
+  routingSelectedAnswer?: string | string[];
   infoField?: string;
   infofieldExplanation?: boolean;
   key_b?: string;

--- a/packages/form/src/form.tsx
+++ b/packages/form/src/form.tsx
@@ -88,7 +88,11 @@ function Form({
       if (
         field?.routingInitiallyHide &&
         field?.routingSelectedQuestion &&
-        field?.routingSelectedAnswer
+        field?.routingSelectedAnswer &&
+        !(
+          Array.isArray(field.routingSelectedAnswer) &&
+          field.routingSelectedAnswer.length === 0
+        )
       ) {
         const getRoutingSelectedQuestionField = fields.find(
           (f) => f.trigger === field.routingSelectedQuestion

--- a/packages/form/src/props.ts
+++ b/packages/form/src/props.ts
@@ -103,7 +103,7 @@ type FieldWithOptionalFields = CombinedFieldProps & {
   trigger?: string;
   routingInitiallyHide?: boolean;
   routingSelectedQuestion?: string;
-  routingSelectedAnswer?: string;
+  routingSelectedAnswer?: string | string[];
   infoBlockStyle?: string;
 };
 

--- a/packages/form/src/utils/routing.tsx
+++ b/packages/form/src/utils/routing.tsx
@@ -29,7 +29,9 @@ export const updateRouting = ({
     if (
       !field?.routingInitiallyHide ||
       !field.routingSelectedQuestion ||
-      !field.routingSelectedAnswer
+      !field.routingSelectedAnswer ||
+      (Array.isArray(field.routingSelectedAnswer) &&
+        field.routingSelectedAnswer.length === 0)
     )
       return;
 
@@ -60,21 +62,26 @@ export const updateRouting = ({
     const fieldChoices = (fieldToCheck as any)?.choices || [];
 
     type choiceType = { trigger: string; value: string };
-    const selectedOption: choiceType = fieldChoices.find(
-      (choice: choiceType) => choice.trigger === field.routingSelectedAnswer
-    );
-    const selectedOptionValue = selectedOption ? selectedOption.value : null;
+    const selectedAnswerTriggers = Array.isArray(field.routingSelectedAnswer)
+      ? field.routingSelectedAnswer
+      : [field.routingSelectedAnswer];
 
-    // This may seem a bit complex, but this way all the TypeScript warnings are gone
-    if (
-      Array.isArray(answer) &&
-      answer.length > 0 &&
-      selectedOption &&
-      selectedOptionValue !== null &&
-      (answer as string[]).includes(selectedOptionValue)
-    ) {
-      return;
-    } else if (!Array.isArray(answer) && answer === selectedOptionValue) {
+    const selectedOptionValues: string[] = selectedAnswerTriggers
+      .map((trigger) => {
+        const option: choiceType = fieldChoices.find(
+          (choice: choiceType) => choice.trigger === trigger
+        );
+        return option ? option.value : null;
+      })
+      .filter((value): value is string => value !== null);
+
+    const answerMatchesAny =
+      selectedOptionValues.length > 0 &&
+      (Array.isArray(answer)
+        ? answer.some((val) => selectedOptionValues.includes(val as string))
+        : selectedOptionValues.includes(answer as string));
+
+    if (answerMatchesAny) {
       return;
     } else {
       hiddenFields.push(fieldKeyFromFieldToHide);

--- a/packages/resource-form/src/props.ts
+++ b/packages/resource-form/src/props.ts
@@ -84,7 +84,7 @@ export type Item = {
   matrixMultiple?: boolean;
   routingInitiallyHide?: boolean;
   routingSelectedQuestion?: string;
-  routingSelectedAnswer?: string;
+  routingSelectedAnswer?: string | string[];
   selectAll?: boolean;
   selectAllLabel?: string;
 };

--- a/packages/ui/src/form-elements/matrix/matrix.css
+++ b/packages/ui/src/form-elements/matrix/matrix.css
@@ -109,7 +109,6 @@ fieldset.utrecht-form-fieldset__fieldset table.utrecht-table td {
     .utrecht-table__body
     > .utrecht-table__row
     td:first-child {
-    font-weight: bold;
     padding-top: 10px;
   }
 


### PR DESCRIPTION
Routing improvements, choiceguide pagination and matrix mobile fix

1. Matrix question type: subjects were styled with bold font-weight on mobile. Removed the bold styling so they render like regular question text.

2. Routing answer selection: changed from single-select dropdown to multi-select checkboxes. Scale (1-5) is now available as a routing trigger type. Stale answer values are cleaned up automatically and selections reset when switching the trigger question.

3. Choiceguide pagination: added a pagination question type to the question selector, similar to enquete and resourceform. 

4. Routing and reordering: routing references (`routingSelectedQuestion`) now stay correct when reordering questions. Routing answer references (`routingSelectedAnswer`) update when saving a question whose options were reordered.

All routing changes apply consistently across enquete, choiceguide and resourceform.