### PR TITLE
feat: send embeddedUrl with resource submissions and show it in export

### DIFF
--- a/apps/admin-server/src/lib/export-helpers/flattenObject.tsx
+++ b/apps/admin-server/src/lib/export-helpers/flattenObject.tsx
@@ -4,6 +4,10 @@ const flattenObject = (obj: any, parent: string = '', res: any = {}) => {
     if (typeof obj[key] === 'object' && obj[key] !== null) {
       if (key === 'extraData') {
         const cleanedExtraData = cleanExtraData(obj[key]);
+        if (cleanedExtraData.embeddedUrl) {
+          res[`${propName}.embeddedUrl`] = cleanedExtraData.embeddedUrl;
+          delete cleanedExtraData.embeddedUrl;
+        }
         res[propName] = JSON.stringify(cleanedExtraData);
       } else if (Array.isArray(obj[key])) {
         res[propName] = obj[key]

--- a/apps/admin-server/src/lib/keyMap.ts
+++ b/apps/admin-server/src/lib/keyMap.ts
@@ -20,6 +20,7 @@ export const keyMap: Record<string, string> = {
   modBreakDate: 'Moderatie bericht datum',
   images: 'Afbeeldingen',
   documents: 'Documenten',
+  'extraData.embeddedUrl': 'Embedded URL',
   extraData: 'Extra gegevens',
   'user.id': 'Gebruiker ID',
   'user.role': 'Gebruiker rol',

--- a/packages/resource-form/src/resource-form.tsx
+++ b/packages/resource-form/src/resource-form.tsx
@@ -269,6 +269,7 @@ function ResourceFormWidget(props: ResourceFormWidgetProps) {
 
   async function onSubmit(formData: any) {
     setDisableSubmit(true);
+    formData.embeddedUrl = window.location.href;
     const finalFormData = configureFormData(formData, true);
     finalFormData.__timeToSubmitMs = Math.max(
       Date.now() - formStartTimeRef.current,


### PR DESCRIPTION
Resources now include the page URL (`embeddedUrl`) in `extraData` when submitted, matching how enquete and comments already do this. The resource export gets a dedicated "Embedded URL" column instead of burying it in the `extraData`.