### PR TITLE
Fix/sms auth

### DIFF
--- a/apps/auth-server/controllers/auth/phonenumber.js
+++ b/apps/auth-server/controllers/auth/phonenumber.js
@@ -283,20 +283,18 @@ exports.postSmsCode = (req, res, next) => {
               return res.redirect(authorizeUrl);
             };
 
-            req.brute.reset(() => {
-              logAuthEvent(req, 'login', {
-                data: { method: 'phonenumber' },
-              });
-              //log the succesfull login
-              authService
-                .logSuccessFullLogin(req)
-                .then(() => {
-                  redirectToAuthorisation();
-                })
-                .catch(() => {
-                  redirectToAuthorisation();
-                });
+            logAuthEvent(req, 'login', {
+              data: { method: 'phonenumber' },
             });
+            //log the succesfull login
+            authService
+              .logSuccessFullLogin(req)
+              .then(() => {
+                redirectToAuthorisation();
+              })
+              .catch(() => {
+                redirectToAuthorisation();
+              });
           })
           .catch((err) => {
             next(err);

--- a/apps/auth-server/services/verificationService.js
+++ b/apps/auth-server/services/verificationService.js
@@ -127,12 +127,6 @@ exports.sendSMS = async (user, client, redirectUrl) => {
     sender: sender,
   };
 
-  console.log('https://api-prd.kpn.com/messaging/sms-kpn/v1/send', {
-    method: 'POST',
-    headers: headers,
-    body: JSON.stringify(body),
-  });
-
   response = await fetch('https://api-prd.kpn.com/messaging/sms-kpn/v1/send', {
     method: 'POST',
     headers: headers,


### PR DESCRIPTION
Remove old method to reset the bruteforce key, as this is causing an error when authenticating with SMS. The new method is already in place for a long time ([see this commit](https://github.com/openstad/openstad-headless/commit/5810a616a6831ec458f8ee7a54d9639c93ca23ec)).

Also removed logging to prevent logging phonenumbers.
