### PR TITLE
feat: add required validation for sort questions

### DIFF
--- a/packages/choiceguide/src/parts/init-fields.tsx
+++ b/packages/choiceguide/src/parts/init-fields.tsx
@@ -198,6 +198,11 @@ export const InitializeFormFields = (
         case 'pagination':
           fieldData['type'] = 'pagination';
           break;
+        case 'sort':
+          fieldData['type'] = 'sort';
+          fieldData['options'] = item.options || [];
+          fieldData['numberingStyle'] = item.numberingStyle || 'none';
+          break;
       }
 
       formFields.push(fieldData);

--- a/packages/form/src/utils/validation.tsx
+++ b/packages/form/src/utils/validation.tsx
@@ -184,6 +184,18 @@ export const getSchemaForField = (field: CombinedFieldPropsWithType) => {
         return undefined;
       }
 
+    case 'sort':
+      if (typeof field.fieldRequired !== 'undefined' && field.fieldRequired) {
+        return z
+          .string()
+          .min(
+            1,
+            field.requiredWarning || 'Het veld' + fieldTitle + 'is verplicht'
+          );
+      } else {
+        return undefined;
+      }
+
     // Default value for range is "50", so it's never empty.
     // If skipQuestion is true, the value is ignored anyway.
     // Therefore, we don't need validation here.

--- a/packages/ui/src/form-elements/sort/index.tsx
+++ b/packages/ui/src/form-elements/sort/index.tsx
@@ -42,6 +42,8 @@ export type SortFieldProps = {
   type?: string;
   defaultValue?: string;
   fieldOptions?: { value: string; label: string }[];
+  fieldRequired?: boolean;
+  requiredWarning?: string;
   images?: Array<{
     url: string;
     name?: string;
@@ -89,6 +91,7 @@ const SortField: FC<SortFieldProps> = ({
   onChange,
   onSort,
   fieldKey,
+  fieldRequired = false,
   overrideDefaultValue,
   numberingStyle,
   infoImage,
@@ -109,6 +112,7 @@ const SortField: FC<SortFieldProps> = ({
   } catch (e) {}
 
   const [items, setItems] = useState(options);
+  const [touched, setTouched] = useState(!!overrideDefaultValue);
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -124,7 +128,14 @@ const SortField: FC<SortFieldProps> = ({
     })
   );
 
+  const markTouched = () => {
+    if (!touched) {
+      setTouched(true);
+    }
+  };
+
   const handleDragEnd = (event: any) => {
+    markTouched();
     const { active, over } = event;
     if (active.id !== over?.id) {
       const oldIndex = items.findIndex(
@@ -143,15 +154,17 @@ const SortField: FC<SortFieldProps> = ({
     const value = items
       .filter((opt) => !!opt.titles)
       ?.map((opt) => opt.titles?.[0]?.key);
+    const sortValue = fieldRequired && !touched ? '' : JSON.stringify(value);
     onChange &&
       onChange({
         name: fieldKey,
-        value: JSON.stringify(value),
+        value: sortValue,
       });
-  }, [items]);
+  }, [items, touched]);
 
   return (
-    <div className={`sort-field-container --${numberingStyle}`}>
+    <div
+      className={`sort-field-container --${numberingStyle}${fieldRequired && !touched ? ' --untouched' : ''}`}>
       <div className="sortable-intro">
         {title && (
           <Paragraph className="utrecht-form-field__label">
@@ -185,7 +198,7 @@ const SortField: FC<SortFieldProps> = ({
           <SortableContext
             items={items.map((opt) => opt.titles?.[0]?.key || '')}
             strategy={verticalListSortingStrategy}>
-            <ol>
+            <ol aria-required={fieldRequired || undefined}>
               {items.map((option, index) => (
                 <li>
                   <SortableItem
@@ -201,6 +214,7 @@ const SortField: FC<SortFieldProps> = ({
                         disabled={index === 0}
                         onClick={(e) => {
                           if (index > 0) {
+                            markTouched();
                             const newItems = arrayMove(items, index, index - 1);
                             setItems(newItems);
                             if (onSort) onSort(newItems);
@@ -214,6 +228,7 @@ const SortField: FC<SortFieldProps> = ({
                         disabled={index === items.length - 1}
                         onClick={(e) => {
                           if (index < items.length - 1) {
+                            markTouched();
                             const newItems = arrayMove(items, index, index + 1);
                             setItems(newItems);
                             if (onSort) onSort(newItems);

--- a/packages/ui/src/form-elements/sort/sort.css
+++ b/packages/ui/src/form-elements/sort/sort.css
@@ -128,3 +128,51 @@
   opacity: 0.4;
   cursor: not-allowed;
 }
+.sort-field-container.--untouched ol li::marker {
+  transition: color 0.6s ease;
+}
+.sort-field-container:not(.--untouched) ol li::marker {
+  transition: color 0.6s ease;
+}
+
+@keyframes sort-pulse {
+  0%,
+  100% {
+    background: color-mix(
+      in srgb,
+      var(--sort-drag-active-background-color) 20%,
+      transparent
+    );
+  }
+  50% {
+    background: color-mix(
+      in srgb,
+      var(--sort-drag-active-background-color) 70%,
+      transparent
+    );
+  }
+}
+.sort-field-container.--untouched
+  .sortable-context
+  li
+  > div
+  span:has(.ri-draggable) {
+  animation: sort-pulse 3s ease-in-out infinite;
+}
+.sort-field-container.--untouched
+  .sortable-context
+  li
+  > div
+  span:has(.ri-draggable)
+  .ri-draggable {
+  color: var(--sort-drag-active-color);
+}
+@media (prefers-reduced-motion: reduce) {
+  .sort-field-container.--untouched
+    .sortable-context
+    li
+    > div
+    span:has(.ri-draggable) {
+    animation: none;
+  }
+}


### PR DESCRIPTION
Sort questions can now be marked as required. The form blocks submission until the user interacts with the field (drag or arrow buttons). Untouched required fields show a pulsing drag-handle animation and faded list markers, which stop after interaction.