### PR TITLE
feat: add tijdlijn (timeline) section to resource-detail-with-map widget

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/index.tsx
@@ -37,6 +37,7 @@ import { LikeWidgetTabProps } from '../../likes/[id]';
 import LikesDisplay from '../../likes/[id]/weergave';
 import WidgetResourceDetailDisplay from './display';
 import WidgetResourceDetailGeneral from './general';
+import WidgetResourceDetailTijdlijn from './tijdlijn';
 
 export const getServerSideProps = withApiUrl;
 
@@ -80,6 +81,7 @@ export default function WidgetResourceDetail({ apiUrl }: WithApiUrlProps) {
             <TabsList className="w-full bg-white border-b-0 mb-4 rounded-md h-fit flex flex-wrap overflow-auto">
               <TabsTrigger value="general">Algemeen</TabsTrigger>
               <TabsTrigger value="display">Weergave</TabsTrigger>
+              <TabsTrigger value="tijdlijn">Tijdlijn</TabsTrigger>
               <TabsTrigger value="map">Kaart</TabsTrigger>
               <TabsTrigger value="comments">Reacties widget</TabsTrigger>
               <TabsTrigger value="likes">Likes widget</TabsTrigger>
@@ -109,6 +111,25 @@ export default function WidgetResourceDetail({ apiUrl }: WithApiUrlProps) {
             <TabsContent value="display" className="p-0">
               {previewConfig && (
                 <WidgetResourceDetailDisplay
+                  {...previewConfig}
+                  updateConfig={(config) =>
+                    updateConfig({ ...widget.config, ...config })
+                  }
+                  onFieldChanged={(key, value) => {
+                    if (previewConfig) {
+                      updatePreview({
+                        ...previewConfig,
+                        [key]: value,
+                      });
+                    }
+                  }}
+                />
+              )}
+            </TabsContent>
+
+            <TabsContent value="tijdlijn" className="p-0">
+              {previewConfig && (
+                <WidgetResourceDetailTijdlijn
                   {...previewConfig}
                   updateConfig={(config) =>
                     updateConfig({ ...widget.config, ...config })

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/tijdlijn.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/tijdlijn.tsx
@@ -1,0 +1,596 @@
+import { Button } from '@/components/ui/button';
+import {
+  Form,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Separator } from '@/components/ui/separator';
+import { Heading } from '@/components/ui/typography';
+import { YesNoSelect } from '@/lib/form-widget-helpers';
+import { EditFieldProps } from '@/lib/form-widget-helpers/EditFieldProps';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { ResourceDetailWidgetProps } from '@openstad-headless/resource-detail/src/resource-detail';
+import * as Switch from '@radix-ui/react-switch';
+import { ArrowDown, ArrowUp, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import * as z from 'zod';
+
+const formSchema = z.object({
+  trigger: z.string(),
+  date: z.string().optional(),
+  title: z.string(),
+  description: z.string(),
+  active: z.boolean(),
+  highlighted: z.boolean(),
+  activeFrom: z.string().optional(),
+  activeTo: z.string().optional(),
+  links: z
+    .array(
+      z.object({
+        trigger: z.string(),
+        date: z.string().optional(),
+        title: z.string(),
+        url: z.string(),
+        openInNewWindow: z.boolean(),
+      })
+    )
+    .optional(),
+});
+
+const DATE_ONLY_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+function toDateInputValue(value?: string) {
+  if (!value) return '';
+  if (DATE_ONLY_REGEX.test(value)) return value;
+  const date = new Date(value);
+  if (isNaN(date.getTime())) return '';
+  return date.toISOString().slice(0, 10);
+}
+
+export default function WidgetResourceDetailTijdlijn(
+  props: ResourceDetailWidgetProps & EditFieldProps<ResourceDetailWidgetProps>
+) {
+  type FormData = z.infer<typeof formSchema>;
+  const [items, setItems] = useState<Item[]>([]);
+  const [links, setLinks] = useState<Link[]>([]);
+  const [selectedItem, setItem] = useState<Item | null>(null);
+  const [selectedLink, setLink] = useState<Link | null>(null);
+  const [settingLinks, setSettingLinks] = useState<boolean>(false);
+
+  async function onSubmit(values: FormData) {
+    if (selectedItem) {
+      setItems((currentItems) =>
+        currentItems.map((item) =>
+          item.trigger === selectedItem.trigger ? { ...item, ...values } : item
+        )
+      );
+      setItem(null);
+    } else {
+      setItems((currentItems) => [
+        ...currentItems,
+        {
+          trigger: `${
+            currentItems.length > 0
+              ? parseInt(currentItems[currentItems.length - 1].trigger) + 1
+              : 0
+          }`,
+          date: values.date || '',
+          title: values.title,
+          description: values.description,
+          active: values.active,
+          highlighted: values.highlighted,
+          activeFrom: values.activeFrom,
+          activeTo: values.activeTo,
+          links: values.links || [],
+        },
+      ]);
+    }
+    form.reset(defaults);
+    setLinks([]);
+  }
+
+  function handleAddLink(values: FormData) {
+    if (selectedLink) {
+      setLinks((currentLinks) =>
+        currentLinks.map((link) =>
+          link.trigger === selectedLink.trigger
+            ? {
+                ...link,
+                title:
+                  values.links?.find((l) => l.trigger === link.trigger)
+                    ?.title || '',
+                url:
+                  values.links?.find((l) => l.trigger === link.trigger)?.url ||
+                  '',
+                openInNewWindow:
+                  values.links?.find((l) => l.trigger === link.trigger)
+                    ?.openInNewWindow || false,
+              }
+            : link
+        )
+      );
+      setLink(null);
+    } else {
+      const newLink = {
+        trigger: `${
+          links.length > 0 ? parseInt(links[links.length - 1].trigger) + 1 : 0
+        }`,
+        title: values.links?.[values.links.length - 1].title || '',
+        url: values.links?.[values.links.length - 1].url || '',
+        openInNewWindow:
+          values.links?.[values.links.length - 1].openInNewWindow || false,
+      };
+      setLinks((currentLinks) => [...currentLinks, newLink]);
+    }
+  }
+
+  const defaults = () => ({
+    trigger: '0',
+    date: '',
+    title: '',
+    description: '',
+    active: true,
+    highlighted: false,
+    activeFrom: '',
+    activeTo: '',
+    links: [],
+  });
+
+  const form = useForm<FormData>({
+    resolver: zodResolver<any>(formSchema),
+    defaultValues: defaults(),
+  });
+
+  type Item = {
+    trigger: string;
+    date?: string;
+    title?: string;
+    description: string;
+    active: boolean;
+    highlighted?: boolean;
+    activeFrom?: string;
+    activeTo?: string;
+    links?: Array<Link>;
+  };
+
+  type Link = {
+    trigger: string;
+    title: string;
+    url: string;
+    openInNewWindow: boolean;
+  };
+
+  useEffect(() => {
+    const agendaItems = (props as any)?.agendaWidget?.items;
+    if (agendaItems && agendaItems.length > 0) {
+      setItems(agendaItems);
+    }
+  }, [(props as any)?.agendaWidget?.items]);
+
+  const { onFieldChanged } = props;
+  useEffect(() => {
+    onFieldChanged('agendaWidget', {
+      ...((props as any)?.agendaWidget || {}),
+      items,
+    });
+  }, [items]);
+
+  useEffect(() => {
+    if (selectedItem) {
+      form.reset({
+        trigger: selectedItem.trigger,
+        date: selectedItem.date || '',
+        title: selectedItem.title || '',
+        description: selectedItem.description,
+        active: selectedItem.active,
+        highlighted: selectedItem.highlighted || false,
+        activeFrom: toDateInputValue(selectedItem.activeFrom),
+        activeTo: toDateInputValue(selectedItem.activeTo),
+        links: selectedItem.links || [],
+      });
+      setLinks(selectedItem.links || []);
+    }
+  }, [selectedItem, form]);
+
+  useEffect(() => {
+    if (selectedLink) {
+      const updatedLinks = [...links];
+      const index = links.findIndex(
+        (link) => link.trigger === selectedLink.trigger
+      );
+      updatedLinks[index] = { ...selectedLink };
+
+      form.reset({
+        ...form.getValues(),
+        links: updatedLinks,
+      });
+    }
+  }, [selectedLink, form, links]);
+
+  const handleAction = (
+    actionType: 'moveUp' | 'moveDown' | 'delete',
+    clickedTrigger: string,
+    isItemAction: boolean
+  ) => {
+    if (isItemAction) {
+      setItems((currentItems) => {
+        return handleMovementOrDeletion(
+          currentItems,
+          actionType,
+          clickedTrigger
+        ) as Item[];
+      });
+    } else {
+      setLinks((currentLinks) => {
+        return handleMovementOrDeletion(
+          currentLinks,
+          actionType,
+          clickedTrigger
+        ) as Link[];
+      });
+    }
+  };
+
+  function handleMovementOrDeletion(
+    list: Array<Item | Link>,
+    actionType: 'moveUp' | 'moveDown' | 'delete',
+    trigger: string
+  ) {
+    const index = list.findIndex((entry) => entry.trigger === trigger);
+
+    if (actionType === 'delete') {
+      return list.filter((entry) => entry.trigger !== trigger);
+    }
+
+    if (
+      (actionType === 'moveUp' && index > 0) ||
+      (actionType === 'moveDown' && index < list.length - 1)
+    ) {
+      const newItemList = [...list];
+      const swapIndex = actionType === 'moveUp' ? index - 1 : index + 1;
+      let tempTrigger = newItemList[swapIndex].trigger;
+      newItemList[swapIndex].trigger = newItemList[index].trigger;
+      newItemList[index].trigger = tempTrigger;
+      return newItemList;
+    }
+
+    return list;
+  }
+
+  function handleSaveItems() {
+    props.updateConfig({
+      ...props,
+      agendaWidget: {
+        ...((props as any)?.agendaWidget || {}),
+        items,
+      },
+    });
+  }
+
+  function resetForm() {
+    form.reset(defaults());
+    setLinks([]);
+    setItem(null);
+  }
+
+  function handleSaveLinks() {
+    form.setValue('links', links);
+    setSettingLinks(false);
+  }
+
+  return (
+    <div>
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="w-full grid gap-4">
+          <div className="lg:w-full grid grid-cols-1 gap-x-6 lg:grid-cols-3">
+            <div className="p-6 bg-white rounded-md flex flex-col justify-between">
+              <div>
+                <Heading size="xl">Lijst van tijdlijn items</Heading>
+                <Separator className="my-4" />
+                <div className="flex flex-col gap-1">
+                  {items.length > 0
+                    ? items
+                        .sort(
+                          (a, b) => parseInt(a.trigger) - parseInt(b.trigger)
+                        )
+                        .map((item, index) => (
+                          <div
+                            key={index}
+                            className={`flex cursor-pointer justify-between border border-secondary ${
+                              item.trigger == selectedItem?.trigger &&
+                              'bg-secondary'
+                            }`}>
+                            <span className="flex gap-2 py-3 px-2">
+                              <ArrowUp
+                                className="cursor-pointer"
+                                onClick={() =>
+                                  handleAction('moveUp', item.trigger, true)
+                                }
+                              />
+                              <ArrowDown
+                                className="cursor-pointer"
+                                onClick={() =>
+                                  handleAction('moveDown', item.trigger, true)
+                                }
+                              />
+                            </span>
+                            <span
+                              className="gap-2 py-3 px-2 w-full"
+                              onClick={() => setItem(item)}>
+                              {item.title}
+                            </span>
+                            <span className="gap-2 py-3 px-2">
+                              <X
+                                className="cursor-pointer"
+                                onClick={() =>
+                                  handleAction('delete', item.trigger, true)
+                                }
+                              />
+                            </span>
+                          </div>
+                        ))
+                    : 'Geen items'}
+                </div>
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  className="w-fit mt-4"
+                  type="button"
+                  onClick={() => handleSaveItems()}>
+                  Configuratie opslaan
+                </Button>
+              </div>
+            </div>
+
+            {settingLinks ? (
+              <div className="p-6 bg-white rounded-md col-span-2 grid grid-cols-1 lg:grid-cols-2 gap-x-6">
+                <div className="flex flex-col justify-between">
+                  <div className="flex flex-col gap-y-2">
+                    <Heading size="xl">Links</Heading>
+                    <Separator className="mt-2" />
+                    <FormField
+                      control={form.control}
+                      name={`links.${links.length - 1}.title`}
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Link titel</FormLabel>
+                          <Input {...field} />
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name={`links.${links.length - 1}.url`}
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Link URL</FormLabel>
+                          <Input {...field} />
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name={`links.${links.length - 1}.openInNewWindow`}
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Open in nieuw venster</FormLabel>
+                          {YesNoSelect(field, props)}
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <Button
+                      className="w-full bg-secondary text-black hover:text-white mt-4"
+                      type="button"
+                      onClick={() => handleAddLink(form.getValues())}>
+                      {selectedLink
+                        ? 'Sla wijzigingen op'
+                        : 'Voeg link toe aan lijst'}
+                    </Button>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button
+                      className="w-fit mt-4 bg-secondary text-black hover:text-white"
+                      type="button"
+                      onClick={() => {
+                        (setSettingLinks(() => !settingLinks),
+                          setLink(null),
+                          setLinks([]));
+                      }}>
+                      Annuleer
+                    </Button>
+                    <Button
+                      className="w-fit mt-4"
+                      type="button"
+                      onClick={() => handleSaveLinks()}>
+                      Sla links op
+                    </Button>
+                  </div>
+                </div>
+                <div>
+                  <Heading size="xl">Lijst van huidige links</Heading>
+                  <Separator className="my-4" />
+                  <div className="flex flex-col gap-1">
+                    {links.length > 0
+                      ? links
+                          .sort(
+                            (a, b) => parseInt(a.trigger) - parseInt(b.trigger)
+                          )
+                          .map((link, index) => (
+                            <div
+                              key={index}
+                              className={`flex cursor-pointer justify-between border border-secondary ${
+                                link.trigger == selectedLink?.trigger &&
+                                'bg-secondary'
+                              }`}>
+                              <span className="flex gap-2 py-3 px-2">
+                                <ArrowUp
+                                  className="cursor-pointer"
+                                  onClick={() =>
+                                    handleAction('moveUp', link.trigger, false)
+                                  }
+                                />
+                                <ArrowDown
+                                  className="cursor-pointer"
+                                  onClick={() =>
+                                    handleAction(
+                                      'moveDown',
+                                      link.trigger,
+                                      false
+                                    )
+                                  }
+                                />
+                              </span>
+                              <span
+                                className="py-3 px-2 w-full"
+                                onClick={() => setLink(link)}>
+                                {link.title}
+                              </span>
+                              <span className="py-3 px-2">
+                                <X
+                                  className="cursor-pointer"
+                                  onClick={() =>
+                                    handleAction('delete', link.trigger, false)
+                                  }
+                                />
+                              </span>
+                            </div>
+                          ))
+                      : 'Geen links'}
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <div className="p-6 bg-white rounded-md flex flex-col col-span-2">
+                <div>
+                  <Heading size="xl">Tijdlijn items</Heading>
+                  <Separator className="my-4" />
+                  <FormField
+                    control={form.control}
+                    name="trigger"
+                    render={({ field }) => (
+                      <FormItem>
+                        <Input type="hidden" {...field} />
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <div className="w-full lg:w-2/3 flex flex-col gap-y-2">
+                    <FormField
+                      control={form.control}
+                      name="date"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Datum</FormLabel>
+                          <Input type="date" {...field} />
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name="title"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Titel</FormLabel>
+                          <Input {...field} />
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name="description"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Beschrijving</FormLabel>
+                          <Input {...field} />
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name="active"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Markeer item als actief</FormLabel>
+                          <Switch.Root
+                            className="block w-[50px] h-[25px] bg-stone-300 rounded-full relative focus:shadow-[0_0_0_2px] focus:shadow-black data-[state=checked]:bg-primary outline-none cursor-default"
+                            onCheckedChange={(e: boolean) => {
+                              field.onChange(e);
+                            }}
+                            checked={field.value}>
+                            <Switch.Thumb className="block w-[21px] h-[21px] bg-white rounded-full transition-transform duration-100 translate-x-0.5 will-change-transform data-[state=checked]:translate-x-[27px]" />
+                          </Switch.Root>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name="highlighted"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Extra uitlichten</FormLabel>
+                          <FormDescription>
+                            Dit item wordt weergegeven als een gekleurd blok met
+                            de primaire kleuren.
+                          </FormDescription>
+                          <Switch.Root
+                            className="block w-[50px] h-[25px] bg-stone-300 rounded-full relative focus:shadow-[0_0_0_2px] focus:shadow-black data-[state=checked]:bg-primary outline-none cursor-default"
+                            onCheckedChange={(e: boolean) => {
+                              field.onChange(e);
+                            }}
+                            checked={field.value}>
+                            <Switch.Thumb className="block w-[21px] h-[21px] bg-white rounded-full transition-transform duration-100 translate-x-0.5 will-change-transform data-[state=checked]:translate-x-[27px]" />
+                          </Switch.Root>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormItem>
+                      <Button
+                        className="w-fit mt-4 bg-secondary text-black hover:text-white"
+                        type="button"
+                        onClick={() => setSettingLinks(!settingLinks)}>
+                        {`Pas website links (${links.length}) aan`}
+                      </Button>
+                      <FormMessage />
+                    </FormItem>
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  {selectedItem && (
+                    <Button
+                      className="w-fit mt-4 bg-secondary text-black hover:text-white"
+                      type="button"
+                      onClick={() => {
+                        resetForm();
+                      }}>
+                      Annuleer
+                    </Button>
+                  )}
+                  <Button className="w-fit mt-4" type="submit">
+                    {selectedItem
+                      ? 'Sla wijzigingen op'
+                      : 'Voeg item toe aan lijst'}
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/packages/resource-detail/src/resource-detail.css
+++ b/packages/resource-detail/src/resource-detail.css
@@ -392,3 +392,141 @@
 .dd-accordion:has(.dd-accordion-content-wrapper[data-visible-lines='10']) {
   --dataAccordionLines: calc(10 * var(--accordion-lineHeight));
 }
+
+/* ============================
+   Agenda / Tijdlijn Section
+   ============================ */
+.osc-resource-detail-agenda-section {
+  padding-top: 0.5rem;
+  padding-bottom: 1.25rem;
+}
+
+.osc-resource-detail-agenda-section .utrecht-heading-3 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 0.6rem;
+  line-height: 1.3;
+}
+
+.osc-resource-detail-agenda-section .osc-agenda {
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  position: relative;
+}
+
+/* Vertical line on the container */
+.osc-resource-detail-agenda-section .osc-agenda::after {
+  content: '';
+  position: absolute;
+  left: 24px;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background-color: var(--nlds-agenda-line-color, #333);
+  z-index: 0;
+}
+
+.osc-resource-detail-agenda-section .osc-agenda-item {
+  background-color: var(--nlds-agenda-item-bg, #f5f5f5);
+  padding: 0.6rem 0.8rem 0.6rem 2.5rem;
+  margin-left: 0;
+  border: none;
+  position: relative;
+}
+
+.osc-resource-detail-agenda-section .osc-agenda-item:last-child {
+  padding-bottom: 0.6rem;
+}
+
+/* Hide ALL original pseudo-element lines */
+.osc-resource-detail-agenda-section .osc-agenda-item::before,
+.osc-resource-detail-agenda-section .osc-agenda-item::after {
+  display: none !important;
+  content: none !important;
+}
+
+/* Circle centered on the line */
+.osc-resource-detail-agenda-section .osc-date-circle {
+  box-sizing: content-box;
+  position: absolute;
+  left: 15px;
+  top: 1.3rem;
+  transform: none;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background-color: #fff;
+  border: 5px solid var(--nlds-agenda-dot-color, #333);
+  outline: none;
+  margin: 0;
+  flex-shrink: 0;
+  z-index: 2;
+}
+
+.osc-resource-detail-agenda-section
+  .osc-agenda-item.--active-item
+  .osc-date-circle {
+  background-color: var(--nlds-agenda-dot-color, #333);
+}
+
+.osc-resource-detail-agenda-section
+  .osc-agenda-item.--active-item
+  .osc-date-circle:before {
+  display: none;
+}
+
+/* Content area */
+.osc-resource-detail-agenda-section .osc-agenda-content {
+  background-color: transparent;
+  border: none;
+  border-radius: 3px;
+  padding: 0.6rem 1rem;
+  flex: 1;
+}
+
+.osc-tijdlijn-date {
+  font-size: 1.1rem;
+  font-weight: 700;
+  line-height: 1.5;
+  color: #282828;
+  display: inline;
+}
+
+.osc-tijdlijn-date::after {
+  content: ' - ';
+}
+
+.osc-resource-detail-agenda-section .osc-agenda-content h4 {
+  font-size: 1.1rem;
+  display: inline;
+  font-weight: 700;
+  line-height: 1.5;
+  margin: 0;
+  color: #282828;
+}
+
+.osc-resource-detail-agenda-section .osc-agenda-content p {
+  font-size: 1.1rem;
+  line-height: 1.5;
+  margin: 0 0 0.1rem 0;
+  color: #282828;
+}
+
+.osc-resource-detail-agenda-section .osc-agenda-list {
+  margin-top: 0.1rem;
+  padding: 0;
+}
+
+.osc-resource-detail-agenda-section .osc-agenda-list a {
+  color: var(--nlds-agenda-link-color, #0a7b6c) !important;
+  text-decoration: underline !important;
+  font-size: 1rem !important;
+  font-weight: 700 !important;
+}
+
+.osc-resource-detail-agenda-section .osc-agenda-list a:hover {
+  text-decoration: none !important;
+}

--- a/packages/resource-detail/src/resource-detail.tsx
+++ b/packages/resource-detail/src/resource-detail.tsx
@@ -61,7 +61,8 @@ type booleanProps = {
     | 'displayEditResourceButton'
     | 'displayDeleteButton'
     | 'displayDeleteEditButtonOnTop'
-    | 'displaySocials']: boolean | undefined;
+    | 'displaySocials'
+    | 'displayAgenda']: boolean | undefined;
 };
 
 export type ResourceDetailWidgetProps = {
@@ -135,6 +136,7 @@ function ResourceDetail({
   displaySocials = true,
   displayDocuments = true,
   clickableImage = false,
+  displayAgenda = false,
   documentsTitle = '',
   documentsDesc = '',
   backUrlText = 'Terug naar het document',
@@ -187,6 +189,10 @@ function ResourceDetail({
   };
 
   if (!resource) return null;
+
+  // Tijdlijn items
+  const tijdlijnItems = resource?.extraData?.tijdlijn || [];
+
   const shouldHaveSideColumn =
     displayLikes ||
     displayTags ||
@@ -606,6 +612,66 @@ function ResourceDetail({
                     </div>
                   ))}
               </div>
+
+              {displayAgenda &&
+                tijdlijnItems.length > 0 &&
+                !resource?.extraData?.hideTijdlijn && (
+                  <div className="osc-resource-detail-agenda-section">
+                    <Heading level={3} appearance="utrecht-heading-3">
+                      Project tijdlijn
+                    </Heading>
+                    <section className="osc-agenda">
+                      {tijdlijnItems
+                        .sort(
+                          (a: any, b: any) =>
+                            parseInt(a.trigger) - parseInt(b.trigger)
+                        )
+                        .map((item: any, index: number) => (
+                          <div
+                            key={index}
+                            className={`osc-agenda-item${item.active || (item.date && new Date(item.date) <= new Date()) ? ' --active-item' : ''}`}>
+                            <div className="osc-date-circle" />
+                            <div className="osc-agenda-content">
+                              {item.date && (
+                                <span className="osc-tijdlijn-date">
+                                  {new Date(item.date).toLocaleDateString(
+                                    'nl-NL',
+                                    {
+                                      day: 'numeric',
+                                      month: 'long',
+                                      year: 'numeric',
+                                    }
+                                  )}
+                                </span>
+                              )}
+                              <h4>{item.title}</h4>
+                              {item.description && <p>{item.description}</p>}
+                              {item.links && item.links.length > 0 && (
+                                <div className="osc-agenda-list">
+                                  {item.links.map(
+                                    (link: any, linkIndex: number) => (
+                                      <a
+                                        key={linkIndex}
+                                        href={link.url || '#'}
+                                        target={
+                                          link.openInNewWindow
+                                            ? '_blank'
+                                            : '_self'
+                                        }
+                                        rel="noopener noreferrer">
+                                        {link.title || 'Lees het verslag'}
+                                      </a>
+                                    )
+                                  )}
+                                </div>
+                              )}
+                            </div>
+                          </div>
+                        ))}
+                    </section>
+                  </div>
+                )}
+
               {displayLocation && resource.location && (
                 <>
                   <Heading level={2} appearance="utrecht-heading-2">


### PR DESCRIPTION
## Beschrijving
Tijdlijn (timeline) sectie toegevoegd aan de resource-detail-with-map widget.
Hiermee kunnen projectbeheerders een visuele tijdlijn tonen op de detailpagina van een resource.

## Wijzigingen
- `displayAgenda` prop toegevoegd om tijdlijn zichtbaarheid te schakelen
- Tijdlijn rendering met datumcirkels, verticale lijn en actieve status
- Tijdlijn CSS met box-sizing fix voor CMS compatibiliteit
- Tijdlijn admin configuratiepagina toegevoegd
- Tijdlijn tab toegevoegd aan widget admin paneel

## Bestanden
- `packages/resource-detail-with-map/src/resourceDetailWithMap.tsx`
- `packages/resource-detail-with-map/src/resourceDetailWithMap.css`
- `apps/admin-server/src/pages/projects/[project]/widgets/resourcedetailwithmap/[id]/tijdlijn.tsx` (nieuw)
- `apps/admin-server/src/pages/projects/[project]/widgets/resourcedetailwithmap/[id]/index.tsx`