### PR TITLE
fix: upgrade Docker base image to Debian 13 (trixie)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Image used for building dependencies
-FROM node:24-slim AS builder
+FROM node:24-trixie-slim AS builder
 ENV GITHUB_REPOSITORY=openstad/openstad-headless
 
 LABEL org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}
@@ -42,7 +42,7 @@ ENV CYPRESS_CACHE_FOLDER=/tmp/CypressCache
 RUN npm ci --include=optional --safe-chain-skip-minimum-package-age
 
 # Minimal target for update-lock. It only serves to update the lock file.
-FROM node:24-slim AS update-lock
+FROM node:24-trixie-slim AS update-lock
 WORKDIR /opt/openstad-headless
 RUN npm update -g npm
 # Install safe-chain so --safe-chain-skip-minimum-package-age is recognized when updating the lock file
@@ -119,7 +119,7 @@ RUN if [ "${APP}" = "image-server" ]; then \
     fi
 
 # Release image
-FROM node:24-slim AS release
+FROM node:24-trixie-slim AS release
 ARG APP
 ARG PORT
 ARG NODE_ENV

--- a/package-lock.json
+++ b/package-lock.json
@@ -11517,6 +11517,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11530,6 +11531,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11543,6 +11545,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11556,6 +11559,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11569,6 +11573,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11582,6 +11587,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11595,6 +11601,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -11611,6 +11618,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -11627,6 +11635,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -11643,6 +11652,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -11659,6 +11669,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -11675,6 +11686,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -11691,6 +11703,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -11707,6 +11720,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -11723,6 +11737,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -11739,6 +11754,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -11755,6 +11771,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -11771,6 +11788,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -11787,6 +11805,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "libc": [
         "musl"
       ],
@@ -11803,6 +11822,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11816,6 +11836,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11829,6 +11850,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11842,6 +11864,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11855,6 +11878,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11868,6 +11892,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -33824,6 +33849,7 @@
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
       "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -45174,7 +45200,7 @@
         "@utrecht/component-library-react": "^4.2.0",
         "@utrecht/design-tokens": "^1.0.0-alpha.631",
         "copy": "^0.0.1",
-        "postcss": "8.4.38",
+        "postcss": "8.5.10",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "swr": "^2.2.4"
@@ -71192,8 +71218,7 @@
         "html-to-react": "^1.7.0",
         "react-transition-group": "^4.4.5",
         "tailwind-merge": "^1.14.0",
-        "trix": "^2.1.15",
-        "vite": "^6.4.1"
+        "trix": "^2.1.15"
       },
       "devDependencies": {
         "@cypress/react": "^9.0.1",
@@ -71205,7 +71230,8 @@
         "cypress": "^15.8.1",
         "rollup": "^4.2.0",
         "rollup-plugin-dts": "^6.1.0",
-        "typescript": "^5.2.2"
+        "typescript": "^5.2.2",
+        "vite": "^6.4.1"
       },
       "peerDependencies": {
         "react": "^19.2.4",
@@ -71219,6 +71245,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71235,6 +71262,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71251,6 +71279,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71267,6 +71296,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71281,6 +71311,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71297,6 +71328,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71313,6 +71345,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71329,6 +71362,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71345,6 +71379,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71361,6 +71396,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71377,6 +71413,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71393,6 +71430,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71409,6 +71447,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71425,6 +71464,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71441,6 +71481,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71457,6 +71498,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71473,6 +71515,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71489,6 +71532,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71505,6 +71549,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71521,6 +71566,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71537,6 +71583,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71553,6 +71600,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71569,6 +71617,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71585,6 +71634,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71601,6 +71651,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71617,6 +71668,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -71628,6 +71680,7 @@
     },
     "packages/ui/node_modules/esbuild": {
       "version": "0.25.12",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -71667,6 +71720,7 @@
     },
     "packages/ui/node_modules/vite": {
       "version": "6.4.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -24,11 +24,11 @@
     "html-to-react": "^1.7.0",
     "react-transition-group": "^4.4.5",
     "tailwind-merge": "^1.14.0",
-    "trix": "^2.1.15",
-    "vite": "^6.4.1"
+    "trix": "^2.1.15"
   },
   "devDependencies": {
     "cypress": "^15.8.1",
+    "vite": "^6.4.1",
     "@cypress/react": "^9.0.1",
     "@cypress/vite-dev-server": "^7.0.0",
     "@rollup/plugin-commonjs": "^25.0.7",


### PR DESCRIPTION
This PR also moves vite from dependencies to devDependencies in packages/ui so esbuild (containing stdlib) is excluded from production images after npm prune. Upgrade all Dockerfile stages from node:24-slim (bookworm) to node:24-trixie-slim (trixie) ahead of Debian 12 EOL.