### PR TITLE
Fix/rte links new tab

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/agenda/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/agenda/[id]/items.tsx
@@ -170,7 +170,9 @@ export default function WidgetAgendaItems(
 
   const { onFieldChanged } = props;
   useEffect(() => {
-    onFieldChanged('items', items);
+    if (onFieldChanged) {
+      onFieldChanged('items', items);
+    }
   }, [items]);
 
   useEffect(() => {

--- a/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/items.tsx
@@ -513,7 +513,9 @@ export default function WidgetChoiceGuideItems(
 
   const { onFieldChanged } = props;
   useEffect(() => {
-    onFieldChanged('items', items);
+    if (onFieldChanged) {
+      onFieldChanged('items', items);
+    }
   }, [items]);
 
   // Sets form to selected item values when item is selected

--- a/apps/admin-server/src/pages/projects/[project]/widgets/distributionmodule/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/distributionmodule/[id]/items.tsx
@@ -87,7 +87,9 @@ export default function WidgetDistributionModuleItems(
 
   const { onFieldChanged } = props;
   useEffect(() => {
-    onFieldChanged('items', items);
+    if (onFieldChanged) {
+      onFieldChanged('items', items);
+    }
   }, [items]);
 
   // Sets form to selected item values when item is selected

--- a/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/items.tsx
@@ -494,7 +494,9 @@ export default function WidgetEnqueteItems(
 
   const { onFieldChanged } = props;
   useEffect(() => {
-    onFieldChanged('items', items);
+    if (onFieldChanged) {
+      onFieldChanged('items', items);
+    }
   }, [items]);
 
   function buildFormValues(item: Item) {

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourceform/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourceform/[id]/items.tsx
@@ -395,7 +395,9 @@ export default function WidgetResourceFormItems(
 
   const { onFieldChanged } = props;
   useEffect(() => {
-    onFieldChanged('items', items);
+    if (onFieldChanged) {
+      onFieldChanged('items', items);
+    }
   }, [items]);
 
   // Sets form to selected item values when item is selected

--- a/apps/admin-server/src/pages/projects/[project]/widgets/videoSlider/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/videoSlider/[id]/items.tsx
@@ -251,7 +251,9 @@ export default function WidgetEnqueteItems(
 
   const { onFieldChanged } = props;
   useEffect(() => {
-    onFieldChanged('items', items);
+    if (onFieldChanged) {
+      onFieldChanged('items', items);
+    }
   }, [items]);
 
   // Sets form to selected item values when item is selected

--- a/packages/ui/src/form-elements/text/index.tsx
+++ b/packages/ui/src/form-elements/text/index.tsx
@@ -38,6 +38,19 @@ declare global {
   }
 }
 
+function getTargetBlankHrefs(html: string): Set<string> {
+  const hrefs = new Set<string>();
+  if (!html || typeof document === 'undefined' || !html.includes('target'))
+    return hrefs;
+  const template = document.createElement('template');
+  template.innerHTML = html;
+  template.content.querySelectorAll('a[target="_blank"]').forEach((link) => {
+    const href = link.getAttribute('href');
+    if (href) hrefs.add(href);
+  });
+  return hrefs;
+}
+
 export type TextInputProps = {
   title: string;
   overrideDefaultValue?: FormValue;
@@ -101,6 +114,8 @@ const TrixEditor: React.FC<{
   const onBlurRef = useRef(onBlur);
   const valueRef = useRef(value);
 
+  const targetBlankHrefsRef = useRef<Set<string>>(new Set());
+
   const idRef = useRef(
     `trix-editor-${Math.random().toString(36).substring(2, 9)}`
   );
@@ -112,8 +127,9 @@ const TrixEditor: React.FC<{
         await import('trix');
         await import('trix/dist/trix.css');
 
-        // Use semantic paragraphs for new blocks created with Enter.
         const trix = (window as any).Trix;
+
+        // Use semantic paragraphs for new blocks created with Enter.
         if (trix?.config?.blockAttributes?.default) {
           trix.config.blockAttributes.default.tagName = 'p';
         }
@@ -146,7 +162,6 @@ const TrixEditor: React.FC<{
     const handleTrixInitialize = () => {
       editorInstance.current = (editorEl as any).editor;
 
-      // Remove the file attachment button from the toolbar
       const toolbar = editorEl.parentElement?.querySelector('trix-toolbar');
       if (toolbar) {
         const fileButton = toolbar.querySelector(
@@ -155,21 +170,120 @@ const TrixEditor: React.FC<{
         if (fileButton) {
           fileButton.remove();
         }
+
+        const dialog = toolbar.querySelector('[data-trix-dialog="href"]');
+        const linkFields = dialog?.querySelector('.trix-dialog__link-fields');
+        if (
+          linkFields &&
+          !linkFields.querySelector('.trix-target-blank-label')
+        ) {
+          const label = document.createElement('label');
+          label.className = 'trix-target-blank-label';
+
+          const checkbox = document.createElement('input');
+          checkbox.type = 'checkbox';
+          checkbox.className = 'trix-target-blank-checkbox';
+
+          label.appendChild(checkbox);
+          label.appendChild(
+            document.createTextNode(' Openen in nieuw tabblad')
+          );
+
+          const buttonGroup = linkFields.querySelector('.trix-button-group');
+          linkFields.insertBefore(label, buttonGroup);
+
+          const linkButton = linkFields.querySelector(
+            '[data-trix-method="setAttribute"]'
+          );
+          if (linkButton) {
+            linkButton.addEventListener('click', () => {
+              const checked = checkbox.checked;
+              setTimeout(() => {
+                const html = inputEl.value || '';
+                const editor = (editorEl as any).editor;
+                const currentHref =
+                  editor?.composition?.currentAttributes?.href;
+                if (!currentHref) return;
+
+                const template = document.createElement('template');
+                template.innerHTML = html;
+                const link = template.content.querySelector(
+                  `a[href="${CSS.escape(currentHref)}"]`
+                );
+                if (!link) return;
+
+                if (checked) {
+                  link.setAttribute('target', '_blank');
+                  link.setAttribute('rel', 'noopener noreferrer');
+                  targetBlankHrefsRef.current.add(currentHref);
+                } else {
+                  link.removeAttribute('target');
+                  link.removeAttribute('rel');
+                  targetBlankHrefsRef.current.delete(currentHref);
+                }
+
+                inputEl.value = template.innerHTML;
+                const syntheticEvent = {
+                  target: { value: template.innerHTML },
+                } as React.ChangeEvent<HTMLInputElement>;
+                onChangeRef.current(syntheticEvent);
+              }, 0);
+            });
+          }
+        }
       }
 
-      // Load initial content
       if (valueRef.current && editorInstance.current) {
+        targetBlankHrefsRef.current = getTargetBlankHrefs(valueRef.current);
         editorInstance.current.loadHTML(valueRef.current);
       }
     };
 
     const handleTrixChange = () => {
-      const html = inputEl.value;
+      let html = inputEl.value;
+
+      if (
+        targetBlankHrefsRef.current.size > 0 &&
+        typeof document !== 'undefined'
+      ) {
+        const template = document.createElement('template');
+        template.innerHTML = html;
+        let changed = false;
+        targetBlankHrefsRef.current.forEach((href) => {
+          const link = template.content.querySelector(
+            `a[href="${CSS.escape(href)}"]`
+          );
+          if (link && !link.hasAttribute('target')) {
+            link.setAttribute('target', '_blank');
+            link.setAttribute('rel', 'noopener noreferrer');
+            changed = true;
+          }
+        });
+        if (changed) {
+          html = template.innerHTML;
+          inputEl.value = html;
+        }
+      }
+
       const syntheticEvent = {
         target: { value: html },
       } as React.ChangeEvent<HTMLInputElement>;
 
       onChangeRef.current(syntheticEvent);
+    };
+
+    const handleDialogShow = () => {
+      const toolbar = editorEl.parentElement?.querySelector('trix-toolbar');
+      const checkbox = toolbar?.querySelector(
+        '.trix-target-blank-checkbox'
+      ) as HTMLInputElement | null;
+      const editor = (editorEl as any).editor;
+      if (!checkbox || !editor) return;
+
+      const currentHref = editor.composition?.currentAttributes?.href;
+      checkbox.checked = !!(
+        currentHref && targetBlankHrefsRef.current.has(currentHref)
+      );
     };
 
     const handleTrixFocus = () => {
@@ -182,12 +296,17 @@ const TrixEditor: React.FC<{
 
     editorEl.addEventListener('trix-initialize', handleTrixInitialize);
     editorEl.addEventListener('trix-change', handleTrixChange);
+    editorEl.addEventListener('trix-toolbar-dialog-show', handleDialogShow);
     inputEl.addEventListener('input', handleTrixChange);
     editorEl.addEventListener('trix-focus', handleTrixFocus);
     editorEl.addEventListener('trix-blur', handleTrixBlur);
     return () => {
       editorEl.removeEventListener('trix-initialize', handleTrixInitialize);
       editorEl.removeEventListener('trix-change', handleTrixChange);
+      editorEl.removeEventListener(
+        'trix-toolbar-dialog-show',
+        handleDialogShow
+      );
       inputEl.removeEventListener('input', handleTrixChange);
       editorEl.removeEventListener('trix-focus', handleTrixFocus);
       editorEl.removeEventListener('trix-blur', handleTrixBlur);
@@ -199,6 +318,10 @@ const TrixEditor: React.FC<{
     if (!editorInstance.current || !inputRef.current) return;
     const currentHTML = inputRef.current.value;
     if (currentHTML !== value) {
+      const newHrefs = getTargetBlankHrefs(value || '');
+      if (newHrefs.size > 0) {
+        newHrefs.forEach((h) => targetBlankHrefsRef.current.add(h));
+      }
       editorInstance.current.loadHTML(value || '');
     }
   }, [value]);

--- a/packages/ui/src/form-elements/text/style.css
+++ b/packages/ui/src/form-elements/text/style.css
@@ -91,6 +91,19 @@ trix-editor a {
   text-decoration: underline;
 }
 
+.trix-target-blank-label {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+  white-space: nowrap;
+  margin: 0.25rem 0;
+}
+
+.trix-target-blank-checkbox {
+  margin: 0;
+}
+
 trix-editor ul {
   list-style-type: disc;
   padding-left: 1.5rem;

--- a/packages/ui/src/rte-formatting/rte-formatting.jsx
+++ b/packages/ui/src/rte-formatting/rte-formatting.jsx
@@ -193,7 +193,8 @@ export default function RenderContent(content, options = {}) {
           <Link
             key={index}
             href={node.attribs.href}
-            target={node.attribs.target}>
+            target={node.attribs.target}
+            rel={node.attribs.rel}>
             {children}
           </Link>
         );


### PR DESCRIPTION
Adds a checkbox to the Trix link dialog that lets editors choose whether a link opens in a new tab. The setting is stored as `target="_blank"` in the HTML and persists across save/reload. Also fixes a crash on widget items pages caused by `onFieldChanged` being called before it was available.