### PR TITLE
fix: use full URL for canonical default on subdirectory sites

### DIFF
--- a/apps/cms-server/app.js
+++ b/apps/cms-server/app.js
@@ -203,6 +203,7 @@ async function run(id, projectData, options, callback) {
   // Get host from projectData url
   const url = Url.parse(projectData.url);
   const protocol = process.env.FORCE_HTTP ? 'http://' : 'https://';
+  projectData.fullUrl = projectData.url;
   projectData.url = protocol + url.hostname + (url.port ? ':' + url.port : '');
 
   const sessionSecret = await getSessionSecret(projectData.url, projectData.id);

--- a/apps/cms-server/modules/@apostrophecms/seo-fields-global/index.js
+++ b/apps/cms-server/modules/@apostrophecms/seo-fields-global/index.js
@@ -20,7 +20,7 @@ function normalizeCanonicalUrl(value) {
       parsed.pathname = '';
     }
 
-    return parsed.toString();
+    return parsed.toString().replace(/\/$/, '');
   } catch (err) {
     return '';
   }
@@ -33,8 +33,10 @@ function getDefaults(self, req) {
     {};
   const global = (req && req.data && req.data.global) || {};
 
+  const canonicalSource = project.fullUrl || project.url;
+
   return {
-    canonicalDefault: normalizeCanonicalUrl(project.url),
+    canonicalDefault: normalizeCanonicalUrl(canonicalSource),
     organizationDefault:
       project.title ||
       global.projectTitle ||
@@ -126,6 +128,9 @@ module.exports = {
           }
 
           const defaults = getDefaults(self);
+          const project =
+            (self.apos && self.apos.options && self.apos.options.project) || {};
+          const hostnameOnlyCanonical = normalizeCanonicalUrl(project.url);
           const globalTypes = {
             $in: ['@apostrophecms/global', 'apostrophe-global'],
           };
@@ -145,6 +150,28 @@ module.exports = {
               );
             } catch (err) {
               logSafeWarning(self, 'Canonical URL backfill failed', err);
+            }
+
+            // Fix previously saved wrong canonicals (hostname-only instead of full URL)
+            if (
+              hostnameOnlyCanonical &&
+              defaults.canonicalDefault !== hostnameOnlyCanonical
+            ) {
+              try {
+                await self.apos.doc.db.updateMany(
+                  {
+                    type: globalTypes,
+                    seoSiteCanonicalUrl: hostnameOnlyCanonical,
+                  },
+                  { $set: { seoSiteCanonicalUrl: defaults.canonicalDefault } }
+                );
+              } catch (err) {
+                logSafeWarning(
+                  self,
+                  'Canonical URL correction backfill failed',
+                  err
+                );
+              }
             }
           }
 


### PR DESCRIPTION
Subdirectory sites (e.g. example.com/test-site) got example.com as their canonical URL because `app.js` strips the path before passing the project to Apostrophe. This preserves the full URL on a separate property and uses it for the canonical default. Also backfills already-saved wrong hostname-only canonicals in MongoDB on startup.