### PR TITLE
feat: add status field type to resource form widget

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourceform/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourceform/[id]/items.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/ui/select';
 import { Separator } from '@/components/ui/separator';
 import { Heading } from '@/components/ui/typography';
+import useStatuses from '@/hooks/use-statuses';
 import useTags from '@/hooks/use-tags';
 import { YesNoSelect } from '@/lib/form-widget-helpers';
 import { EditFieldProps } from '@/lib/form-widget-helpers/EditFieldProps';
@@ -54,6 +55,9 @@ const TrixEditor = dynamic(
     ),
   }
 );
+
+const stripHtml = (html: string): string =>
+  html?.replace(/<[^>]*>/g, '').trim() || '';
 
 const formSchema = z.object({
   trigger: z.string(),
@@ -166,6 +170,7 @@ export default function WidgetResourceFormItems(
   const router = useRouter();
   const { project } = router.query;
 
+  const { data: allStatuses } = useStatuses(project as string);
   const { data: allTags } = useTags(project as string);
   const firstTagType = allTags?.[0]?.type ?? '';
 
@@ -1204,6 +1209,9 @@ export default function WidgetResourceFormItems(
                               <SelectItem value="tags">
                                 Inzending: Tags
                               </SelectItem>
+                              <SelectItem value="status">
+                                Inzending: Status
+                              </SelectItem>
                               <SelectItem value="location">
                                 Inzending: Locatie
                               </SelectItem>
@@ -1514,6 +1522,20 @@ export default function WidgetResourceFormItems(
                         )}
                       </>
                     )}
+                    {form.watch('type') === 'status' &&
+                      (!allStatuses || allStatuses.length === 0) && (
+                        <p
+                          style={{
+                            fontSize: '14px',
+                            margin: '20px 0',
+                            color: 'red',
+                          }}>
+                          <strong>
+                            Geen statussen gevonden om te selecteren. Maak dit
+                            aan onder het kopje &apos;Statussen&apos;
+                          </strong>
+                        </p>
+                      )}
                     {![
                       'none',
                       'pagination',
@@ -1933,7 +1955,7 @@ export default function WidgetResourceFormItems(
                                           <SelectItem
                                             key={f.trigger}
                                             value={f.trigger}>
-                                            {f.title || f.fieldKey}
+                                            {stripHtml(f.title) || f.fieldKey}
                                           </SelectItem>
                                         )
                                       )}

--- a/apps/api-server/src/models/Resource.js
+++ b/apps/api-server/src/models/Resource.js
@@ -1174,8 +1174,7 @@ module.exports = function (db, sequelize, DataTypes) {
     },
     canMutateStatus: function canMutateStatus(user, self) {
       if (!user || !self) return false;
-      if (!self.auth.canUpdate(user, self)) return false;
-      return userHasRole(user, 'editor');
+      return self.auth.canUpdate(user, self);
     },
     toAuthorizedJSON: function (user, data, self) {
       if (!self.auth.canView(user, self)) {

--- a/packages/data-store/src/api/index.js
+++ b/packages/data-store/src/api/index.js
@@ -13,6 +13,7 @@ import projectVotedUsersCount from './projectVotedUsersCount';
 import resource from './resource';
 import resourceMarkers from './resource-markers';
 import resources from './resources';
+import statuses from './statuses';
 import submissions from './submissions';
 import tags from './tags';
 import user from './user';
@@ -105,6 +106,10 @@ function API(props = {}) {
   self.submissions = {
     fetch: submissions.fetch.bind(self),
     create: submissions.create.bind(self),
+  };
+
+  self.statuses = {
+    fetch: statuses.fetch.bind(self),
   };
 
   self.tags = {

--- a/packages/data-store/src/api/statuses.js
+++ b/packages/data-store/src/api/statuses.js
@@ -1,0 +1,6 @@
+export default {
+  fetch: async function ({ projectId }) {
+    let url = `/api/project/${projectId}/status`;
+    return this.fetch(url);
+  },
+};

--- a/packages/data-store/src/hooks/use-statuses.js
+++ b/packages/data-store/src/hooks/use-statuses.js
@@ -1,0 +1,20 @@
+export default function useStatuses(props) {
+  let self = this;
+  const projectId = props.projectId;
+
+  const { data, error, isLoading } = self.useSWR(
+    { projectId: projectId || self.projectId },
+    'statuses.fetch'
+  );
+
+  let statuses = data || [];
+
+  if (error) {
+    let event = new window.CustomEvent('osc-error', {
+      detail: new Error(error),
+    });
+    document.dispatchEvent(event);
+  }
+
+  return { data: statuses, error, isLoading };
+}

--- a/packages/data-store/src/index.js
+++ b/packages/data-store/src/index.js
@@ -16,6 +16,7 @@ import useMarkers from './hooks/use-markers.js';
 import useProjectVotedUsersCount from './hooks/use-project-voted-users-count';
 import useResource from './hooks/use-resource.js';
 import useResources from './hooks/use-resources.js';
+import useStatuses from './hooks/use-statuses.js';
 import useSubmissions from './hooks/use-submissions.js';
 import useTags from './hooks/use-tags.js';
 import useUserActivity from './hooks/use-user-activity';
@@ -41,6 +42,7 @@ function DataStore(props = {}) {
   self.useDatalayer = useDatalayer.bind(self);
   self.useMarkers = useMarkers.bind(self);
   self.useAreas = useAreas.bind(self);
+  self.useStatuses = useStatuses.bind(self);
   self.useTags = useTags.bind(self);
   self.useCurrentUser = useCurrentUser.bind(self);
   self.useUserVote = useUserVote.bind(self);

--- a/packages/resource-form/src/parts/default-values.tsx
+++ b/packages/resource-form/src/parts/default-values.tsx
@@ -79,6 +79,21 @@ export const defaultFormValues = [
     fieldType: 'select',
   },
   {
+    trigger: '14',
+    title: 'Status',
+    description: 'Selecteer de status van je inzending.',
+    type: 'status',
+    fieldKey: 'status',
+    fieldRequired: false,
+    onlyForModerator: false,
+    minCharacters: '',
+    maxCharacters: '',
+    variant: 'text input',
+    multiple: false,
+    options: [],
+    fieldType: 'select',
+  },
+  {
     trigger: '6',
     title: 'Locatie',
     description:

--- a/packages/resource-form/src/parts/init-fields.tsx
+++ b/packages/resource-form/src/parts/init-fields.tsx
@@ -36,6 +36,20 @@ export const InitializeFormFields = (items, data) => {
           : [];
       }
 
+      if (item.type === 'status') {
+        const { data: statuses } = datastore.useStatuses({
+          projectId: data.projectId,
+        });
+
+        item.options = !!statuses
+          ? statuses.map((status: any, index: number) => ({
+              trigger: `${index}`,
+              titles: [{ text: status.name, key: status.id }],
+              images: [],
+            }))
+          : [];
+      }
+
       const fieldData: any = {
         type: item.fieldType || item.type,
         title: item.title,
@@ -134,6 +148,22 @@ export const InitializeFormFields = (items, data) => {
                 trigger: option.trigger || '',
               };
             });
+          }
+          break;
+        case 'status':
+          fieldData['type'] = 'select';
+          if (item.options && item.options.length > 0) {
+            fieldData['choices'] = item.options.map((option) => {
+              return {
+                value: option.titles[0].key.toString(),
+                label: option.titles[0].text,
+                trigger: option.trigger || '',
+              };
+            });
+          } else {
+            fieldData['disabled'] = true;
+            fieldData['description'] =
+              'Geen statussen beschikbaar voor dit project.';
           }
           break;
         case 'budget':

--- a/packages/resource-form/src/resource-form.tsx
+++ b/packages/resource-form/src/resource-form.tsx
@@ -39,6 +39,11 @@ const getExistingValue = (fieldKey, resource, multiple) => {
           ? filteredTags[0]
           : undefined;
     }
+
+    if (fieldKey === 'status' && resource.statuses) {
+      const firstStatus = resource.statuses[0];
+      return firstStatus ? String(firstStatus.id) : undefined;
+    }
   }
   return undefined;
 };
@@ -204,6 +209,15 @@ function ResourceFormWidget(props: ResourceFormWidgetProps) {
     return formData;
   };
 
+  const addStatusToFormData = (formData) => {
+    const value = formData['status'];
+    if (value !== undefined && value !== null && value !== '') {
+      formData.statuses = [Number(value)];
+    }
+    delete formData['status'];
+    return formData;
+  };
+
   const configureFormData = (formData, publish = false) => {
     const dbFixedColumns = [
       'title',
@@ -213,12 +227,14 @@ function ResourceFormWidget(props: ResourceFormWidgetProps) {
       'images',
       'location',
       'tags',
+      'statuses',
       'documents',
     ];
     const extraData = {};
     let configuredFormData = { ...formData };
 
     configuredFormData = addTagsToFormData(configuredFormData);
+    configuredFormData = addStatusToFormData(configuredFormData);
 
     for (const key in configuredFormData) {
       if (configuredFormData.hasOwnProperty(key)) {


### PR DESCRIPTION
## What

Adds a new **status** field type to the resource-form widget, letting
submitters select a project status when creating/editing a resource.

## Changes

- **data-store**: new `statuses` API client + `useStatuses` hook
  (`GET /api/project/:id/status`)
- **resource-form**: status field default value; init logic mapping the
  project's statuses to select choices (with an empty/disabled state when a
  project has none); submit mapping of `status` → `statuses: [id]`
- **admin-server**: new "Inzending: Status" config option in the
  resourceform widget items page, with a warning when no statuses exist;
  strip HTML from field titles in the trigger `<Select>`
- **api-server**: relax `canMutateStatus` to authorize off
  `auth.canUpdate(user, self)` instead of requiring the `editor` role, so a
  submitter can set the status on their own submission

## Testing

- Configure a resourceform widget with a "Status" field on a project that
  has statuses → field renders as a select populated with project statuses
- Submit the form → resource is saved with the selected status
  (`statuses: [id]`)
- On a project with no statuses → admin shows the warning and the field is
  disabled with an explanatory description
