### PR TITLE
fix: remove deleted tags and tag groups from widget settings on load

### DIFF
--- a/apps/admin-server/src/components/checkbox-list.tsx
+++ b/apps/admin-server/src/components/checkbox-list.tsx
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import React, { Fragment, useEffect } from 'react';
+import React, { Fragment, useEffect, useRef } from 'react';
 
 import { Checkbox } from './ui/checkbox';
 import {
@@ -37,10 +37,42 @@ export const CheckboxList = <T extends { [key: string]: any }>({
 }: Props<T>) => {
   const [groupNames, setGroupedNames] = React.useState<string[]>([]);
 
+  const prevCleanedRef = useRef<string>('');
+
   useEffect(() => {
     if (Array.isArray(items) && keyForGrouping) {
       const groupNames = _.chain(items).map(keyForGrouping).uniq().value();
       setGroupedNames(groupNames);
+    }
+  }, [items]);
+
+  useEffect(() => {
+    if (!items || items.length === 0) return;
+
+    const currentValue = form.getValues(fieldName);
+    if (currentValue == null) return;
+
+    const validKeys = new Set(items.map((item) => keyPerItem(item)));
+
+    if (typeof currentValue === 'string') {
+      const ids = currentValue.split(',').filter(Boolean);
+      const cleaned = ids.filter((id) => validKeys.has(id)).join(',');
+      if (cleaned !== currentValue && cleaned !== prevCleanedRef.current) {
+        prevCleanedRef.current = cleaned;
+        form.setValue(fieldName, cleaned);
+      }
+    } else if (Array.isArray(currentValue)) {
+      const cleaned = currentValue.filter((id) =>
+        validKeys.has(typeof id === 'number' ? `${id}` : id)
+      );
+      const cleanedKey = JSON.stringify(cleaned);
+      if (
+        cleaned.length !== currentValue.length &&
+        cleanedKey !== prevCleanedRef.current
+      ) {
+        prevCleanedRef.current = cleanedKey;
+        form.setValue(fieldName, cleaned);
+      }
     }
   }, [items]);
 

--- a/apps/admin-server/src/lib/form-widget-helpers/TagGroupHelper.ts
+++ b/apps/admin-server/src/lib/form-widget-helpers/TagGroupHelper.ts
@@ -43,3 +43,11 @@ export function handleTagCheckboxGroupChange(
 
   return updatedFields;
 }
+
+export function filterStaleTagGroups<T extends { type: string }>(
+  groups: Array<T>,
+  validTagTypes: string[]
+): Array<T> {
+  const validSet = new Set(validTagTypes);
+  return groups.filter((g) => validSet.has(g.type));
+}

--- a/apps/admin-server/src/pages/projects/[project]/widgets/begrootmodule/[id]/tags.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/begrootmodule/[id]/tags.tsx
@@ -21,7 +21,10 @@ import { Heading } from '@/components/ui/typography';
 import useTags from '@/hooks/use-tags';
 import { YesNoSelect } from '@/lib/form-widget-helpers';
 import { EditFieldProps } from '@/lib/form-widget-helpers/EditFieldProps';
-import { handleTagCheckboxGroupChange } from '@/lib/form-widget-helpers/TagGroupHelper';
+import {
+  filterStaleTagGroups,
+  handleTagCheckboxGroupChange,
+} from '@/lib/form-widget-helpers/TagGroupHelper';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { StemBegrootWidgetProps } from '@openstad-headless/stem-begroot/src/stem-begroot';
 import * as Switch from '@radix-ui/react-switch';
@@ -65,6 +68,12 @@ export default function WidgetStemBegrootOverviewTags(
       const fetchedTags = tags as Array<Tag>;
       const groupNames = _.chain(fetchedTags).map('type').uniq().value();
       setGroupedNames(groupNames);
+
+      const currentGroups = form.getValues('tagGroups');
+      const cleaned = filterStaleTagGroups(currentGroups, groupNames);
+      if (cleaned.length !== currentGroups.length) {
+        form.setValue('tagGroups', cleaned);
+      }
     }
   }, [tags]);
 

--- a/apps/admin-server/src/pages/projects/[project]/widgets/comments/[id]/extraFields.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/comments/[id]/extraFields.tsx
@@ -15,7 +15,10 @@ import { Heading } from '@/components/ui/typography';
 import useTags from '@/hooks/use-tags';
 import { useFieldDebounce } from '@/hooks/useFieldDebounce';
 import { EditFieldProps } from '@/lib/form-widget-helpers/EditFieldProps';
-import { handleTagCheckboxGroupChange } from '@/lib/form-widget-helpers/TagGroupHelper';
+import {
+  filterStaleTagGroups,
+  handleTagCheckboxGroupChange,
+} from '@/lib/form-widget-helpers/TagGroupHelper';
 import { ArgumentWidgetTabProps } from '@/pages/projects/[project]/widgets/comments/[id]/index';
 import { zodResolver } from '@hookform/resolvers/zod';
 import _ from 'lodash';
@@ -58,6 +61,12 @@ export default function ArgumentsExtraFields(
       const fetchedTags = tags as Array<Tag>;
       const groupNames = _.chain(fetchedTags).map('type').uniq().value();
       setGroupedNames(groupNames);
+
+      const currentGroups = form.getValues('extraFieldsTagGroups');
+      const cleaned = filterStaleTagGroups(currentGroups, groupNames);
+      if (cleaned.length !== currentGroups.length) {
+        form.setValue('extraFieldsTagGroups', cleaned);
+      }
     }
   }, [tags]);
 

--- a/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/extraFields.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/extraFields.tsx
@@ -15,7 +15,10 @@ import { Heading } from '@/components/ui/typography';
 import useTags from '@/hooks/use-tags';
 import { useFieldDebounce } from '@/hooks/useFieldDebounce';
 import { EditFieldProps } from '@/lib/form-widget-helpers/EditFieldProps';
-import { handleTagCheckboxGroupChange } from '@/lib/form-widget-helpers/TagGroupHelper';
+import {
+  filterStaleTagGroups,
+  handleTagCheckboxGroupChange,
+} from '@/lib/form-widget-helpers/TagGroupHelper';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { DocumentMapProps } from '@openstad-headless/document-map/src/document-map';
 import _ from 'lodash';
@@ -58,6 +61,12 @@ export default function DocumentExtraFields(
       const fetchedTags = tags as Array<Tag>;
       const groupNames = _.chain(fetchedTags).map('type').uniq().value();
       setGroupedNames(groupNames);
+
+      const currentGroups = form.getValues('extraFieldsTagGroups');
+      const cleaned = filterStaleTagGroups(currentGroups, groupNames);
+      if (cleaned.length !== currentGroups.length) {
+        form.setValue('extraFieldsTagGroups', cleaned);
+      }
     }
   }, [tags]);
 

--- a/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/filters.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/documentmap/[id]/filters.tsx
@@ -22,7 +22,10 @@ import { Heading } from '@/components/ui/typography';
 import useTags from '@/hooks/use-tags';
 import { useFieldDebounce } from '@/hooks/useFieldDebounce';
 import { EditFieldProps } from '@/lib/form-widget-helpers/EditFieldProps';
-import { handleTagCheckboxGroupChange } from '@/lib/form-widget-helpers/TagGroupHelper';
+import {
+  filterStaleTagGroups,
+  handleTagCheckboxGroupChange,
+} from '@/lib/form-widget-helpers/TagGroupHelper';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { DocumentMapProps } from '@openstad-headless/document-map/src/document-map';
 import _ from 'lodash';
@@ -65,6 +68,12 @@ export default function DocumentFilters(
       const fetchedTags = tags as Array<Tag>;
       const groupNames = _.chain(fetchedTags).map('type').uniq().value();
       setGroupedNames(groupNames);
+
+      const currentGroups = form.getValues('tagGroups');
+      const cleaned = filterStaleTagGroups(currentGroups, groupNames);
+      if (cleaned.length !== currentGroups.length) {
+        form.setValue('tagGroups', cleaned);
+      }
     }
   }, [tags]);
 

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourceoverview/[id]/tags.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourceoverview/[id]/tags.tsx
@@ -27,7 +27,10 @@ import useTags from '@/hooks/use-tags';
 import { useFieldDebounce } from '@/hooks/useFieldDebounce';
 import { YesNoSelect } from '@/lib/form-widget-helpers';
 import { EditFieldProps } from '@/lib/form-widget-helpers/EditFieldProps';
-import { handleTagCheckboxGroupChange } from '@/lib/form-widget-helpers/TagGroupHelper';
+import {
+  filterStaleTagGroups,
+  handleTagCheckboxGroupChange,
+} from '@/lib/form-widget-helpers/TagGroupHelper';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ResourceOverviewWidgetProps } from '@openstad-headless/resource-overview/src/resource-overview';
 import _ from 'lodash';
@@ -83,6 +86,12 @@ export default function WidgetResourceOverviewTags(
       const fetchedTags = tags as Array<Tag>;
       const groupNames = _.chain(fetchedTags).map('type').uniq().value();
       setGroupedNames(groupNames);
+
+      const currentGroups = form.getValues('tagGroups');
+      const cleaned = filterStaleTagGroups(currentGroups, groupNames);
+      if (cleaned.length !== currentGroups.length) {
+        form.setValue('tagGroups', cleaned);
+      }
     }
   }, [tags]);
 


### PR DESCRIPTION
When a tag or status was deleted, its ID stayed in widget config because the checkbox UI no longer rendered it. Opening and saving the settings would silently preserve stale entries. `CheckboxList` now filters the form value against actual API data on load, and tag group arrays are cleaned in the existing useEffect that processes tags.