### PR TITLE
feat: add month and year dropdowns to SimpleCalendar date picker

### DIFF
--- a/apps/admin-server/src/components/simple-calender-popup.tsx
+++ b/apps/admin-server/src/components/simple-calender-popup.tsx
@@ -83,6 +83,10 @@ export const SimpleCalendar: React.FC<{
                       : (date) =>
                           date < new Date(new Date().setHours(0, 0, 0, 0))
                   }
+                  captionLayout="dropdown-buttons"
+                  fromYear={new Date().getFullYear() - 5}
+                  toYear={new Date().getFullYear() + 50}
+                  classNames={{ caption_label: 'hidden' }}
                   initialFocus
                 />
                 {withReset && (

--- a/apps/admin-server/src/components/ui/calendar.tsx
+++ b/apps/admin-server/src/components/ui/calendar.tsx
@@ -21,6 +21,12 @@ function Calendar({
         month: 'space-y-4',
         caption: 'flex justify-center pt-1 relative items-center',
         caption_label: 'text-sm font-medium',
+        caption_dropdowns: 'flex gap-1',
+        dropdown_month: '',
+        dropdown_year: '',
+        dropdown:
+          'appearance-none bg-transparent border border-input rounded-md px-2 py-1 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-ring cursor-pointer',
+        vhidden: 'hidden',
         nav: 'space-x-1 flex items-center',
         nav_button: cn(
           buttonVariants({ variant: 'outline' }),


### PR DESCRIPTION
The `SimpleCalendar` date picker (used in project settings and resource forms) only had prev/next month arrows, making it a lot of work to navigate to dates far in the future. This PR adds dropdown selects for month and year.