### PR TITLE
fix: clear project URL when website toggle is turned off

### DIFF
--- a/apps/admin-server/src/hooks/use-project.tsx
+++ b/apps/admin-server/src/hooks/use-project.tsx
@@ -80,6 +80,8 @@ export function useProject(scopes?: Array<string>) {
     const body: { config: any; name?: string; url?: string } = { config };
     if (name) {
       body.name = name;
+    }
+    if (url !== undefined) {
       body.url = url;
     }
 

--- a/apps/admin-server/src/pages/projects/[project]/settings/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/settings/index.tsx
@@ -100,6 +100,8 @@ export default function ProjectSettings() {
   }, [form, defaults]);
 
   useEffect(() => {
+    if (!data) return;
+
     if (checkboxInitial) {
       const toggle = data?.config?.project?.projectToggle ?? !!data?.url;
       setShowUrl(toggle);
@@ -120,6 +122,7 @@ export default function ProjectSettings() {
           project: {
             endDate: values.endDate,
             projectToggle: values.projectToggle,
+            lastUrl: values.url || data?.config?.project?.lastUrl || '',
           },
           basicAuth: {
             active: values.basicAuthActive,
@@ -128,7 +131,7 @@ export default function ProjectSettings() {
           },
         },
         values.name,
-        values.url
+        values.projectToggle ? values.url : ''
       );
       if (project?.error) {
         toast.error(project.error);
@@ -314,6 +317,12 @@ export default function ProjectSettings() {
                               <Input placeholder="Url" {...field} />
                             </FormControl>
                             <FormMessage />
+                            {!field.value && data?.config?.project?.lastUrl && (
+                              <p className="text-xs text-muted-foreground">
+                                Laatst ingestelde URL:{' '}
+                                {data.config.project.lastUrl}
+                              </p>
+                            )}
                           </FormItem>
                         )}
                       />

--- a/apps/api-server/src/routes/api/project.js
+++ b/apps/api-server/src/routes/api/project.js
@@ -1375,7 +1375,7 @@ router
     req.pendingMessages = [
       { key: `project-${project.id}-update`, value: 'event' },
     ];
-    if (req.body.url && req.body.url != project.url)
+    if ('url' in req.body && req.body.url != project.url)
       req.pendingMessages.push({ key: `project-urls-update`, value: 'event' });
 
     let updateBody = req.body;


### PR DESCRIPTION
The website toggle didn't clear the project URL, so the site stayed reachable. Now it does, and the last URL is shown as a hint when the toggle is turned back on.