### PR TITLE
Add timeline to resource detail widget and admin panel

### DIFF
--- a/apps/admin-server/src/components/resource-form.tsx
+++ b/apps/admin-server/src/components/resource-form.tsx
@@ -254,6 +254,49 @@ export default function ResourceForm({ onFormSubmit }: Props) {
   const [extraData, setExtraData] = useState(existingData?.extraData || '');
   const [imageIndexOpen, setImageIndexOpen] = useState<number>(-1);
 
+  // Timeline state
+  interface TimelineLink {
+    title: string;
+    url: string;
+    openInNewWindow: boolean;
+  }
+  interface TimelineItem {
+    trigger: string;
+    date?: string;
+    title: string;
+    description: string;
+    active: boolean;
+    highlighted?: boolean;
+    links?: TimelineLink[];
+  }
+  // `timeline` is the canonical key; `tijdlijn` is kept as a read-only fallback
+  // for backward compatibility with records saved before the rename.
+  const [timelineItems, setTimelineItems] = useState<TimelineItem[]>(
+    existingData?.extraData?.timeline ?? existingData?.extraData?.tijdlijn ?? []
+  );
+  const [tlTitle, setTlTitle] = useState('');
+  const [tlDate, setTlDate] = useState('');
+  const [tlDescription, setTlDescription] = useState('');
+  const [tlActive, setTlActive] = useState(true);
+  const [tlHighlighted, setTlHighlighted] = useState(false);
+  const [tlLinks, setTlLinks] = useState<TimelineLink[]>([]);
+  const [tlLinkTitle, setTlLinkTitle] = useState('');
+  const [tlLinkUrl, setTlLinkUrl] = useState('');
+  const [tlLinkNewWindow, setTlLinkNewWindow] = useState(false);
+  const [editingTlIndex, setEditingTlIndex] = useState<number | null>(null);
+
+  // Sync timeline state once existingData finishes loading (SWR is async).
+  // Without this, opening an edit page shows an empty editor even if the
+  // resource already has timeline items saved.
+  useEffect(() => {
+    if (!existingData) return;
+    const loaded =
+      existingData?.extraData?.timeline ??
+      existingData?.extraData?.tijdlijn ??
+      [];
+    setTimelineItems(loaded);
+  }, [existingData?.id, existingData?.extraData]);
+
   const [targetUser, setTargetUser] = useState<{
     name?: string;
     email?: string;
@@ -300,10 +343,27 @@ export default function ResourceForm({ onFormSubmit }: Props) {
   function onSubmit(values: FormType) {
     // Add extraData if its valid JSON
     try {
-      if (extraData !== values.extraData) {
+      if (typeof extraData === 'string' && extraData.length > 0) {
         values.extraData = JSON.parse(extraData);
       }
-    } catch (e) {}
+    } catch (e) {
+      console.warn('Invalid extraData JSON, skipping parse:', e);
+    }
+    // extraData is a freeform JSON blob in this codebase;
+    // schema types only the `originalId` key explicitly. Localized cast is
+    // intentional here to avoid forcing all other extraData writers to update.
+    // extraData is a freeform JSON blob; the schema only types `originalId`
+    // explicitly. A localized cast keeps the write site type-safe without
+    // forcing every other extraData consumer to update.
+    const extraDataObj =
+      typeof values.extraData === 'object' && values.extraData !== null
+        ? (values.extraData as Record<string, unknown>)
+        : {};
+    extraDataObj.timeline = timelineItems;
+    // Drop the legacy `tijdlijn` key on write so new saves use the canonical
+    // `timeline` key. Old records are still readable via the fallback above.
+    delete extraDataObj.tijdlijn;
+    values.extraData = extraDataObj as typeof values.extraData;
 
     onFormSubmit(values)
       .then(() => {
@@ -886,6 +946,217 @@ export default function ResourceForm({ onFormSubmit }: Props) {
                 );
               }}
             />
+          </div>
+          <div className="col-span-full">
+            <h3 className="text-lg font-bold mb-2">Timeline</h3>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="border rounded p-4 bg-gray-50">
+                <h4 className="font-semibold mb-2">
+                  Items ({timelineItems.length})
+                </h4>
+                <div className="flex flex-col gap-1 max-h-60 overflow-y-auto">
+                  {timelineItems.map((item, idx) => (
+                    <div
+                      key={idx}
+                      className={`flex items-center gap-2 p-2 border rounded cursor-pointer ${editingTlIndex === idx ? 'bg-blue-100 border-blue-400' : 'bg-white'}`}
+                      onClick={() => {
+                        setEditingTlIndex(idx);
+                        setTlTitle(item.title);
+                        setTlDate(item.date || '');
+                        setTlDescription(item.description);
+                        setTlActive(item.active);
+                        setTlHighlighted(item.highlighted || false);
+                        setTlLinks(item.links || []);
+                      }}>
+                      <span
+                        className={`w-3 h-3 rounded-full flex-shrink-0 ${item.active ? 'bg-green-500' : 'bg-gray-300'}`}></span>
+                      <span className="flex-1 text-sm font-medium truncate">
+                        {item.date
+                          ? new Date(item.date).toLocaleDateString('nl-NL', {
+                              day: 'numeric',
+                              month: 'short',
+                              year: 'numeric',
+                            }) + ' - '
+                          : ''}
+                        {item.title}
+                      </span>
+                      <button
+                        type="button"
+                        className="text-red-500 text-xs flex-shrink-0"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setTimelineItems(
+                            timelineItems.filter((_, i) => i !== idx)
+                          );
+                          if (editingTlIndex === idx) setEditingTlIndex(null);
+                        }}>
+                        ✕
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <div className="border rounded p-4 bg-gray-50">
+                <h4 className="font-semibold mb-2">
+                  {editingTlIndex !== null ? 'Edit item' : 'New item'}
+                </h4>
+                <div className="flex flex-col gap-2">
+                  <input
+                    className="border rounded p-2"
+                    placeholder="Title"
+                    value={tlTitle}
+                    onChange={(e) => setTlTitle(e.target.value)}
+                  />
+                  <input
+                    className="border rounded p-2"
+                    type="date"
+                    value={tlDate}
+                    onChange={(e) => setTlDate(e.target.value)}
+                  />
+                  <input
+                    className="border rounded p-2"
+                    placeholder="Description"
+                    value={tlDescription}
+                    onChange={(e) => setTlDescription(e.target.value)}
+                  />
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={tlActive}
+                      onChange={(e) => setTlActive(e.target.checked)}
+                    />{' '}
+                    Active
+                  </label>
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={tlHighlighted}
+                      onChange={(e) => setTlHighlighted(e.target.checked)}
+                    />{' '}
+                    Highlighted
+                  </label>
+                  <div className="border-t pt-2 mt-1">
+                    <h5 className="text-sm font-semibold mb-1">
+                      Links ({tlLinks.length})
+                    </h5>
+                    {tlLinks.map((link, li) => (
+                      <div
+                        key={li}
+                        className="flex items-center gap-1 text-xs mb-1">
+                        <span className="flex-1 truncate">{link.title}</span>
+                        <button
+                          type="button"
+                          className="text-red-500"
+                          onClick={() =>
+                            setTlLinks(tlLinks.filter((_, i) => i !== li))
+                          }>
+                          ✕
+                        </button>
+                      </div>
+                    ))}
+                    <div className="flex gap-1 mt-1">
+                      <input
+                        className="border rounded p-1 text-xs flex-1"
+                        placeholder="Link title"
+                        value={tlLinkTitle}
+                        onChange={(e) => setTlLinkTitle(e.target.value)}
+                      />
+                      <input
+                        className="border rounded p-1 text-xs flex-1"
+                        placeholder="URL"
+                        value={tlLinkUrl}
+                        onChange={(e) => setTlLinkUrl(e.target.value)}
+                      />
+                      <button
+                        type="button"
+                        className="bg-gray-200 px-2 py-1 rounded text-xs"
+                        onClick={() => {
+                          if (!tlLinkTitle || !tlLinkUrl) return;
+                          setTlLinks([
+                            ...tlLinks,
+                            {
+                              title: tlLinkTitle,
+                              url: tlLinkUrl,
+                              openInNewWindow: tlLinkNewWindow,
+                            },
+                          ]);
+                          setTlLinkTitle('');
+                          setTlLinkUrl('');
+                        }}>
+                        +
+                      </button>
+                    </div>
+                  </div>
+                  <div className="flex gap-2 mt-2">
+                    <button
+                      type="button"
+                      className="bg-blue-500 text-white px-3 py-1 rounded text-sm"
+                      onClick={() => {
+                        if (!tlTitle) return;
+                        // If user typed a link but didn't click "+", auto-append so it isn't silently lost.
+                        const pendingLinks =
+                          tlLinkTitle && tlLinkUrl
+                            ? [
+                                ...tlLinks,
+                                {
+                                  title: tlLinkTitle,
+                                  url: tlLinkUrl,
+                                  openInNewWindow: tlLinkNewWindow,
+                                },
+                              ]
+                            : tlLinks;
+                        const item: TimelineItem = {
+                          trigger:
+                            editingTlIndex !== null
+                              ? timelineItems[editingTlIndex].trigger
+                              : String(timelineItems.length),
+                          date: tlDate || undefined,
+                          title: tlTitle,
+                          description: tlDescription,
+                          active: tlActive,
+                          highlighted: tlHighlighted,
+                          links: pendingLinks,
+                        };
+                        setTimelineItems((prev) =>
+                          editingTlIndex !== null
+                            ? prev.map((it, i) =>
+                                i === editingTlIndex ? item : it
+                              )
+                            : [...prev, item]
+                        );
+                        setEditingTlIndex(null);
+                        setTlTitle('');
+                        setTlDate('');
+                        setTlDescription('');
+                        setTlActive(true);
+                        setTlHighlighted(false);
+                        setTlLinks([]);
+                        setTlLinkTitle('');
+                        setTlLinkUrl('');
+                        setTlLinkNewWindow(false);
+                      }}>
+                      {editingTlIndex !== null ? 'Update' : 'Add'}
+                    </button>
+                    {editingTlIndex !== null && (
+                      <button
+                        type="button"
+                        className="bg-gray-300 px-3 py-1 rounded text-sm"
+                        onClick={() => {
+                          setEditingTlIndex(null);
+                          setTlTitle('');
+                          setTlDate('');
+                          setTlDescription('');
+                          setTlActive(true);
+                          setTlHighlighted(false);
+                          setTlLinks([]);
+                        }}>
+                        Cancel
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
 
           <div className="col-span-full lg:col-span-1">

--- a/apps/admin-server/src/pages/projects/[project]/resources/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/resources/index.tsx
@@ -67,7 +67,9 @@ const prepareDataForExport = (data: any[]) => {
             .join(' | ');
 
           resource[key] = createString || '';
-        } catch (e) {}
+        } catch (e) {
+          console.warn(`Failed to serialize statuses for export (${key}):`, e);
+        }
       }
 
       if (
@@ -87,10 +89,11 @@ const prepareDataForExport = (data: any[]) => {
             .join(' | ');
 
           resource[key] = createString || '';
-        } catch (e) {}
+        } catch (e) {
+          console.warn(`Failed to serialize ${key} for export:`, e);
+        }
       }
     }
-
     allResources.push(resource);
   });
 

--- a/apps/admin-server/src/pages/projects/[project]/widgets/agenda/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/agenda/[id]/items.tsx
@@ -22,6 +22,7 @@ import * as z from 'zod';
 
 const formSchema = z.object({
   trigger: z.string(),
+  date: z.string().optional(),
   title: z.string(),
   description: z.string(),
   active: z.boolean(),
@@ -32,6 +33,7 @@ const formSchema = z.object({
     .array(
       z.object({
         trigger: z.string(),
+        date: z.string().optional(),
         title: z.string(),
         url: z.string(),
         openInNewWindow: z.boolean(),
@@ -78,6 +80,7 @@ export default function WidgetAgendaItems(
               ? parseInt(currentItems[currentItems.length - 1].trigger) + 1
               : 0
           }`,
+          date: values.date,
           title: values.title,
           description: values.description,
           active: values.active,
@@ -130,6 +133,7 @@ export default function WidgetAgendaItems(
 
   const defaults = () => ({
     trigger: '0',
+    date: '',
     title: '',
     description: '',
     active: true,
@@ -146,6 +150,7 @@ export default function WidgetAgendaItems(
 
   type Item = {
     trigger: string;
+    date?: string;
     title?: string;
     description: string;
     active: boolean;
@@ -177,6 +182,7 @@ export default function WidgetAgendaItems(
     if (selectedItem) {
       form.reset({
         trigger: selectedItem.trigger,
+        date: selectedItem.date || '',
         title: selectedItem.title || '',
         description: selectedItem.description,
         active: selectedItem.active,
@@ -490,6 +496,17 @@ export default function WidgetAgendaItems(
                         <FormItem>
                           <FormLabel>Beschrijving</FormLabel>
                           <Input {...field} />
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name="date"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Datum</FormLabel>
+                          <Input type="date" {...field} />
                           <FormMessage />
                         </FormItem>
                       )}

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/index.tsx
@@ -80,6 +80,7 @@ export default function WidgetResourceDetail({ apiUrl }: WithApiUrlProps) {
             <TabsList className="w-full bg-white border-b-0 mb-4 rounded-md h-fit flex flex-wrap overflow-auto">
               <TabsTrigger value="general">Algemeen</TabsTrigger>
               <TabsTrigger value="display">Weergave</TabsTrigger>
+              <TabsTrigger value="timeline">Timeline</TabsTrigger>
               <TabsTrigger value="map">Kaart</TabsTrigger>
               <TabsTrigger value="comments">Reacties widget</TabsTrigger>
               <TabsTrigger value="likes">Likes widget</TabsTrigger>
@@ -122,6 +123,36 @@ export default function WidgetResourceDetail({ apiUrl }: WithApiUrlProps) {
                     }
                   }}
                 />
+              )}
+            </TabsContent>
+
+            <TabsContent value="timeline" className="p-0">
+              {previewConfig && (
+                <div className="p-6 bg-white rounded-md">
+                  <h3 className="text-lg font-bold mb-4">Timeline</h3>
+                  <p className="text-sm text-gray-600 mb-4">
+                    Enable or disable the timeline section on the resource
+                    detail page. Timeline items are managed per resource in the
+                    resource form.
+                  </p>
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={previewConfig?.displayTimeline || false}
+                      onChange={(e) => {
+                        updateConfig({
+                          ...widget.config,
+                          displayTimeline: e.target.checked,
+                        });
+                        updatePreview({
+                          ...previewConfig,
+                          displayTimeline: e.target.checked,
+                        });
+                      }}
+                    />
+                    <span>Show timeline</span>
+                  </label>
+                </div>
               )}
             </TabsContent>
 

--- a/packages/agenda/src/agenda.css
+++ b/packages/agenda/src/agenda.css
@@ -154,3 +154,27 @@
   > :nth-last-child(1 of .osc-agenda-item)::after {
   content: none;
 }
+
+.osc-agenda-title-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+}
+
+.osc-agenda-date {
+  font-weight: 700;
+  display: inline;
+  font-size: inherit;
+  font-family: inherit;
+  line-height: inherit;
+  margin: 0;
+}
+
+.osc-agenda-content .utrecht-heading-4 {
+  display: inline;
+  margin: 0;
+}
+
+.osc-agenda-title-row .osc-agenda-date {
+  font-size: var(--utrecht-heading-4-font-size, 1.125rem);
+}

--- a/packages/agenda/src/agenda.tsx
+++ b/packages/agenda/src/agenda.tsx
@@ -26,6 +26,7 @@ export type AgendaWidgetProps = BaseProps &
     useActiveDates?: boolean;
     items?: Array<{
       trigger: string;
+      date?: string;
       title?: string;
       description: string;
       active: boolean;
@@ -114,7 +115,19 @@ function Agenda({
           aria-current={item.active ? 'true' : undefined}>
           <div className="osc-date-circle"></div>
           <div className="osc-agenda-content">
-            <Heading4>{item.title}</Heading4>
+            <div className="osc-agenda-title-row">
+              {item.date && (
+                <span className="osc-agenda-date">
+                  {new Date(item.date).toLocaleDateString('nl-NL', {
+                    day: 'numeric',
+                    month: 'long',
+                    year: 'numeric',
+                  })}
+                  {item.title ? ' - ' : ''}
+                </span>
+              )}
+              <Heading4>{item.title}</Heading4>
+            </div>
             <Paragraph>{item.description}</Paragraph>
             {item.links && item.links?.length > 0 && (
               <LinkList className="osc-agenda-list">

--- a/packages/resource-detail/src/resource-detail.tsx
+++ b/packages/resource-detail/src/resource-detail.tsx
@@ -1,8 +1,9 @@
+//@ts-ignore D.type def missing, will disappear when datastore is ts
+import { Agenda } from '@openstad-headless/agenda/src/agenda';
 import {
   Comments,
   CommentsWidgetProps,
 } from '@openstad-headless/comments/src/comments';
-//@ts-ignore D.type def missing, will disappear when datastore is ts
 import DataStore from '@openstad-headless/data-store/src';
 import { ResourceDetailMap } from '@openstad-headless/leaflet-map/src/resource-detail-map';
 import { MapPropsType } from '@openstad-headless/leaflet-map/src/types';
@@ -61,7 +62,8 @@ type booleanProps = {
     | 'displayEditResourceButton'
     | 'displayDeleteButton'
     | 'displayDeleteEditButtonOnTop'
-    | 'displaySocials']: boolean | undefined;
+    | 'displaySocials'
+    | 'displayTimeline']: boolean | undefined;
 };
 
 export type ResourceDetailWidgetProps = {
@@ -105,6 +107,21 @@ export type ResourceDetailWidgetProps = {
       ResourceDetailMapWidgetProps,
       keyof BaseProps | keyof ProjectSettingProps | 'resourceId'
     >;
+    items?: Array<{
+      trigger: string;
+      title?: string;
+      description: string;
+      active: boolean;
+      highlighted?: boolean;
+      activeFrom?: string;
+      activeTo?: string;
+      links?: Array<{
+        trigger: string;
+        title: string;
+        url: string;
+        openInNewWindow: boolean;
+      }>;
+    }>;
   };
 
 type DocumentType = {
@@ -144,6 +161,7 @@ function ResourceDetail({
   urlWithResourceFormForEditing = '',
   displayDeleteButton = true,
   displayDeleteEditButtonOnTop = false,
+  displayTimeline = false,
   selectedSocialShareOptions = [
     'facebook',
     'x',
@@ -187,6 +205,10 @@ function ResourceDetail({
   };
 
   if (!resource) return null;
+
+  // Timeline items
+  const timelineItems =
+    resource?.extraData?.timeline ?? resource?.extraData?.tijdlijn ?? [];
   const shouldHaveSideColumn =
     displayLikes ||
     displayTags ||
@@ -606,6 +628,14 @@ function ResourceDetail({
                     </div>
                   ))}
               </div>
+              {displayTimeline && timelineItems.length > 0 && (
+                <Agenda
+                  items={timelineItems}
+                  displayTitle={true}
+                  title="Timeline"
+                  {...props}
+                />
+              )}
               {displayLocation && resource.location && (
                 <>
                   <Heading level={2} appearance="utrecht-heading-2">


### PR DESCRIPTION
## Summary

Adds timeline support to the resource detail widget and the admin resource editor, by reusing the existing Agenda widget and extending the existing resource form instead of duplicating either.

## Changes

- **Widget rendering** — resource-detail now renders the timeline by composing the existing Agenda component; the custom timeline rendering added in the previous revision was removed (`resource-detail.tsx` +34 / -133).
- **Admin form** — a timeline section is added to the existing `resource-form.tsx`; the separate `project-resource-form.tsx` (1358 lines) and `tijdlijn.tsx` (596 lines) have been removed.
- **Items editor** — the existing agenda items editor (`widgets/agenda/[id]/items.tsx`) gained a date field so both widgets share the same item shape.
- **Data key migration** — the widget and the admin form read the legacy `extraData.tijdlijn` as a fallback and write the canonical `extraData.timeline`, so existing records keep rendering during the transition. No database migration required.

## Response to review feedback

1. **Platform-generic vs project-specific** — Nijmegen wijken, the Project/Idee distinction, and the form-type selector on the create page are all gone.
2. **Reuse existing components** — widget rendering goes through `packages/agenda/src/agenda.tsx`; the admin items editor is the existing one with one added field.
3. **Form duplication** — `project-resource-form.tsx` removed; the timeline section lives in the original `resource-form.tsx`.
4. **Regression in resources list** — the Wilson score column and sort option have been restored.
5. **Data-based type detection** — `getResourceType` / `isProjectType` / the type filter have been removed; resources stay generic.
6. **Debug code** — `console.log` statements and empty `catch (e) {}` blocks touched by this change are gone.
7. **Language** — variable, function, file, and comment names are in English. Dutch end-user UI labels are kept as-is per the convention in this repo.
8. **TypeScript `any`** — reduced where this change introduced it (e.g. `Record<string, unknown>` instead of `any` for the extraData write path). Some pre-existing `any` usage in export helpers was not expanded; a wider typing pass can follow in a separate PR.

## Data migration note

`extraData.tijdlijn` → `extraData.timeline`. No DB migration needed; both sites read `timeline ?? tijdlijn`, new writes use `timeline` only.