### PR TITLE
feat(admin,api): add PDF attachment for resource submission emails

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/settings/notifications.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/settings/notifications.tsx
@@ -21,6 +21,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Separator } from '@/components/ui/separator';
+import { Textarea } from '@/components/ui/textarea';
 import { Heading } from '@/components/ui/typography';
 import { WhitelistedEmailSelect } from '@/components/ui/whitelisted-email-select';
 import {
@@ -44,6 +45,7 @@ const formSchema = z.object({
   projectmanagerAddress: z.string().email(),
   fromName: z.string().optional(),
   sendUpdatedResourceAdminEmail: z.boolean().optional(),
+  pdfAttachmentEnabled: z.boolean().optional(),
   pdfTitle: z.string().optional(),
   pdfDescription: z.string().optional(),
 });
@@ -64,6 +66,8 @@ export default function ProjectSettingsNotifications({
         data?.emailConfig?.[category]?.projectmanagerAddress || null,
       sendUpdatedResourceAdminEmail:
         data?.emailConfig?.[category]?.sendUpdatedResourceAdminEmail || false,
+      pdfAttachmentEnabled:
+        data?.emailConfig?.[category]?.pdfAttachmentEnabled || false,
       pdfTitle: data?.emailConfig?.[category]?.pdfTitle ?? '',
       pdfDescription: data?.emailConfig?.[category]?.pdfDescription ?? '',
     }),
@@ -88,6 +92,7 @@ export default function ProjectSettingsNotifications({
           fromName: values.fromName,
           sendUpdatedResourceAdminEmail:
             values.sendUpdatedResourceAdminEmail || false,
+          pdfAttachmentEnabled: values.pdfAttachmentEnabled || false,
           pdfTitle: values.pdfTitle || '',
           pdfDescription: values.pdfDescription || '',
         },
@@ -235,6 +240,34 @@ export default function ProjectSettingsNotifications({
               <Heading size="lg">PDF bijlage instellingen</Heading>
               <FormField
                 control={form.control}
+                name="pdfAttachmentEnabled"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>PDF bijlage</FormLabel>
+                    <FormDescription>
+                      Wanneer ingeschakeld wordt er een PDF bijlage meegestuurd
+                      met de bevestigingsmail na het indienen van een inzending.
+                    </FormDescription>
+                    <FormControl>
+                      <div className="flex items-center gap-2">
+                        <Checkbox
+                          id={field.name}
+                          checked={field.value}
+                          onCheckedChange={(checked) =>
+                            field.onChange(Boolean(checked))
+                          }
+                        />
+                        <Label htmlFor={field.name} className="cursor-pointer">
+                          PDF bijlage meesturen bij bevestigingsmails
+                        </Label>
+                      </div>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
                 name="pdfTitle"
                 render={({ field }) => (
                   <FormItem>
@@ -247,7 +280,11 @@ export default function ProjectSettingsNotifications({
                       />
                     </FormLabel>
                     <FormControl>
-                      <Input placeholder="Nieuwe inzending" {...field} />
+                      <Input
+                        placeholder="Nieuwe inzending"
+                        disabled={!form.watch('pdfAttachmentEnabled')}
+                        {...field}
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -267,8 +304,9 @@ export default function ProjectSettingsNotifications({
                       />
                     </FormLabel>
                     <FormControl>
-                      <Input
+                      <Textarea
                         placeholder="Er is een nieuwe inzending ontvangen."
+                        disabled={!form.watch('pdfAttachmentEnabled')}
                         {...field}
                       />
                     </FormControl>

--- a/apps/admin-server/src/pages/projects/[project]/settings/notifications.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/settings/notifications.tsx
@@ -44,6 +44,8 @@ const formSchema = z.object({
   projectmanagerAddress: z.string().email(),
   fromName: z.string().optional(),
   sendUpdatedResourceAdminEmail: z.boolean().optional(),
+  pdfTitle: z.string().optional(),
+  pdfDescription: z.string().optional(),
 });
 
 export default function ProjectSettingsNotifications({
@@ -62,6 +64,8 @@ export default function ProjectSettingsNotifications({
         data?.emailConfig?.[category]?.projectmanagerAddress || null,
       sendUpdatedResourceAdminEmail:
         data?.emailConfig?.[category]?.sendUpdatedResourceAdminEmail || false,
+      pdfTitle: data?.emailConfig?.[category]?.pdfTitle ?? '',
+      pdfDescription: data?.emailConfig?.[category]?.pdfDescription ?? '',
     }),
     [data?.emailConfig]
   );
@@ -84,6 +88,8 @@ export default function ProjectSettingsNotifications({
           fromName: values.fromName,
           sendUpdatedResourceAdminEmail:
             values.sendUpdatedResourceAdminEmail || false,
+          pdfTitle: values.pdfTitle || '',
+          pdfDescription: values.pdfDescription || '',
         },
       });
       if (project) {
@@ -220,6 +226,51 @@ export default function ProjectSettingsNotifications({
                     </FormLabel>
                     <FormControl>
                       <Input placeholder="" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <Separator className="my-4" />
+              <Heading size="lg">PDF bijlage instellingen</Heading>
+              <FormField
+                control={form.control}
+                name="pdfTitle"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Titel van de PDF bijlage
+                      <InfoDialog
+                        content={
+                          'Deze titel wordt bovenaan de PDF weergegeven die als bijlage bij de bevestigingsmail wordt meegestuurd.'
+                        }
+                      />
+                    </FormLabel>
+                    <FormControl>
+                      <Input placeholder="Nieuwe inzending" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="pdfDescription"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Beschrijving van de PDF bijlage
+                      <InfoDialog
+                        content={
+                          'Deze beschrijving wordt onder de titel weergegeven in de PDF bijlage.'
+                        }
+                      />
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="Er is een nieuwe inzending ontvangen."
+                        {...field}
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/apps/api-server/src/models/Notification.js
+++ b/apps/api-server/src/models/Notification.js
@@ -300,20 +300,109 @@ module.exports = (db, sequelize, DataTypes) => {
                   </mj-table>
                 `;
 
-                  // Generate PDF attachment if configured
+                  // Generate PDF attachment for user notifications only
+                  const userNotificationTypes = [
+                    'new concept resource - user feedback',
+                    'new published resource - user feedback',
+                    'updated resource - user feedback',
+                  ];
                   if (
                     process.env.PDF_API_ENDPOINT &&
                     process.env.PDF_API_KEY &&
-                    questionsAndAnswers.length > 0
+                    questionsAndAnswers.length > 0 &&
+                    userNotificationTypes.includes(instance.type)
                   ) {
                     try {
                       const {
                         buildPdfHtml,
                         generatePdf,
                       } = require('../services/pdf-service');
-                      const pdfHtml = buildPdfHtml(questionsAndAnswers, {
-                        title: resource?.title,
-                        description: resource?.description,
+
+                      // Build user data section
+                      const userDetails = [];
+                      if (instance.data?.userId) {
+                        const pdfUser = await db.User.findByPk(
+                          instance.data.userId
+                        );
+                        if (pdfUser) {
+                          const fullName =
+                            [pdfUser.firstname, pdfUser.lastname]
+                              .filter(Boolean)
+                              .join(' ') || pdfUser.name;
+                          if (fullName)
+                            userDetails.push({
+                              question: 'Voor- en achternaam',
+                              answer: fullName,
+                            });
+                          if (pdfUser.phoneNumber)
+                            userDetails.push({
+                              question: 'Telefoonnummer',
+                              answer: pdfUser.phoneNumber,
+                            });
+                          if (pdfUser.email)
+                            userDetails.push({
+                              question: 'Email',
+                              answer: pdfUser.email,
+                            });
+                          const addressParts = [
+                            pdfUser.address,
+                            pdfUser.postcode,
+                            pdfUser.city,
+                          ]
+                            .filter(Boolean)
+                            .join(' ');
+                          if (addressParts)
+                            userDetails.push({
+                              question: 'Adres',
+                              answer: addressParts,
+                            });
+                        }
+                      }
+
+                      const pdfItems = [];
+
+                      // Add user data section if available
+                      if (userDetails.length > 0) {
+                        pdfItems.push({ section: 'Je gegevens' });
+                        pdfItems.push(...userDetails);
+                      }
+
+                      // Add form data with sections
+                      widgetItems
+                        .filter((item) => item.fieldType !== 'none')
+                        .forEach((item) => {
+                          if (item.fieldType === 'pagination') {
+                            pdfItems.push({ section: item.title || '' });
+                          } else {
+                            const qa = questionsAndAnswers.find(
+                              (q) =>
+                                q.question === (item.title || item.fieldKey)
+                            );
+                            pdfItems.push(
+                              qa || {
+                                question: item.title || item.fieldKey,
+                                answer: '',
+                              }
+                            );
+                          }
+                        });
+
+                      const pdfProject = await db.Project.scope(
+                        'includeEmailConfig'
+                      ).findByPk(instance.projectId);
+                      const logoUrl =
+                        pdfProject?.emailConfig?.styling?.logo ||
+                        pdfProject?.config?.auth?.provider?.openstad?.config
+                          ?.styling?.logo ||
+                        '';
+                      const pdfHtml = buildPdfHtml(pdfItems, {
+                        title:
+                          pdfProject?.emailConfig?.notifications?.pdfTitle ||
+                          'Nieuwe inzending',
+                        description:
+                          pdfProject?.emailConfig?.notifications
+                            ?.pdfDescription || '',
+                        logoUrl,
                       });
                       const pdfBuffer = await generatePdf(pdfHtml);
                       pdfAttachment = {

--- a/apps/api-server/src/models/Notification.js
+++ b/apps/api-server/src/models/Notification.js
@@ -206,13 +206,24 @@ module.exports = (db, sequelize, DataTypes) => {
                 const resourceResult = await processResourceQA(instance, db);
                 htmlContent = resourceResult.htmlContent;
 
-                if (shouldGeneratePdf(instance.type)) {
-                  pdfAttachment = await buildPdfAttachment(
-                    instance,
-                    resourceResult.questionsAndAnswers,
-                    resourceResult.widgetItems,
-                    db
-                  );
+                if (
+                  resourceResult.questionsAndAnswers.length &&
+                  shouldGeneratePdf(instance.type)
+                ) {
+                  const project = await db.Project.scope(
+                    'includeEmailConfig'
+                  ).findByPk(instance.projectId);
+                  if (
+                    project?.emailConfig?.notifications?.pdfAttachmentEnabled
+                  ) {
+                    pdfAttachment = await buildPdfAttachment(
+                      instance,
+                      resourceResult.questionsAndAnswers,
+                      resourceResult.widgetItems,
+                      db,
+                      project
+                    );
+                  }
                 }
               }
 

--- a/apps/api-server/src/models/Notification.js
+++ b/apps/api-server/src/models/Notification.js
@@ -306,6 +306,7 @@ module.exports = (db, sequelize, DataTypes) => {
                     'new published resource - user feedback',
                     'updated resource - user feedback',
                   ];
+
                   if (
                     process.env.PDF_API_ENDPOINT &&
                     process.env.PDF_API_KEY &&
@@ -368,33 +369,75 @@ module.exports = (db, sequelize, DataTypes) => {
                       }
 
                       // Add form data with sections
-                      widgetItems
-                        .filter((item) => item.fieldType !== 'none')
-                        .forEach((item) => {
-                          if (item.fieldType === 'pagination') {
-                            pdfItems.push({ section: item.title || '' });
-                          } else {
-                            const qa = questionsAndAnswers.find(
-                              (q) =>
-                                q.question === (item.title || item.fieldKey)
-                            );
-                            pdfItems.push(
-                              qa || {
-                                question: item.title || item.fieldKey,
-                                answer: '',
-                              }
-                            );
-                          }
-                        });
+                      widgetItems.forEach((item, index) => {
+                        if (item.type === 'none') {
+                          pdfItems.push({ section: item.title || '' });
+                        } else {
+                          pdfItems.push(
+                            questionsAndAnswers[index] || {
+                              question: item.title || item.fieldKey || '',
+                              answer: '',
+                            }
+                          );
+                        }
+                      });
 
                       const pdfProject = await db.Project.scope(
                         'includeEmailConfig'
                       ).findByPk(instance.projectId);
-                      const logoUrl =
-                        pdfProject?.emailConfig?.styling?.logo ||
-                        pdfProject?.config?.auth?.provider?.openstad?.config
-                          ?.styling?.logo ||
-                        '';
+                      // Try emailConfig logo first, then fetch from auth server
+                      let rawLogoUrl =
+                        pdfProject?.emailConfig?.styling?.logo || '';
+                      if (!rawLogoUrl) {
+                        try {
+                          const authSettings = require('../util/auth-settings');
+                          const providers = await authSettings.providers({
+                            project: pdfProject,
+                          });
+                          for (const provider of providers) {
+                            if (provider === 'default') continue;
+                            const authConfig = await authSettings.config({
+                              project: pdfProject,
+                              useAuth: provider,
+                            });
+                            const adapter = await authSettings.adapter({
+                              authConfig,
+                            });
+                            if (
+                              adapter.service.fetchClient &&
+                              authConfig.clientId
+                            ) {
+                              const client = await adapter.service.fetchClient({
+                                authConfig,
+                                project: pdfProject,
+                              });
+                              if (client?.config?.styling?.logo) {
+                                rawLogoUrl = client.config.styling.logo;
+                                break;
+                              }
+                            }
+                          }
+                        } catch (err) {
+                          console.error(
+                            'Failed to fetch auth logo:',
+                            err.message
+                          );
+                        }
+                      }
+                      let logoUrl = rawLogoUrl;
+                      if (rawLogoUrl) {
+                        try {
+                          const {
+                            fetchImageAsDataUrl,
+                          } = require('../services/pdf-service');
+                          logoUrl = await fetchImageAsDataUrl(rawLogoUrl);
+                        } catch (err) {
+                          console.error(
+                            'Failed to fetch logo for PDF:',
+                            err.message
+                          );
+                        }
+                      }
                       const pdfHtml = buildPdfHtml(pdfItems, {
                         title:
                           pdfProject?.emailConfig?.notifications?.pdfTitle ||

--- a/apps/api-server/src/models/Notification.js
+++ b/apps/api-server/src/models/Notification.js
@@ -186,6 +186,7 @@ module.exports = (db, sequelize, DataTypes) => {
               };
 
               let htmlContent = '';
+              let pdfAttachment = null;
 
               if (instance.data.resourceId) {
                 const resource = await db.Resource.findByPk(
@@ -298,6 +299,35 @@ module.exports = (db, sequelize, DataTypes) => {
                     </tbody>
                   </mj-table>
                 `;
+
+                  // Generate PDF attachment if configured
+                  if (
+                    process.env.PDF_API_ENDPOINT &&
+                    process.env.PDF_API_KEY &&
+                    questionsAndAnswers.length > 0
+                  ) {
+                    try {
+                      const {
+                        buildPdfHtml,
+                        generatePdf,
+                      } = require('../services/pdf-service');
+                      const pdfHtml = buildPdfHtml(questionsAndAnswers, {
+                        title: resource?.title,
+                        description: resource?.description,
+                      });
+                      const pdfBuffer = await generatePdf(pdfHtml);
+                      pdfAttachment = {
+                        filename: `inzending-${new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)}.pdf`,
+                        content: pdfBuffer,
+                        contentType: 'application/pdf',
+                      };
+                    } catch (err) {
+                      console.error(
+                        'PDF generation failed, sending email without attachment:',
+                        err
+                      );
+                    }
+                  }
                 }
               }
 
@@ -413,6 +443,7 @@ module.exports = (db, sequelize, DataTypes) => {
                           ...messageData.data,
                           submissionContent: htmlContent,
                           enqueteContent: htmlContentEnquete,
+                          pdfAttachment,
                         },
                       }
                     );

--- a/apps/api-server/src/models/Notification.js
+++ b/apps/api-server/src/models/Notification.js
@@ -1,4 +1,12 @@
 const merge = require('merge');
+const {
+  processResourceQA,
+  processSubmissionQA,
+} = require('../services/qa-processor');
+const {
+  buildPdfAttachment,
+  shouldGeneratePdf,
+} = require('../services/pdf-attachment');
 
 function deriveNotificationTemplateData(instance) {
   const normalizeBaseUrl = (url) => {
@@ -150,8 +158,8 @@ module.exports = (db, sequelize, DataTypes) => {
           try {
             await instance.update({ status: 'pending' });
 
-            // send immediatly or wait for cron
-            let immediateTypes = [
+            // send immediately or wait for cron
+            const immediateTypes = [
               'new concept resource - user feedback',
               'new published resource - user feedback',
               'updated resource - user feedback',
@@ -174,7 +182,7 @@ module.exports = (db, sequelize, DataTypes) => {
               const derivedTemplateData =
                 deriveNotificationTemplateData(instance);
 
-              let messageData = {
+              const messageData = {
                 projectId: instance.projectId,
                 engine: instance.engine,
                 type: instance.type,
@@ -186,389 +194,45 @@ module.exports = (db, sequelize, DataTypes) => {
               };
 
               let htmlContent = '';
+              // _pdfAttachment is a non-persisted in-memory property.
+              // This works because immediateTypes are sent synchronously
+              // after .create() — never re-fetched from DB. If the send
+              // flow is ever refactored to re-fetch, this property will be lost.
               let pdfAttachment = null;
-
-              if (instance.data.resourceId) {
-                const resource = await db.Resource.findByPk(
-                  instance.data.resourceId,
-                  {
-                    include: [{ model: db.Tag, attributes: ['name', 'type'] }],
-                  }
-                );
-
-                const widget = !!resource
-                  ? await db.Widget.findByPk(resource.widgetId)
-                  : instance.widgetId || null;
-
-                if (
-                  widget &&
-                  widget.dataValues.config &&
-                  widget.dataValues.config.items
-                ) {
-                  const widgetItems = widget.dataValues.config.items;
-
-                  const questionsAndAnswers = widgetItems.map((item) => {
-                    const question = item.title || item.fieldKey;
-                    const fieldKey = item.fieldKey;
-                    let answer =
-                      resource[fieldKey] ||
-                      resource.extraData?.[fieldKey] ||
-                      '';
-
-                    if (fieldKey.includes('[') && fieldKey.includes(']')) {
-                      const [mainKey, subKey] = fieldKey
-                        .split(/[\[\]]/)
-                        .filter(Boolean);
-                      if (mainKey === 'tags') {
-                        const tags = resource.tags.filter(
-                          (tag) => tag.type === subKey
-                        );
-                        answer = tags.map((tag) => tag.name).join(', ');
-                      }
-                    } else {
-                      if (
-                        typeof answer === 'string' &&
-                        answer.startsWith('[') &&
-                        answer.endsWith(']')
-                      ) {
-                        try {
-                          const parsedAnswer = JSON.parse(answer);
-                          if (Array.isArray(parsedAnswer)) {
-                            answer = parsedAnswer.length
-                              ? parsedAnswer.join(', ')
-                              : '';
-                          }
-                        } catch (e) {
-                          // If parsing fails, keep the original answer
-                        }
-                      } else if (Array.isArray(answer)) {
-                        // Check if the elements are objects with a 'url' field
-                        if (
-                          answer.every(
-                            (item) =>
-                              typeof item === 'object' &&
-                              item !== null &&
-                              'url' in item
-                          )
-                        ) {
-                          // Determine if the field is for images or documents based on the fieldKey
-                          answer = answer
-                            .map((item, index) => {
-                              const name =
-                                item.name ||
-                                (fieldKey === 'images'
-                                  ? `Afbeelding ${index + 1}`
-                                  : `Document ${index + 1}`);
-                              return `<a href="${item.url}" target="_blank">${name}</a>`;
-                            })
-                            .join(', ');
-                        } else {
-                          answer = answer.join(', ');
-                        }
-                      } else if (
-                        typeof answer === 'object' &&
-                        answer !== null
-                      ) {
-                        answer = Object.entries(answer)
-                          .map(([key, value]) => `${key}: ${value}`)
-                          .join(', ');
-                      }
-                    }
-
-                    return { question, answer };
-                  });
-
-                  htmlContent = `
-                  <mj-table cellpadding="5" border="1px solid black" width="100%">
-                    <tbody>
-                      ${questionsAndAnswers
-                        .map(
-                          (qa) => `
-                        <tr style="background-color: #f0f0f0;">
-                          <td style="padding: 10px; font-weight: bold; color: #000; font-size: 13px;font-family: Roboto;">${qa.question}</td>
-                        </tr>
-                        <tr style="background-color: #ffffff;">
-                          <td style="padding: 10px; color: #000; font-size: 13px;font-family: Roboto;">
-                            ${qa.answer}
-                            <br/>
-                          </td>
-                        </tr>
-                      `
-                        )
-                        .join('')}
-                    </tbody>
-                  </mj-table>
-                `;
-
-                  // Generate PDF attachment for user notifications only
-                  const userNotificationTypes = [
-                    'new concept resource - user feedback',
-                    'new published resource - user feedback',
-                    'updated resource - user feedback',
-                  ];
-
-                  if (
-                    process.env.PDF_API_ENDPOINT &&
-                    process.env.PDF_API_KEY &&
-                    questionsAndAnswers.length > 0 &&
-                    userNotificationTypes.includes(instance.type)
-                  ) {
-                    try {
-                      const {
-                        buildPdfHtml,
-                        generatePdf,
-                      } = require('../services/pdf-service');
-
-                      // Build user data section
-                      const userDetails = [];
-                      if (instance.data?.userId) {
-                        const pdfUser = await db.User.findByPk(
-                          instance.data.userId
-                        );
-                        if (pdfUser) {
-                          const fullName =
-                            [pdfUser.firstname, pdfUser.lastname]
-                              .filter(Boolean)
-                              .join(' ') || pdfUser.name;
-                          if (fullName)
-                            userDetails.push({
-                              question: 'Voor- en achternaam',
-                              answer: fullName,
-                            });
-                          if (pdfUser.phoneNumber)
-                            userDetails.push({
-                              question: 'Telefoonnummer',
-                              answer: pdfUser.phoneNumber,
-                            });
-                          if (pdfUser.email)
-                            userDetails.push({
-                              question: 'Email',
-                              answer: pdfUser.email,
-                            });
-                          const addressParts = [
-                            pdfUser.address,
-                            pdfUser.postcode,
-                            pdfUser.city,
-                          ]
-                            .filter(Boolean)
-                            .join(' ');
-                          if (addressParts)
-                            userDetails.push({
-                              question: 'Adres',
-                              answer: addressParts,
-                            });
-                        }
-                      }
-
-                      const pdfItems = [];
-
-                      // Add user data section if available
-                      if (userDetails.length > 0) {
-                        pdfItems.push({ section: 'Je gegevens' });
-                        pdfItems.push(...userDetails);
-                      }
-
-                      // Add form data with sections
-                      widgetItems.forEach((item, index) => {
-                        if (item.type === 'none') {
-                          pdfItems.push({ section: item.title || '' });
-                        } else {
-                          pdfItems.push(
-                            questionsAndAnswers[index] || {
-                              question: item.title || item.fieldKey || '',
-                              answer: '',
-                            }
-                          );
-                        }
-                      });
-
-                      const pdfProject = await db.Project.scope(
-                        'includeEmailConfig'
-                      ).findByPk(instance.projectId);
-                      // Try emailConfig logo first, then fetch from auth server
-                      let rawLogoUrl =
-                        pdfProject?.emailConfig?.styling?.logo || '';
-                      if (!rawLogoUrl) {
-                        try {
-                          const authSettings = require('../util/auth-settings');
-                          const providers = await authSettings.providers({
-                            project: pdfProject,
-                          });
-                          for (const provider of providers) {
-                            if (provider === 'default') continue;
-                            const authConfig = await authSettings.config({
-                              project: pdfProject,
-                              useAuth: provider,
-                            });
-                            const adapter = await authSettings.adapter({
-                              authConfig,
-                            });
-                            if (
-                              adapter.service.fetchClient &&
-                              authConfig.clientId
-                            ) {
-                              const client = await adapter.service.fetchClient({
-                                authConfig,
-                                project: pdfProject,
-                              });
-                              if (client?.config?.styling?.logo) {
-                                rawLogoUrl = client.config.styling.logo;
-                                break;
-                              }
-                            }
-                          }
-                        } catch (err) {
-                          console.error(
-                            'Failed to fetch auth logo:',
-                            err.message
-                          );
-                        }
-                      }
-                      let logoUrl = rawLogoUrl;
-                      if (rawLogoUrl) {
-                        try {
-                          const {
-                            fetchImageAsDataUrl,
-                          } = require('../services/pdf-service');
-                          logoUrl = await fetchImageAsDataUrl(rawLogoUrl);
-                        } catch (err) {
-                          console.error(
-                            'Failed to fetch logo for PDF:',
-                            err.message
-                          );
-                        }
-                      }
-                      const pdfHtml = buildPdfHtml(pdfItems, {
-                        title:
-                          pdfProject?.emailConfig?.notifications?.pdfTitle ||
-                          'Nieuwe inzending',
-                        description:
-                          pdfProject?.emailConfig?.notifications
-                            ?.pdfDescription || '',
-                        logoUrl,
-                      });
-                      const pdfBuffer = await generatePdf(pdfHtml);
-                      pdfAttachment = {
-                        filename: `inzending-${new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)}.pdf`,
-                        content: pdfBuffer,
-                        contentType: 'application/pdf',
-                      };
-                    } catch (err) {
-                      console.error(
-                        'PDF generation failed, sending email without attachment:',
-                        err
-                      );
-                    }
-                  }
-                }
-              }
-
               let htmlContentEnquete = '';
 
-              if (instance.data.submissionId) {
-                const submission = await db.Submission.findByPk(
-                  instance.data.submissionId
-                );
+              // Process resource Q&A
+              if (instance.data.resourceId) {
+                const resourceResult = await processResourceQA(instance, db);
+                htmlContent = resourceResult.htmlContent;
 
-                const widget = !!instance.data.widgetId
-                  ? await db.Widget.findByPk(instance.data.widgetId)
-                  : null;
-
-                if (
-                  widget &&
-                  widget.dataValues.config &&
-                  widget.dataValues.config.items &&
-                  submission &&
-                  submission.dataValues &&
-                  submission.dataValues.submittedData
-                ) {
-                  const widgetItems = widget.dataValues.config.items;
-                  const submittedData = submission.dataValues.submittedData;
-
-                  const questionsAndAnswers = widgetItems.map((item) => {
-                    const question = item.title || item.fieldKey;
-                    const fieldKey = item.fieldKey;
-                    let answer = submittedData[fieldKey] || '';
-
-                    if (
-                      typeof answer === 'string' &&
-                      answer.startsWith('[') &&
-                      answer.endsWith(']')
-                    ) {
-                      try {
-                        const parsedAnswer = JSON.parse(answer);
-                        if (Array.isArray(parsedAnswer)) {
-                          answer = parsedAnswer.length
-                            ? parsedAnswer.join(', ')
-                            : '';
-                        }
-                      } catch (e) {
-                        // If parsing fails, keep the original answer
-                      }
-                    } else if (Array.isArray(answer)) {
-                      // Check if the elements are objects with a 'url' field
-                      if (
-                        answer.every(
-                          (item) =>
-                            typeof item === 'object' &&
-                            item !== null &&
-                            'url' in item
-                        )
-                      ) {
-                        // Determine if the field is for images or documents based on the fieldKey
-                        answer = answer
-                          .map((item, index) => {
-                            const name =
-                              item.name ||
-                              (fieldKey === 'images'
-                                ? `Afbeelding ${index + 1}`
-                                : `Document ${index + 1}`);
-                            return `<a href="${item.url}" target="_blank">${name}</a>`;
-                          })
-                          .join(', ');
-                      } else {
-                        answer = answer.join(', ');
-                      }
-                    } else if (typeof answer === 'object' && answer !== null) {
-                      answer = Object.entries(answer)
-                        .map(([key, value]) => `${key}: ${value}`)
-                        .join(', ');
-                    }
-
-                    return { question, answer };
-                  });
-
-                  htmlContentEnquete = `
-                  <mj-table cellpadding="5" border="1px solid black" width="100%">
-                    <tbody>
-                      ${questionsAndAnswers
-                        .map(
-                          (qa) => `
-                        <tr style="background-color: #f0f0f0;">
-                          <td style="padding: 10px; font-weight: bold; color: #000; font-size: 13px;font-family: Roboto;">${qa.question}</td>
-                        </tr>
-                        <tr style="background-color: #ffffff;">
-                          <td style="padding: 10px; color: #000; font-size: 13px;font-family: Roboto;">
-                            ${qa.answer}
-                            <br/>
-                          </td>
-                        </tr>
-                      `
-                        )
-                        .join('')}
-                    </tbody>
-                  </mj-table>
-                `;
+                if (shouldGeneratePdf(instance.type)) {
+                  pdfAttachment = await buildPdfAttachment(
+                    instance,
+                    resourceResult.questionsAndAnswers,
+                    resourceResult.widgetItems,
+                    db
+                  );
                 }
               }
 
-              let recipients =
+              // Process submission Q&A
+              if (instance.data.submissionId) {
+                const submissionResult = await processSubmissionQA(
+                  instance,
+                  db
+                );
+                htmlContentEnquete = submissionResult.htmlContent;
+              }
+
+              // Create and send messages to all recipients
+              const recipients =
                 instance.to &&
                 instance.to.split(',').map((email) => email.trim());
               if (recipients && recipients.length) {
                 await Promise.all(
                   recipients.map(async (recipient) => {
-                    let message = await db.NotificationMessage.create(
+                    const message = await db.NotificationMessage.create(
                       { ...messageData, to: recipient },
                       {
                         data: {
@@ -582,6 +246,12 @@ module.exports = (db, sequelize, DataTypes) => {
                     await message.send();
                   })
                 );
+              }
+
+              // Allow GC to reclaim PDF buffer immediately
+              if (pdfAttachment) {
+                pdfAttachment.content = null;
+                pdfAttachment = null;
               }
 
               await instance.update({ status: 'sent' });

--- a/apps/api-server/src/models/NotificationMessage.js
+++ b/apps/api-server/src/models/NotificationMessage.js
@@ -149,6 +149,11 @@ module.exports = (db, sequelize, DataTypes) => {
               body = await mjml2html(body);
               instance.body = body.html;
             } catch (err) {}
+
+            // Carry PDF attachment as non-persisted property for email sending
+            if (options.data?.pdfAttachment) {
+              instance._pdfAttachment = options.data.pdfAttachment;
+            }
           }
         },
       },

--- a/apps/api-server/src/models/lib/project-emailconfig.js
+++ b/apps/api-server/src/models/lib/project-emailconfig.js
@@ -52,6 +52,14 @@ Wil je dit liever niet? Dan hoef je alleen een keer in te loggen op de website o
         type: 'boolean',
         default: false,
       },
+      pdfTitle: {
+        type: 'string',
+        default: 'Nieuwe inzending',
+      },
+      pdfDescription: {
+        type: 'string',
+        default: '',
+      },
       sendEndDateNotifications: {
         type: 'object',
         subset: {

--- a/apps/api-server/src/models/lib/project-emailconfig.js
+++ b/apps/api-server/src/models/lib/project-emailconfig.js
@@ -52,6 +52,10 @@ Wil je dit liever niet? Dan hoef je alleen een keer in te loggen op de website o
         type: 'boolean',
         default: false,
       },
+      pdfAttachmentEnabled: {
+        type: 'boolean',
+        default: false,
+      },
       pdfTitle: {
         type: 'string',
         default: 'Nieuwe inzending',

--- a/apps/api-server/src/notifications/send-engines/email.js
+++ b/apps/api-server/src/notifications/send-engines/email.js
@@ -29,13 +29,19 @@ module.exports = async function sendMessage({ message }) {
       });
     }
 
-    await transporter.sendMail({
+    const mailOptions = {
       from: message.from,
       to: message.to,
       subject: message.subject,
       text: message.text,
       html: message.body,
-    });
+    };
+
+    if (message._pdfAttachment) {
+      mailOptions.attachments = [message._pdfAttachment];
+    }
+
+    await transporter.sendMail(mailOptions);
   } catch (err) {
     console.error(err);
     throw err;

--- a/apps/api-server/src/services/pdf-attachment.js
+++ b/apps/api-server/src/services/pdf-attachment.js
@@ -17,7 +17,9 @@ const PDF_USER_NOTIFICATION_TYPES = [
 ];
 
 /**
- * Check whether PDF attachment generation should run for this notification.
+ * Check whether PDF attachment generation could run for this notification.
+ * Only checks env vars and notification type. The project-level toggle
+ * (pdfAttachmentEnabled) is checked separately after fetching the project.
  */
 function shouldGeneratePdf(notificationType) {
   return (
@@ -139,13 +141,15 @@ function buildPdfItems(widgetItems, questionsAndAnswers, userDetails) {
  * @param {Array} questionsAndAnswers - Processed Q&A array from qa-processor
  * @param {Array} widgetItems - Widget config items
  * @param {object} db - Sequelize models
+ * @param {object} project - Project with emailConfig scope (pre-fetched by caller)
  * @returns {object|null} Attachment object or null
  */
 async function buildPdfAttachment(
   instance,
   questionsAndAnswers,
   widgetItems,
-  db
+  db,
+  project
 ) {
   if (!questionsAndAnswers.length) return null;
 
@@ -157,9 +161,6 @@ async function buildPdfAttachment(
       userDetails
     );
 
-    const project = await db.Project.scope('includeEmailConfig').findByPk(
-      instance.projectId
-    );
     const logoUrl = await fetchLogoUrl(project);
 
     const pdfHtml = buildPdfHtml(pdfItems, {

--- a/apps/api-server/src/services/pdf-attachment.js
+++ b/apps/api-server/src/services/pdf-attachment.js
@@ -1,0 +1,194 @@
+/**
+ * PDF attachment service.
+ * Builds a PDF attachment from Q&A data for resource form submission emails.
+ * Handles user details, logo fetching, and PDF generation via pdf-service.
+ */
+
+const {
+  buildPdfHtml,
+  generatePdf,
+  fetchImageAsDataUrl,
+} = require('./pdf-service');
+
+const PDF_USER_NOTIFICATION_TYPES = [
+  'new concept resource - user feedback',
+  'new published resource - user feedback',
+  'updated resource - user feedback',
+];
+
+/**
+ * Check whether PDF attachment generation should run for this notification.
+ */
+function shouldGeneratePdf(notificationType) {
+  return (
+    !!process.env.PDF_API_ENDPOINT &&
+    !!process.env.PDF_API_KEY &&
+    PDF_USER_NOTIFICATION_TYPES.includes(notificationType)
+  );
+}
+
+/**
+ * Collect user contact details for the PDF header section.
+ */
+async function collectUserDetails(userId, db) {
+  if (!userId) return [];
+
+  const user = await db.User.findByPk(userId);
+  if (!user) return [];
+
+  const details = [];
+
+  const fullName =
+    [user.firstname, user.lastname].filter(Boolean).join(' ') || user.name;
+  if (fullName)
+    details.push({ question: 'Voor- en achternaam', answer: fullName });
+  if (user.phoneNumber)
+    details.push({ question: 'Telefoonnummer', answer: user.phoneNumber });
+  if (user.email) details.push({ question: 'Email', answer: user.email });
+
+  const addressParts = [user.address, user.postcode, user.city]
+    .filter(Boolean)
+    .join(' ');
+  if (addressParts) details.push({ question: 'Adres', answer: addressParts });
+
+  return details;
+}
+
+/**
+ * Fetch the project logo as a data URL for embedding in the PDF.
+ * Tries emailConfig logo first, then the auth server client config.
+ */
+async function fetchLogoUrl(project) {
+  let rawLogoUrl = project?.emailConfig?.styling?.logo || '';
+
+  if (!rawLogoUrl) {
+    try {
+      const authSettings = require('../util/auth-settings');
+      const providers = await authSettings.providers({ project });
+
+      for (const provider of providers) {
+        if (provider === 'default') continue;
+        const authConfig = await authSettings.config({
+          project,
+          useAuth: provider,
+        });
+        const adapter = await authSettings.adapter({ authConfig });
+        if (adapter.service.fetchClient && authConfig.clientId) {
+          const client = await adapter.service.fetchClient({
+            authConfig,
+            project,
+          });
+          if (client?.config?.styling?.logo) {
+            rawLogoUrl = client.config.styling.logo;
+            break;
+          }
+        }
+      }
+    } catch (err) {
+      console.error('Failed to fetch auth logo:', err.message);
+    }
+  }
+
+  if (!rawLogoUrl) return '';
+
+  try {
+    return await fetchImageAsDataUrl(rawLogoUrl);
+  } catch (err) {
+    console.error('Failed to fetch logo for PDF:', err.message);
+    return rawLogoUrl;
+  }
+}
+
+/**
+ * Build the list of PDF items (sections + Q&A rows) from widget items and Q&A data.
+ */
+function buildPdfItems(widgetItems, questionsAndAnswers, userDetails) {
+  const pdfItems = [];
+
+  // Add user data section if available
+  if (userDetails.length > 0) {
+    pdfItems.push({ section: 'Je gegevens' });
+    pdfItems.push(...userDetails);
+  }
+
+  // Add form data with sections
+  widgetItems.forEach((item, index) => {
+    if (item.type === 'none') {
+      pdfItems.push({ section: item.title || '' });
+    } else {
+      pdfItems.push(
+        questionsAndAnswers[index] || {
+          question: item.title || item.fieldKey || '',
+          answer: '',
+        }
+      );
+    }
+  });
+
+  return pdfItems;
+}
+
+/**
+ * Build a PDF attachment for a resource form submission notification.
+ * Returns the attachment object { filename, content, contentType } or null on failure.
+ *
+ * Note: The returned buffer is held in memory until the email is sent.
+ * The caller should null the reference after sending to allow garbage collection.
+ *
+ * @param {object} instance - Notification instance
+ * @param {Array} questionsAndAnswers - Processed Q&A array from qa-processor
+ * @param {Array} widgetItems - Widget config items
+ * @param {object} db - Sequelize models
+ * @returns {object|null} Attachment object or null
+ */
+async function buildPdfAttachment(
+  instance,
+  questionsAndAnswers,
+  widgetItems,
+  db
+) {
+  if (!questionsAndAnswers.length) return null;
+
+  try {
+    const userDetails = await collectUserDetails(instance.data?.userId, db);
+    const pdfItems = buildPdfItems(
+      widgetItems,
+      questionsAndAnswers,
+      userDetails
+    );
+
+    const project = await db.Project.scope('includeEmailConfig').findByPk(
+      instance.projectId
+    );
+    const logoUrl = await fetchLogoUrl(project);
+
+    const pdfHtml = buildPdfHtml(pdfItems, {
+      title:
+        project?.emailConfig?.notifications?.pdfTitle || 'Nieuwe inzending',
+      description: project?.emailConfig?.notifications?.pdfDescription || '',
+      logoUrl,
+    });
+
+    const pdfBuffer = await generatePdf(pdfHtml);
+
+    if (pdfBuffer && pdfBuffer.length > 5 * 1024 * 1024) {
+      console.warn(
+        `[Notification] Large PDF generated: ${(pdfBuffer.length / 1024 / 1024).toFixed(1)}MB`
+      );
+    }
+
+    return {
+      filename: `inzending-${new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)}.pdf`,
+      content: pdfBuffer,
+      contentType: 'application/pdf',
+    };
+  } catch (err) {
+    console.error(
+      'PDF generation failed, sending email without attachment:',
+      err
+    );
+    return null;
+  }
+}
+
+module.exports = { buildPdfAttachment, shouldGeneratePdf };

--- a/apps/api-server/src/services/pdf-service.js
+++ b/apps/api-server/src/services/pdf-service.js
@@ -6,7 +6,13 @@
 
 function stripHtml(str) {
   if (typeof str !== 'string') return '';
-  return str.replace(/<[^>]*>/g, '').trim();
+  let result = str;
+  let prev;
+  do {
+    prev = result;
+    result = result.replace(/<[^>]*>/g, '');
+  } while (result !== prev);
+  return result.trim();
 }
 
 function escapeHtml(str) {
@@ -26,7 +32,12 @@ function sanitizeAnswer(str) {
     preserved.push(match);
     return `%%LINK${preserved.length - 1}%%`;
   });
-  result = result.replace(/<[^>]*>/g, '').trim();
+  let prev;
+  do {
+    prev = result;
+    result = result.replace(/<[^>]*>/g, '');
+  } while (result !== prev);
+  result = result.trim();
   preserved.forEach((link, i) => {
     result = result.replace(`%%LINK${i}%%`, link);
   });

--- a/apps/api-server/src/services/pdf-service.js
+++ b/apps/api-server/src/services/pdf-service.js
@@ -75,7 +75,7 @@ function buildPdfHtml(
     .join('');
 
   const logoHtml = logoUrl
-    ? `<img src="${escapeHtml(logoUrl)}" alt="Logo" class="logo" />`
+    ? `<img src="${escapeAttr(logoUrl)}" alt="Logo" class="logo" />`
     : '';
   const titleHtml = title ? `<h1>${escapeHtml(title)}</h1>` : '';
   const descriptionHtml = description

--- a/apps/api-server/src/services/pdf-service.js
+++ b/apps/api-server/src/services/pdf-service.js
@@ -178,4 +178,37 @@ async function generatePdf(htmlString) {
   return Buffer.from(arrayBuffer);
 }
 
-module.exports = { buildPdfHtml, generatePdf };
+async function fetchImageAsDataUrl(url) {
+  if (!url || url.startsWith('data:')) return url;
+  // Replace external image URL with internal Docker URL for container-to-container fetch
+  let fetchUrl = url;
+  if (process.env.IMAGE_APP_URL && process.env.IMAGE_APP_URL_INTERNAL) {
+    fetchUrl = url.replace(
+      process.env.IMAGE_APP_URL,
+      process.env.IMAGE_APP_URL_INTERNAL
+    );
+  }
+  const response = await fetch(fetchUrl, {
+    signal: AbortSignal.timeout(10000),
+  });
+  if (!response.ok) throw new Error(`Image fetch failed: ${response.status}`);
+  const contentType = response.headers.get('content-type') || 'image/png';
+  if (!contentType.startsWith('image/')) {
+    throw new Error(`Expected image content-type, got: ${contentType}`);
+  }
+  const contentLength = parseInt(
+    response.headers.get('content-length') || '0',
+    10
+  );
+  if (contentLength > 2 * 1024 * 1024) {
+    throw new Error(`Image too large: ${contentLength} bytes`);
+  }
+  const arrayBuffer = await response.arrayBuffer();
+  if (arrayBuffer.byteLength > 2 * 1024 * 1024) {
+    throw new Error(`Image too large: ${arrayBuffer.byteLength} bytes`);
+  }
+  const base64 = Buffer.from(arrayBuffer).toString('base64');
+  return `data:${contentType};base64,${base64}`;
+}
+
+module.exports = { buildPdfHtml, generatePdf, fetchImageAsDataUrl };

--- a/apps/api-server/src/services/pdf-service.js
+++ b/apps/api-server/src/services/pdf-service.js
@@ -24,6 +24,16 @@ function escapeHtml(str) {
     .replace(/"/g, '&quot;');
 }
 
+function escapeAttr(str) {
+  if (typeof str !== 'string') return '';
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
 function sanitizeAnswer(str) {
   if (typeof str !== 'string') return '';
   // Preserve <a> tags but strip all other HTML
@@ -211,4 +221,11 @@ async function fetchImageAsDataUrl(url) {
   return `data:${contentType};base64,${base64}`;
 }
 
-module.exports = { buildPdfHtml, generatePdf, fetchImageAsDataUrl };
+module.exports = {
+  buildPdfHtml,
+  generatePdf,
+  fetchImageAsDataUrl,
+  escapeHtml,
+  escapeAttr,
+  stripHtml,
+};

--- a/apps/api-server/src/services/pdf-service.js
+++ b/apps/api-server/src/services/pdf-service.js
@@ -1,0 +1,129 @@
+/**
+ * PDF generation service using the draad-pdf API.
+ * Generates PDFs from questionsAndAnswers data (same data used for email content).
+ * Requires PDF_API_ENDPOINT and PDF_API_KEY environment variables.
+ */
+
+function escapeHtml(str) {
+  if (typeof str !== 'string') return '';
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function buildPdfHtml(questionsAndAnswers, { title, description } = {}) {
+  const rows = questionsAndAnswers
+    .map(
+      (qa) => `
+      <tr class="question">
+        <td>${escapeHtml(qa.question)}</td>
+      </tr>
+      <tr class="answer">
+        <td>${escapeHtml(qa.answer)}</td>
+      </tr>`
+    )
+    .join('');
+
+  const titleHtml = title ? `<h1>${escapeHtml(title)}</h1>` : '';
+  const descriptionHtml = description
+    ? `<p class="description">${escapeHtml(description)}</p>`
+    : '';
+
+  return `<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8">
+  <style>
+    body {
+      font-family: Arial, Helvetica, sans-serif;
+      font-size: 13px;
+      color: #000;
+      margin: 40px;
+    }
+    h1 {
+      font-size: 20px;
+      margin-bottom: 8px;
+    }
+    .description {
+      font-size: 14px;
+      color: #333;
+      margin-bottom: 24px;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      border: 1px solid #000;
+    }
+    tr.question td {
+      background-color: #f0f0f0;
+      padding: 10px;
+      font-weight: bold;
+    }
+    tr.answer td {
+      background-color: #fff;
+      padding: 10px;
+    }
+    td {
+      border: 1px solid #000;
+    }
+  </style>
+</head>
+<body>
+  ${titleHtml}
+  ${descriptionHtml}
+  <table>
+    <tbody>
+      ${rows}
+    </tbody>
+  </table>
+</body>
+</html>`;
+}
+
+async function generatePdf(htmlString) {
+  const endpoint = process.env.PDF_API_ENDPOINT;
+  const apiKey = process.env.PDF_API_KEY;
+
+  const formData = new FormData();
+  formData.append(
+    'html',
+    new Blob([htmlString], { type: 'text/html' }),
+    'template.html'
+  );
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: formData,
+    signal: AbortSignal.timeout(15000),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`PDF API returned ${response.status}: ${body}`);
+  }
+
+  const data = await response.json();
+  if (!data.pdf_url) {
+    throw new Error('PDF API response missing pdf_url');
+  }
+
+  const pdfResponse = await fetch(data.pdf_url, {
+    signal: AbortSignal.timeout(15000),
+  });
+
+  if (!pdfResponse.ok) {
+    throw new Error(
+      `Failed to download PDF from ${data.pdf_url}: ${pdfResponse.status}`
+    );
+  }
+
+  const arrayBuffer = await pdfResponse.arrayBuffer();
+  return Buffer.from(arrayBuffer);
+}
+
+module.exports = { buildPdfHtml, generatePdf };

--- a/apps/api-server/src/services/pdf-service.js
+++ b/apps/api-server/src/services/pdf-service.js
@@ -4,6 +4,11 @@
  * Requires PDF_API_ENDPOINT and PDF_API_KEY environment variables.
  */
 
+function stripHtml(str) {
+  if (typeof str !== 'string') return '';
+  return str.replace(/<[^>]*>/g, '').trim();
+}
+
 function escapeHtml(str) {
   if (typeof str !== 'string') return '';
   return str
@@ -13,19 +18,44 @@ function escapeHtml(str) {
     .replace(/"/g, '&quot;');
 }
 
-function buildPdfHtml(questionsAndAnswers, { title, description } = {}) {
+function sanitizeAnswer(str) {
+  if (typeof str !== 'string') return '';
+  // Preserve <a> tags but strip all other HTML
+  const preserved = [];
+  let result = str.replace(/<a\s[^>]*>.*?<\/a>/gi, (match) => {
+    preserved.push(match);
+    return `%%LINK${preserved.length - 1}%%`;
+  });
+  result = result.replace(/<[^>]*>/g, '').trim();
+  preserved.forEach((link, i) => {
+    result = result.replace(`%%LINK${i}%%`, link);
+  });
+  return result;
+}
+
+function buildPdfHtml(
+  questionsAndAnswers,
+  { title, description, logoUrl } = {}
+) {
   const rows = questionsAndAnswers
-    .map(
-      (qa) => `
-      <tr class="question">
-        <td>${escapeHtml(qa.question)}</td>
-      </tr>
-      <tr class="answer">
-        <td>${escapeHtml(qa.answer)}</td>
-      </tr>`
-    )
+    .map((qa) => {
+      if (qa.section !== undefined) {
+        return `
+      <tr class="section">
+        <td colspan="2">${stripHtml(qa.section)}</td>
+      </tr>`;
+      }
+      return `
+      <tr>
+        <td class="question">${stripHtml(qa.question)}</td>
+        <td class="answer">${qa.answer != null ? sanitizeAnswer(String(qa.answer)) : '-'}</td>
+      </tr>`;
+    })
     .join('');
 
+  const logoHtml = logoUrl
+    ? `<img src="${escapeHtml(logoUrl)}" alt="Logo" class="logo" />`
+    : '';
   const titleHtml = title ? `<h1>${escapeHtml(title)}</h1>` : '';
   const descriptionHtml = description
     ? `<p class="description">${escapeHtml(description)}</p>`
@@ -38,39 +68,64 @@ function buildPdfHtml(questionsAndAnswers, { title, description } = {}) {
   <style>
     body {
       font-family: Arial, Helvetica, sans-serif;
-      font-size: 13px;
-      color: #000;
-      margin: 40px;
+      font-size: 14px;
+      color: #1a1a1a;
+      margin: 60px 80px;
+    }
+    .logo {
+      max-height: 60px;
+      max-width: 220px;
+      margin-bottom: 32px;
     }
     h1 {
-      font-size: 20px;
-      margin-bottom: 8px;
+      font-size: 28px;
+      font-weight: bold;
+      color: #000;
+      margin: 0 0 12px 0;
     }
     .description {
       font-size: 14px;
-      color: #333;
-      margin-bottom: 24px;
+      color: #1a1a1a !important;
+      text-decoration: none;
+      margin: 0 0 24px 0;
     }
     table {
       width: 100%;
       border-collapse: collapse;
-      border: 1px solid #000;
     }
-    tr.question td {
-      background-color: #f0f0f0;
-      padding: 10px;
+    tr {
+      border: 1px solid #e0e0e0;
+    }
+    tr.section {
+      page-break-after: avoid;
+    }
+    tr.section td {
+      background-color: #f7f7f7;
+      padding: 12px 14px;
       font-weight: bold;
+      font-size: 14px;
+      color: #000;
     }
-    tr.answer td {
-      background-color: #fff;
-      padding: 10px;
+    td.question {
+      width: 35%;
+      padding: 14px 14px;
+      vertical-align: top;
+      color: #1a1a1a;
     }
-    td {
-      border: 1px solid #000;
+    td.answer {
+      width: 65%;
+      padding: 14px 14px;
+      vertical-align: top;
+      color: #000;
+    }
+    td.answer a {
+      color: #1a56db;
+      text-decoration: underline;
     }
   </style>
 </head>
 <body>
+  ${logoHtml}
   ${titleHtml}
   ${descriptionHtml}
   <table>
@@ -92,6 +147,7 @@ async function generatePdf(htmlString) {
     new Blob([htmlString], { type: 'text/html' }),
     'template.html'
   );
+  formData.append('save', 'false');
 
   const response = await fetch(endpoint, {
     method: 'POST',
@@ -107,22 +163,7 @@ async function generatePdf(htmlString) {
     throw new Error(`PDF API returned ${response.status}: ${body}`);
   }
 
-  const data = await response.json();
-  if (!data.pdf_url) {
-    throw new Error('PDF API response missing pdf_url');
-  }
-
-  const pdfResponse = await fetch(data.pdf_url, {
-    signal: AbortSignal.timeout(15000),
-  });
-
-  if (!pdfResponse.ok) {
-    throw new Error(
-      `Failed to download PDF from ${data.pdf_url}: ${pdfResponse.status}`
-    );
-  }
-
-  const arrayBuffer = await pdfResponse.arrayBuffer();
+  const arrayBuffer = await response.arrayBuffer();
   return Buffer.from(arrayBuffer);
 }
 

--- a/apps/api-server/src/services/qa-processor.js
+++ b/apps/api-server/src/services/qa-processor.js
@@ -1,0 +1,211 @@
+/**
+ * Q&A processor service.
+ * Extracts questions and answers from widget items + data source (resource or submission).
+ * Applies HTML escaping at the source to prevent XSS in email and PDF output.
+ */
+
+const { escapeHtml, escapeAttr, stripHtml } = require('./pdf-service');
+
+/**
+ * Transform a raw answer value into a safe, display-ready string.
+ * Handles: strings, JSON-encoded arrays, object arrays with URLs,
+ * plain arrays, and plain objects.
+ *
+ * All user-submitted values are HTML-escaped at this level so that
+ * the returned string is safe to embed in HTML templates.
+ */
+function transformAnswer(answer, fieldKey, tags) {
+  // Handle tag fields like tags[type]
+  if (fieldKey.includes('[') && fieldKey.includes(']') && tags) {
+    const [mainKey, subKey] = fieldKey.split(/[\[\]]/).filter(Boolean);
+    if (mainKey === 'tags') {
+      const filtered = tags.filter((tag) => tag.type === subKey);
+      return filtered.map((tag) => escapeHtml(tag.name)).join(', ');
+    }
+  }
+
+  // JSON-encoded array string
+  if (
+    typeof answer === 'string' &&
+    answer.startsWith('[') &&
+    answer.endsWith(']')
+  ) {
+    try {
+      const parsed = JSON.parse(answer);
+      if (Array.isArray(parsed)) {
+        return parsed.length
+          ? parsed.map((v) => escapeHtml(String(v))).join(', ')
+          : '';
+      }
+    } catch (e) {
+      // If parsing fails, fall through to plain string escaping
+    }
+  }
+
+  // Array of objects with URL (uploaded images/documents)
+  if (Array.isArray(answer)) {
+    if (
+      answer.every(
+        (item) => typeof item === 'object' && item !== null && 'url' in item
+      )
+    ) {
+      return answer
+        .map((item, index) => {
+          const name =
+            item.name ||
+            (fieldKey === 'images'
+              ? `Afbeelding ${index + 1}`
+              : `Document ${index + 1}`);
+          return `<a href="${escapeAttr(item.url)}" target="_blank">${escapeHtml(name)}</a>`;
+        })
+        .join(', ');
+    }
+    // Plain array
+    return answer.map((v) => escapeHtml(String(v))).join(', ');
+  }
+
+  // Plain object
+  if (typeof answer === 'object' && answer !== null) {
+    return Object.entries(answer)
+      .map(
+        ([key, value]) =>
+          `${escapeHtml(String(key))}: ${escapeHtml(String(value))}`
+      )
+      .join(', ');
+  }
+
+  // Plain string (or anything else)
+  if (typeof answer === 'string') {
+    return escapeHtml(answer);
+  }
+
+  return escapeHtml(String(answer || ''));
+}
+
+/**
+ * Build the MJML HTML table from a questions-and-answers array.
+ */
+function buildQAHtmlTable(questionsAndAnswers) {
+  return `
+    <mj-table cellpadding="5" border="1px solid black" width="100%">
+      <tbody>
+        ${questionsAndAnswers
+          .map((qa) => {
+            if (qa.section !== undefined) {
+              return `
+          <tr style="background-color: #f0f0f0;">
+            <td style="padding: 10px; font-weight: bold; color: #000; font-size: 13px;font-family: Roboto;">${escapeHtml(qa.section)}</td>
+          </tr>`;
+            }
+            return `
+          <tr style="background-color: #f0f0f0;">
+            <td style="padding: 10px; font-weight: bold; color: #000; font-size: 13px;font-family: Roboto;">${escapeHtml(qa.question)}</td>
+          </tr>
+          <tr style="background-color: #ffffff;">
+            <td style="padding: 10px; color: #000; font-size: 13px;font-family: Roboto;">
+              ${qa.answer}
+              <br/>
+            </td>
+          </tr>`;
+          })
+          .join('')}
+      </tbody>
+    </mj-table>
+  `;
+}
+
+/**
+ * Process resource data into questions, answers, and HTML content.
+ *
+ * @param {object} instance - Notification instance
+ * @param {object} db - Sequelize models
+ * @returns {{ htmlContent: string, questionsAndAnswers: Array, widgetItems: Array }}
+ */
+async function processResourceQA(instance, db) {
+  const result = { htmlContent: '', questionsAndAnswers: [], widgetItems: [] };
+
+  const resource = await db.Resource.findByPk(instance.data.resourceId, {
+    include: [{ model: db.Tag, attributes: ['name', 'type'] }],
+  });
+
+  const widget = resource
+    ? await db.Widget.findByPk(resource.widgetId)
+    : instance.widgetId || null;
+
+  if (!widget || !widget.dataValues.config || !widget.dataValues.config.items) {
+    return result;
+  }
+
+  const widgetItems = widget.dataValues.config.items;
+  result.widgetItems = widgetItems;
+
+  result.questionsAndAnswers = widgetItems.map((item) => {
+    if (item.type === 'none') {
+      return { section: stripHtml(item.title || '') };
+    }
+
+    const question = stripHtml(item.title || item.fieldKey);
+    const fieldKey = item.fieldKey;
+    const rawAnswer =
+      resource[fieldKey] || resource.extraData?.[fieldKey] || '';
+
+    const answer = transformAnswer(rawAnswer, fieldKey, resource.tags);
+
+    return { question, answer };
+  });
+
+  result.htmlContent = buildQAHtmlTable(result.questionsAndAnswers);
+
+  return result;
+}
+
+/**
+ * Process submission data into questions, answers, and HTML content.
+ *
+ * @param {object} instance - Notification instance
+ * @param {object} db - Sequelize models
+ * @returns {{ htmlContent: string, questionsAndAnswers: Array }}
+ */
+async function processSubmissionQA(instance, db) {
+  const result = { htmlContent: '', questionsAndAnswers: [] };
+
+  const submission = await db.Submission.findByPk(instance.data.submissionId);
+
+  const widget = instance.data.widgetId
+    ? await db.Widget.findByPk(instance.data.widgetId)
+    : null;
+
+  if (
+    !widget ||
+    !widget.dataValues.config ||
+    !widget.dataValues.config.items ||
+    !submission ||
+    !submission.dataValues ||
+    !submission.dataValues.submittedData
+  ) {
+    return result;
+  }
+
+  const widgetItems = widget.dataValues.config.items;
+  const submittedData = submission.dataValues.submittedData;
+
+  result.questionsAndAnswers = widgetItems.map((item) => {
+    if (item.type === 'none') {
+      return { section: stripHtml(item.title || '') };
+    }
+
+    const question = stripHtml(item.title || item.fieldKey);
+    const fieldKey = item.fieldKey;
+    const rawAnswer = submittedData[fieldKey] || '';
+
+    const answer = transformAnswer(rawAnswer, fieldKey);
+
+    return { question, answer };
+  });
+
+  result.htmlContent = buildQAHtmlTable(result.questionsAndAnswers);
+
+  return result;
+}
+
+module.exports = { processResourceQA, processSubmissionQA };

--- a/charts/openstad-headless/templates/_helpers.tpl
+++ b/charts/openstad-headless/templates/_helpers.tpl
@@ -32,6 +32,14 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 {{- end -}}
 
+{{- define "openstad.pdf.secret.fullname" -}}
+{{- if not .Values.secrets.existingSecret -}}
+{{- printf "%s-pdf-secret" (include "openstad.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{ .Values.secrets.existingSecret }}
+{{- end -}}
+{{- end -}}
+
 {{- define "openstad.cdn.secret.fullname" -}}
 {{- if not .Values.secrets.existingSecret -}}
 {{- printf "%s-cdn-secret" (include "openstad.fullname" .) | trunc 63 | trimSuffix "-" -}}

--- a/charts/openstad-headless/templates/api/deployment.yaml
+++ b/charts/openstad-headless/templates/api/deployment.yaml
@@ -158,6 +158,20 @@ spec:
           - name: SPAM_FILTER_ENABLED
             value: "{{ .Values.api.spamFilterEnabled }}"
 
+          - name: PDF_API_ENDPOINT
+            valueFrom:
+              secretKeyRef:
+                key: pdfApiEndpoint
+                name: {{ template "openstad.pdf.secret.fullname" . }}
+                optional: true
+
+          - name: PDF_API_KEY
+            valueFrom:
+              secretKeyRef:
+                key: pdfApiKey
+                name: {{ template "openstad.pdf.secret.fullname" . }}
+                optional: true
+
           - name: AUTH_JWTSECRET
             valueFrom:
               secretKeyRef:

--- a/charts/openstad-headless/templates/secrets/pdf-secret.yaml
+++ b/charts/openstad-headless/templates/secrets/pdf-secret.yaml
@@ -1,0 +1,12 @@
+{{- if not .Values.secrets.existingSecret -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "openstad.pdf.secret.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+  pdfApiEndpoint: {{ .Values.secrets.pdf.apiEndpoint | default "" | b64enc }}
+  pdfApiKey: {{ .Values.secrets.pdf.apiKey | default "" | b64enc }}
+{{- end -}}

--- a/charts/openstad-headless/values.yaml
+++ b/charts/openstad-headless/values.yaml
@@ -559,6 +559,10 @@ secrets:
     cookieName:
     onlySecure:
     jwtSecret:
+  ### PDF generation (optional, leave empty to disable)
+  pdf:
+    apiEndpoint: ""
+    apiKey: ""
   cdn:
     reactUrl: https://unpkg.com/react@18.3.1/umd/react.production.min.js
     reactDomUrl: https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,6 +144,8 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://openstad-otel-collector:4317}
       - OTEL_ENABLED=${OTEL_ENABLED_API:-false}
       - SPAM_FILTER_ENABLED=${SPAM_FILTER_ENABLED:-false}
+      - PDF_API_ENDPOINT=${PDF_API_ENDPOINT}
+      - PDF_API_KEY=${PDF_API_KEY}
     ports:
       - '${API_PORT}:${API_PORT}'
     volumes:


### PR DESCRIPTION
## Summary
- Add admin UI fields for configuring PDF title and description in project notification settings
- Add pdfTitle/pdfDescription fields to the email config model
- Refactor pdf-service with improved HTML builder, styling, and section support
- Generate PDF attachments only for user feedback notification types (concept, published, updated)

## Test plan
- [ ] Configure PDF title and description in admin → Project → Settings → Notifications
- [ ] Submit a resource and verify the user feedback email includes a PDF attachment
- [ ] Verify admin notification emails do NOT include a PDF attachment
- [ ] Verify PDF contains user details section and form answers with correct styling
- [ ] Test with PDF_API_ENDPOINT and PDF_API_KEY env vars unset — should gracefully skip PDF generation