### PR TITLE
fix: use scrollable select for routing question dropdown

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/items.tsx
@@ -15,6 +15,7 @@ import { Input } from '@/components/ui/input';
 import {
   Select,
   SelectContent,
+  SelectContentScrollable,
   SelectItem,
   SelectTrigger,
   SelectValue,
@@ -2634,7 +2635,7 @@ export default function WidgetChoiceGuideItems(
                                               <SelectValue placeholder="Kies een vraag" />
                                             </SelectTrigger>
                                           </FormControl>
-                                          <SelectContent>
+                                          <SelectContentScrollable>
                                             {formMultipleChoiceFields.map(
                                               (f: any) => (
                                                 <SelectItem
@@ -2644,7 +2645,7 @@ export default function WidgetChoiceGuideItems(
                                                 </SelectItem>
                                               )
                                             )}
-                                          </SelectContent>
+                                          </SelectContentScrollable>
                                         </Select>
                                       )}
 

--- a/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/items.tsx
@@ -16,6 +16,7 @@ import { Input } from '@/components/ui/input';
 import {
   Select,
   SelectContent,
+  SelectContentScrollable,
   SelectGroup,
   SelectItem,
   SelectLabel,
@@ -2525,7 +2526,7 @@ export default function WidgetEnqueteItems(
                                         <SelectValue placeholder="Kies een vraag" />
                                       </SelectTrigger>
                                     </FormControl>
-                                    <SelectContent>
+                                    <SelectContentScrollable>
                                       {formMultipleChoiceFields.map(
                                         (f: any) => (
                                           <SelectItem
@@ -2535,7 +2536,7 @@ export default function WidgetEnqueteItems(
                                           </SelectItem>
                                         )
                                       )}
-                                    </SelectContent>
+                                    </SelectContentScrollable>
                                   </Select>
                                 )}
 

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourceform/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourceform/[id]/items.tsx
@@ -14,6 +14,7 @@ import { Input } from '@/components/ui/input';
 import {
   Select,
   SelectContent,
+  SelectContentScrollable,
   SelectItem,
   SelectTrigger,
   SelectValue,
@@ -1927,7 +1928,7 @@ export default function WidgetResourceFormItems(
                                         <SelectValue placeholder="Kies een vraag" />
                                       </SelectTrigger>
                                     </FormControl>
-                                    <SelectContent>
+                                    <SelectContentScrollable>
                                       {formMultipleChoiceFields.map(
                                         (f: any) => (
                                           <SelectItem
@@ -1937,7 +1938,7 @@ export default function WidgetResourceFormItems(
                                           </SelectItem>
                                         )
                                       )}
-                                    </SelectContent>
+                                    </SelectContentScrollable>
                                   </Select>
                                 )}
 


### PR DESCRIPTION
The routing question dropdown in the item editor overflows the viewport when the widget has many choice-type questions. Switches to `SelectContentScrollable` (existing component with max-height + scroll) in enquete, resourceform, and choiceguide items pages.