### PR TITLE
Feat/widget rendering warning

### DIFF
--- a/apps/admin-server/src/components/ui/typography.tsx
+++ b/apps/admin-server/src/components/ui/typography.tsx
@@ -7,13 +7,18 @@ export function Paragraph({
   children,
   className,
   style,
+  title,
 }: {
   children: ReactNode;
   className?: string;
   style?: CSSProperties;
+  title?: string;
 }) {
   return (
-    <p className={cn('text-sm leading-7', className)} style={style}>
+    <p
+      className={cn('text-sm leading-7', className)}
+      style={style}
+      title={title}>
       {children}
     </p>
   );

--- a/apps/admin-server/src/pages/issues.tsx
+++ b/apps/admin-server/src/pages/issues.tsx
@@ -41,14 +41,46 @@ export default function Projects() {
             </div>
             <ul>
               {data.map((project: any) => {
+                if (
+                  project.issue === 'blocked-domains' &&
+                  project.domainBlocks
+                ) {
+                  return project.domainBlocks.map((block: any) => (
+                    <li
+                      className="grid grid-cols-2 lg:grid-cols-4 items-center py-3 px-2 hover:bg-secondary-background hover:cursor-pointer border-b border-border gap-2"
+                      key={`${project.id}-block-${block.widgetId}-${block.domain}`}
+                      onClick={() => {
+                        router.push(
+                          `/projects/${project.id}/settings/alloweddomains`
+                        );
+                      }}>
+                      <Paragraph className="truncate">{project.name}</Paragraph>
+                      <Paragraph className="hidden lg:flex truncate">
+                        Widget {block.widgetId} ({block.count}x)
+                      </Paragraph>
+                      <Paragraph
+                        className="hidden lg:flex -mr-16 break-all"
+                        title={block.referer}>
+                        Geblokkeerd op {block.domain} ({block.referer})
+                      </Paragraph>
+                      <Paragraph className="flex">
+                        <ChevronRight
+                          strokeWidth={1.5}
+                          className="w-5 h-5 my-auto ml-auto"
+                        />
+                      </Paragraph>
+                    </li>
+                  ));
+                }
+
                 const currentDate = Date.now();
                 const anonymizationDate = addDays(
-                  project.config.project.endDate,
-                  project.config.anonymize.anonymizeUsersXDaysAfterEndDate
+                  project.config?.project?.endDate,
+                  project.config?.anonymize?.anonymizeUsersXDaysAfterEndDate
                 );
                 if (
-                  currentDate > project.config.project.endDate &&
-                  project.config.project.endDate != null
+                  currentDate > project.config?.project?.endDate &&
+                  project.config?.project?.endDate != null
                 ) {
                   return (
                     <li

--- a/apps/api-server/migrations/107-create-domain-blocks.js
+++ b/apps/api-server/migrations/107-create-domain-blocks.js
@@ -1,0 +1,62 @@
+module.exports = {
+  async up({ context: queryInterface }) {
+    await queryInterface.createTable('domain_blocks', {
+      id: {
+        type: require('sequelize').INTEGER,
+        autoIncrement: true,
+        primaryKey: true,
+      },
+      projectId: {
+        type: require('sequelize').INTEGER,
+        allowNull: false,
+        references: { model: 'projects', key: 'id' },
+        onDelete: 'CASCADE',
+      },
+      widgetId: {
+        type: require('sequelize').INTEGER,
+        allowNull: false,
+        references: { model: 'widgets', key: 'id' },
+        onDelete: 'CASCADE',
+      },
+      domain: {
+        type: require('sequelize').STRING,
+        allowNull: false,
+      },
+      referer: {
+        type: require('sequelize').STRING(2048),
+        allowNull: true,
+      },
+      count: {
+        type: require('sequelize').INTEGER,
+        allowNull: false,
+        defaultValue: 1,
+      },
+      lastSeen: {
+        type: require('sequelize').DATE,
+        allowNull: false,
+        defaultValue: require('sequelize').fn('NOW'),
+      },
+      createdAt: {
+        type: require('sequelize').DATE,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: require('sequelize').DATE,
+        allowNull: false,
+      },
+    });
+
+    await queryInterface.addIndex(
+      'domain_blocks',
+      ['projectId', 'widgetId', 'domain'],
+      {
+        unique: true,
+        name: 'domain_blocks_unique',
+      }
+    );
+  },
+
+  async down({ context: queryInterface }) {
+    await queryInterface.dropTable('domain_blocks');
+  },
+};

--- a/apps/api-server/src/adapter/oidc/router.js
+++ b/apps/api-server/src/adapter/oidc/router.js
@@ -277,7 +277,10 @@ router
   })
   .get(function (req, res, next) {
     const isSafeRedirectUrl = (url, allowedDomains) => {
-      allowedDomains = prefillAllowedDomains(allowedDomains || []);
+      allowedDomains = prefillAllowedDomains(
+        allowedDomains || [],
+        req.project?.url
+      );
 
       let redirectUrlHost = '';
       try {

--- a/apps/api-server/src/adapter/openstad/router.js
+++ b/apps/api-server/src/adapter/openstad/router.js
@@ -168,15 +168,10 @@ router
 
     const isAllowedRedirectDomain = (url, project) => {
       let allowedDomains = prefillAllowedDomains(
-        project?.config?.allowedDomains || []
+        project?.config?.allowedDomains || [],
+        project?.url
       );
 
-      if (project.url) {
-        try {
-          let projectDomain = new URL(project.url).host;
-          allowedDomains.push(projectDomain);
-        } catch (err) {}
-      }
       if (config.admin.domain) {
         const domain = config.admin.domain.replace(/:\d+$/, '');
         allowedDomains.push(domain);

--- a/apps/api-server/src/adapter/openstad/service.js
+++ b/apps/api-server/src/adapter/openstad/service.js
@@ -6,6 +6,27 @@ const db = require('../../db');
 
 let service = {};
 
+function getClientDomains(apiDomain, project) {
+  let domains = [apiDomain];
+  if (project?.config?.allowedDomains?.length > 0) {
+    domains = domains.concat(project.config.allowedDomains);
+  }
+  if (project?.url) {
+    try {
+      let url = project.url;
+      if (url.indexOf('http') !== 0) url = 'https://' + url;
+      domains.push(new URL(url).host);
+    } catch (e) {
+      console.log(
+        '[allowedDomains] Could not parse project url:',
+        project.url,
+        e.message
+      );
+    }
+  }
+  return [...new Set(domains.filter(Boolean))];
+}
+
 service.fetchUserData = async function fetchUserData({
   authConfig,
   userId,
@@ -298,7 +319,7 @@ service.createClient = async function ({ authConfig, project }) {
         twoFactorRoles,
         siteUrl: project.url || '',
         redirectUrl: config.url || '',
-        allowedDomains: [config.domain],
+        allowedDomains: getClientDomains(config.domain, project),
         name: authConfig.name || project.name || '',
         description: `Client for API project ${project.name} (${project.id})`,
         config: newConfig,
@@ -339,7 +360,7 @@ service.updateClient = async function ({ authConfig, project }) {
       requiredUserFields,
       twoFactorRoles,
       redirectUrl: `${config.url}`,
-      allowedDomains: [config.domain],
+      allowedDomains: getClientDomains(config.domain, project),
       name: `${project.name}`,
       description: `Client for API project ${project.name} (${project.id})`,
     };
@@ -432,14 +453,6 @@ service.updateClient = async function ({ authConfig, project }) {
 
     let clientConfig = client.config;
     data.config = merge.recursive({}, clientConfig, newClientConfig);
-
-    // Update allowedDomains if exists
-    if (
-      typeof project.config.allowedDomains !== 'undefined' &&
-      project.config.allowedDomains.length > 0
-    ) {
-      data.allowedDomains = project.config.allowedDomains;
-    }
 
     // update client
     let url = `${authConfig.serverUrlInternal}/api/admin/client/${clientId}`;

--- a/apps/api-server/src/cron/send_project_issues_notifications.js
+++ b/apps/api-server/src/cron/send_project_issues_notifications.js
@@ -57,6 +57,18 @@ module.exports = {
           );
         }
 
+        let blockedByProject = await projectsWithIssues.blockedDomains();
+        for (let projectId of Object.keys(blockedByProject)) {
+          let { project, blocks } = blockedByProject[projectId];
+          if (!notificationsToBeSent[projectId])
+            notificationsToBeSent[projectId] = { project, messages: [] };
+          for (let block of blocks) {
+            notificationsToBeSent[projectId].messages.push(
+              `Widget ${block.widgetId} was blocked ${block.count}x on domain "${block.domain}" (last seen: ${block.referer})`
+            );
+          }
+        }
+
         // send notifications
         let projectIds = Object.keys(notificationsToBeSent);
         for (let projectId of projectIds) {

--- a/apps/api-server/src/middleware/security-headers.js
+++ b/apps/api-server/src/middleware/security-headers.js
@@ -13,7 +13,10 @@ module.exports = function (req, res, next) {
   let allowedDomains =
     (req.project && req.project.config && req.project.config.allowedDomains) ||
     config.allowedDomains;
-  allowedDomains = prefillAllowedDomains(allowedDomains || []);
+  allowedDomains = prefillAllowedDomains(
+    allowedDomains || [],
+    req.project?.url
+  );
 
   if (!allowedDomains || allowedDomains.indexOf(domain) === -1) {
     url = config.url || req.protocol + '://' + req.host;

--- a/apps/api-server/src/models/DomainBlock.js
+++ b/apps/api-server/src/models/DomainBlock.js
@@ -1,0 +1,59 @@
+module.exports = function (db, sequelize, DataTypes) {
+  let DomainBlock = sequelize.define(
+    'domain_block',
+    {
+      projectId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      widgetId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      domain: {
+        type: DataTypes.STRING,
+        allowNull: false,
+      },
+      referer: {
+        type: DataTypes.STRING(2048),
+        allowNull: true,
+      },
+      count: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        defaultValue: 1,
+      },
+      lastSeen: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+    },
+    {
+      tableName: 'domain_blocks',
+      paranoid: false,
+      indexes: [
+        {
+          unique: true,
+          fields: ['projectId', 'widgetId', 'domain'],
+          name: 'domain_blocks_unique',
+        },
+      ],
+    }
+  );
+
+  DomainBlock.associate = function (models) {
+    DomainBlock.belongsTo(models.Project, { foreignKey: 'projectId' });
+    DomainBlock.belongsTo(models.Widget, { foreignKey: 'widgetId' });
+  };
+
+  DomainBlock.auth = DomainBlock.prototype.auth = {
+    listableBy: 'admin',
+    viewableBy: 'admin',
+    createableBy: 'admin',
+    updateableBy: 'admin',
+    deleteableBy: 'admin',
+  };
+
+  return DomainBlock;
+};

--- a/apps/api-server/src/models/lib/project-config.js
+++ b/apps/api-server/src/models/lib/project-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   allowedDomains: {
     type: 'arrayOfStrings',
-    default: ['api.openstad.org'],
+    default: [],
   },
 
   project: {

--- a/apps/api-server/src/routes/api/project.js
+++ b/apps/api-server/src/routes/api/project.js
@@ -1214,13 +1214,37 @@ router
       })
       .catch(next);
   })
+  .get(async function (req, res, next) {
+    // blocked domains (last 24h)
+    try {
+      let blockedByProject = await projectsWithIssues.blockedDomains();
+      for (let projectId of Object.keys(blockedByProject)) {
+        let { project, blocks } = blockedByProject[projectId];
+        let entry = project.toJSON();
+        entry.issue = 'blocked-domains';
+        entry.domainBlocks = blocks.map((b) => ({
+          widgetId: b.widgetId,
+          domain: b.domain,
+          referer: b.referer,
+          count: b.count,
+          lastSeen: b.lastSeen,
+        }));
+        req.results.push(entry);
+        req.dbQuery.count += 1;
+      }
+    } catch (e) {
+      console.log('[issues] Could not fetch blocked domains:', e.message);
+    }
+    return next();
+  })
   .get(searchInResults({ searchfields: ['name', 'title'] }))
   .get(auth.useReqUser)
   .get(pagination.paginateResults)
   .get(function (req, res, next) {
     let records = req.results.records || req.results;
     records.forEach((record, i) => {
-      let project = record.toJSON();
+      let project =
+        typeof record.toJSON === 'function' ? record.toJSON() : record;
       if (!(req.user && hasRole(req.user, 'admin'))) {
         project.config = undefined;
       }

--- a/apps/api-server/src/routes/api/project.js
+++ b/apps/api-server/src/routes/api/project.js
@@ -1325,33 +1325,31 @@ router
     if (req.body.url && req.body.url != project.url)
       req.pendingMessages.push({ key: `project-urls-update`, value: 'event' });
 
-    // Update allowedDomains if creating a new site
     let updateBody = req.body;
-    const hasInitDomain =
-      project?.config?.allowedDomains !== undefined &&
-      project.config.allowedDomains.length === 1 &&
-      project.config.allowedDomains[0] == 'api.openstad.org';
-    if (
-      ((project?.config?.allowedDomains || []).length === 0 || hasInitDomain) &&
-      req?.body?.url
-    ) {
-      // Check if url has protocol
-      let reqUrl = req.body.url;
-      if (!reqUrl.includes('http://') && !reqUrl.includes('https://')) {
-        reqUrl = 'http://' + reqUrl;
+
+    if (req.body.url && req.body.url !== project.url) {
+      try {
+        let providers = await authSettings.providers({ project });
+        for (let provider of providers) {
+          let authConfig = await authSettings.config({
+            project,
+            useAuth: provider,
+          });
+          let adapter = await authSettings.adapter({ authConfig });
+          if (adapter.service.updateClient) {
+            let projectWithNewUrl = { ...project.toJSON(), url: req.body.url };
+            await adapter.service.updateClient({
+              authConfig,
+              project: projectWithNewUrl,
+            });
+          }
+        }
+      } catch (err) {
+        console.log(
+          '[allowedDomains] Could not sync auth client after url change:',
+          err.message
+        );
       }
-      let url = new URL(reqUrl);
-      let host = url.host;
-
-      updateBody.config = updateBody.config || {};
-      updateBody.config.allowedDomains = [host];
-
-      // Update client (auth-db)
-      let adminAuthConfig = await authSettings.config({ project: project });
-      service.updateClient({
-        authConfig: adminAuthConfig,
-        project: updateBody,
-      });
     }
 
     project

--- a/apps/api-server/src/routes/widget/widget.js
+++ b/apps/api-server/src/routes/widget/widget.js
@@ -11,6 +11,7 @@ const getWidgetSettings = require('./widget-settings');
 const widgetDefinitions = getWidgetSettings();
 
 const reactCheck = require('../../util/react-check');
+const prefillAllowedDomains = require('../../services/prefillAllowedDomains');
 
 let router = express.Router({ mergeParams: true });
 
@@ -139,6 +140,37 @@ router
       );
     }
 
+    const projectDomains = widget.project.config.allowedDomains || [];
+    const hasProjectDomains = projectDomains.length > 0 || !!widget.project.url;
+
+    const allowedDomains = hasProjectDomains
+      ? prefillAllowedDomains([...projectDomains], widget.project.url)
+      : null;
+
+    const referer = req.headers.referer || req.headers.referrer;
+    if (referer) {
+      if (hasProjectDomains) {
+        try {
+          const refererHost = new URL(referer).hostname;
+          const allowed = allowedDomains.some(
+            (domain) =>
+              refererHost === domain || refererHost === domain.split(':')[0]
+          );
+          if (!allowed) {
+            console.log(
+              `[widget] Widget ${widgetId}: referer "${referer}" is not in the allowed domains for project ${widget.project.id}`
+            );
+          }
+        } catch (e) {
+          // Malformed Referer header, skip domain check
+        }
+      } else {
+        console.log(
+          `[widget] Widget ${widgetId}: project ${widget.project.id} has no url or allowedDomains configured, loaded from "${referer}"`
+        );
+      }
+    }
+
     const defaultConfig = getDefaultConfig(widget.project, widget.type);
 
     try {
@@ -149,7 +181,8 @@ router
         defaultConfig,
         widget.project.safeConfig,
         widget.config,
-        widgetId
+        widgetId,
+        allowedDomains
       );
 
       res.header('Content-Type', 'application/javascript');
@@ -242,7 +275,8 @@ function setConfigsToOutput(
   defaultConfig,
   projectConfig,
   widgetConfig,
-  widgetId
+  widgetId,
+  allowedDomains
 ) {
   // Move general settings to the root to ensure we have the correct config
   if (widgetConfig.hasOwnProperty('general')) {
@@ -264,7 +298,8 @@ function setConfigsToOutput(
     widgetSettings,
     widgetType,
     componentId,
-    config
+    config,
+    allowedDomains
   );
 }
 
@@ -272,7 +307,8 @@ function getWidgetJavascriptOutput(
   widgetSettings,
   widgetType,
   componentId,
-  widgetConfig
+  widgetConfig,
+  allowedDomains
 ) {
   // If we include remix icon in the components, we are sending a lot of data to the client
   // By using a CDN and loading it through a <link> tag, we reduce the size of the response and leverage browser cache
@@ -405,6 +441,31 @@ function getWidgetJavascriptOutput(
         
         const currentScript = document.currentScript;
           currentScript.insertAdjacentHTML('afterend', \`<div class="openstad" id="\${randomComponentId}"></div>\`);
+
+          ${
+            allowedDomains && allowedDomains.length > 0
+              ? `
+          const allowedHosts = ${JSON.stringify(allowedDomains)};
+          const currentHostname = window.location.hostname;
+          const domainAllowed = allowedHosts.some(function(host) {
+            return currentHostname === host || currentHostname === host.split(':')[0];
+          });
+
+          if (!domainAllowed) {
+            var warningEl = document.getElementById(randomComponentId);
+            if (warningEl) {
+              warningEl.innerHTML = '<div style="border: 2px solid #f59e0b; background-color: #fffbeb; border-radius: 8px; padding: 16px 20px; font-family: sans-serif; color: #92400e; margin: 12px 0;">' +
+                '<strong style="font-size: 16px;">OpenStad widget kan niet worden geladen</strong>' +
+                '<p style="margin: 8px 0 0 0; font-size: 14px;">Deze website (<strong>' + currentHostname + '</strong>) staat niet in de lijst met toegestane websites voor dit project. ' +
+                'Voeg dit domein toe in het OpenStad admin-panel onder Instellingen &gt; Toegestane websites.</p></div>';
+            }
+            console.error('OpenStad: widget kan niet laden op ' + currentHostname + ' (domein niet toegestaan)');
+            currentScript.remove();
+            return;
+          }
+          `
+              : ''
+          }
 
           const redirectUri = new URL(encodeURI(window.location.href));
           redirectUri.searchParams.delete('openstadlogout');

--- a/apps/api-server/src/routes/widget/widget.js
+++ b/apps/api-server/src/routes/widget/widget.js
@@ -160,6 +160,32 @@ router
             console.log(
               `[widget] Widget ${widgetId}: referer "${referer}" is not in the allowed domains for project ${widget.project.id}`
             );
+            db.DomainBlock.findOne({
+              where: {
+                projectId: widget.project.id,
+                widgetId: parseInt(widgetId),
+                domain: refererHost,
+              },
+            })
+              .then((record) => {
+                if (record) {
+                  record.update({
+                    count: record.count + 1,
+                    lastSeen: new Date(),
+                    referer,
+                  });
+                } else {
+                  db.DomainBlock.create({
+                    projectId: widget.project.id,
+                    widgetId: parseInt(widgetId),
+                    domain: refererHost,
+                    referer,
+                  });
+                }
+              })
+              .catch((e) =>
+                console.log('[widget] Could not save domain block:', e.message)
+              );
           }
         } catch (e) {
           // Malformed Referer header, skip domain check

--- a/apps/api-server/src/services/isRedirectAllowed.js
+++ b/apps/api-server/src/services/isRedirectAllowed.js
@@ -6,7 +6,8 @@ const isRedirectAllowed = async (projectId, redirectUri) => {
   const project = await db.Project.findByPk(projectId);
   if (!project) return false;
   let allowedDomains = prefillAllowedDomains(
-    project?.config?.allowedDomains || []
+    project?.config?.allowedDomains || [],
+    project?.url
   );
 
   allowedDomains = allowedDomains.map((domain) => {

--- a/apps/api-server/src/services/prefillAllowedDomains.js
+++ b/apps/api-server/src/services/prefillAllowedDomains.js
@@ -1,5 +1,13 @@
-const prefillAllowedDomains = function (allowedDomains) {
+const prefillAllowedDomains = function (allowedDomains, projectUrl) {
   try {
+    if (projectUrl) {
+      let url = projectUrl;
+      if (url.indexOf('http') !== 0) {
+        url = 'https://' + url;
+      }
+      allowedDomains.push(new URL(url).host);
+    }
+
     if (process.env.BASE_DOMAIN) {
       let baseDomain = process.env.BASE_DOMAIN;
       if (baseDomain.indexOf('http') !== 0) {

--- a/apps/api-server/src/services/prefillAllowedDomains.js
+++ b/apps/api-server/src/services/prefillAllowedDomains.js
@@ -1,43 +1,42 @@
+function getParentDomains(hostname) {
+  const host = hostname.split(':')[0];
+  const parts = host.split('.');
+  const parents = [];
+  for (let i = 1; i < parts.length - 1; i++) {
+    parents.push(parts.slice(i).join('.'));
+  }
+  return parents;
+}
+
+function parseHost(value) {
+  if (!value) return null;
+  if (value.indexOf('http') !== 0) value = 'https://' + value;
+  return new URL(value).host;
+}
+
 const prefillAllowedDomains = function (allowedDomains, projectUrl) {
   try {
     if (projectUrl) {
-      let url = projectUrl;
-      if (url.indexOf('http') !== 0) {
-        url = 'https://' + url;
+      allowedDomains.push(parseHost(projectUrl));
+    }
+
+    const envVars = [
+      process.env.BASE_DOMAIN,
+      process.env.URL,
+      process.env.CMS_URL,
+      process.env.AUTH_ADAPTER_OPENSTAD_SERVERURL,
+      process.env.ADMIN_DOMAIN,
+    ];
+
+    for (const envVar of envVars) {
+      if (!envVar) continue;
+      const host = parseHost(envVar);
+      if (host) {
+        allowedDomains.push(host);
+        for (const parent of getParentDomains(host)) {
+          allowedDomains.push(parent);
+        }
       }
-      allowedDomains.push(new URL(url).host);
-    }
-
-    if (process.env.BASE_DOMAIN) {
-      let baseDomain = process.env.BASE_DOMAIN;
-      if (baseDomain.indexOf('http') !== 0) {
-        baseDomain = 'https://' + baseDomain;
-      }
-      const baseUrl = new URL(baseDomain);
-      allowedDomains.push(baseUrl.host);
-    }
-
-    if (process.env.URL) {
-      let hostname = process.env.URL;
-      if (hostname.indexOf('http') !== 0) {
-        hostname = 'https://' + hostname;
-      }
-      const url = new URL(hostname);
-      allowedDomains.push(url.host);
-    }
-
-    if (process.env.CMS_URL) {
-      const cmsUrl = new URL(process.env.CMS_URL);
-      allowedDomains.push(cmsUrl.host);
-    }
-
-    if (process.env.AUTH_ADAPTER_OPENSTAD_SERVERURL) {
-      const authUrl = new URL(process.env.AUTH_ADAPTER_OPENSTAD_SERVERURL);
-      allowedDomains.push(authUrl.host);
-    }
-
-    if (process.env.ADMIN_DOMAIN) {
-      allowedDomains.push(process.env.ADMIN_DOMAIN);
     }
   } catch (err) {
     console.error('Error processing allowed domains:', err);

--- a/apps/api-server/src/services/projects-with-issues.js
+++ b/apps/api-server/src/services/projects-with-issues.js
@@ -92,4 +92,42 @@ projectsWithIssues.endedButNotAnonymized = function ({ offset, limit }) {
   );
 };
 
+projectsWithIssues.blockedDomains = async function () {
+  let blocks = await db.DomainBlock.findAll({
+    attributes: [
+      'projectId',
+      'widgetId',
+      'domain',
+      'referer',
+      'count',
+      'lastSeen',
+    ],
+    where: {
+      lastSeen: {
+        [Sequelize.Op.gte]: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      },
+    },
+    include: [
+      {
+        model: db.Project,
+        attributes: ['id', 'name', 'url'],
+      },
+    ],
+    order: [['count', 'DESC']],
+  });
+
+  let byProject = {};
+  for (let block of blocks) {
+    if (!byProject[block.projectId]) {
+      byProject[block.projectId] = {
+        project: block.project,
+        blocks: [],
+      };
+    }
+    byProject[block.projectId].blocks.push(block);
+  }
+
+  return byProject;
+};
+
 module.exports = exports = projectsWithIssues;


### PR DESCRIPTION
Widgets on domains that aren't in the project's allowed list now show a warning banner instead of silently failing. Projects without any configured domains just log the referer URL server-side so we can spot them in pod logs.

New projects no longer need manual domain configuration before login works. The project URL is automatically included in all allowed domain checks. Changing the URL re-syncs to the auth server.

System domains from env vars now also allow their parent domains, so when the platform runs on openstad.gemeente.nl (with api.openstad.gemeente.nl, cms.openstad.gemeente.nl etc.), both openstad.gemeente.nl and gemeente.nl are automatically allowed. Duplicates are deduplicated.

Blocked widget loads are tracked in a new `domain_blocks` table and show up on the admin issues page with widget ID, domain, and full referer URL. The daily cron includes a summary in the project issues notification.