### PR TITLE
fix(cms): render extra TLS hosts on separate lines

### DIFF
--- a/charts/openstad-headless/templates/cms/ingress.yaml
+++ b/charts/openstad-headless/templates/cms/ingress.yaml
@@ -61,8 +61,8 @@ spec:
     - secretName: {{ .Values.cms.ingress.tls.secretName }}
       hosts:
         - {{ template "openstad.cms.url" . }}
-  {{- range $value := .Values.cms.ingress.tls.hosts -}}
+  {{- range $value := .Values.cms.ingress.tls.hosts }}
         - {{ $value }}
-  {{- end -}}
+  {{- end }}
 
 {{- end -}}


### PR DESCRIPTION
The trailing dash on {{- range -}} and leading dash on {{- end -}} stripped the newlines around the host loop body, concatenating all extra TLS hosts onto the first host line.