### PR TITLE
fix: strip hash fragment from redirect URL during login

### DIFF
--- a/apps/api-server/src/adapter/openstad/router.js
+++ b/apps/api-server/src/adapter/openstad/router.js
@@ -151,6 +151,11 @@ router
     returnTo = decodeURIComponent(returnTo);
     returnTo = returnTo || '/?openstadlogintoken=[[jwt]]';
     returnTo = String(returnTo);
+
+    const hashIndex = returnTo.indexOf('#');
+    if (hashIndex !== -1) {
+      returnTo = returnTo.substring(0, hashIndex);
+    }
     if (!returnTo.match(/\[\[jwt\]\]/))
       returnTo =
         returnTo +

--- a/apps/api-server/src/routes/widget/widget.js
+++ b/apps/api-server/src/routes/widget/widget.js
@@ -409,6 +409,7 @@ function getWidgetJavascriptOutput(
           const redirectUri = new URL(encodeURI(window.location.href));
           redirectUri.searchParams.delete('openstadlogout');
           redirectUri.searchParams.delete('openstadlogintoken');
+          redirectUri.hash = '';
           
           const config = JSON.parse(\`${widgetConfigWithCorrectEscapes}\`.replaceAll("[[REDIRECT_URI]]", encodeURIComponent(redirectUri.toString())));
           


### PR DESCRIPTION
When a page URL contains a hash fragment (#anchor), the login token was appended after it, making it part of the fragment instead of the query string. The browser never parsed the token, so users stayed logged out. Strips the hash from the redirect URL in both the widget config and the digest-login route.