### PR TITLE
feat: add optional confetti animation on like and vote submit

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/begrootmodule/[id]/display.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/begrootmodule/[id]/display.tsx
@@ -54,6 +54,7 @@ const formSchema = z.object({
   tagTypeTag: z.string().optional(),
   voteAfterLoggingIn: z.boolean().optional(),
   displayModBreak: z.boolean().optional(),
+  showConfetti: z.boolean().optional(),
 });
 
 type Formdata = z.infer<typeof formSchema>;
@@ -95,6 +96,7 @@ export default function BegrootmoduleDisplay(
       hideTagsForResources: props.hideTagsForResources || false,
       voteAfterLoggingIn: props.voteAfterLoggingIn || false,
       displayModBreak: props.displayModBreak || false,
+      showConfetti: props.showConfetti || false,
     },
   });
 
@@ -267,6 +269,18 @@ export default function BegrootmoduleDisplay(
             render={({ field }) => (
               <FormItem className="col-span-1">
                 <FormLabel>Toon de ModBreak</FormLabel>
+                {YesNoSelect(field, props)}
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="showConfetti"
+            render={({ field }) => (
+              <FormItem className="col-span-1">
+                <FormLabel>Toon confetti na het stemmen</FormLabel>
                 {YesNoSelect(field, props)}
                 <FormMessage />
               </FormItem>

--- a/apps/admin-server/src/pages/projects/[project]/widgets/likes/[id]/weergave.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/likes/[id]/weergave.tsx
@@ -39,6 +39,7 @@ const formSchema = z.object({
   showProgressBar: z.boolean(),
   displayDislike: z.boolean().optional(),
   progressBarDescription: z.string().optional(),
+  showConfetti: z.boolean().optional(),
   resourceId: z.string().optional(),
 });
 type FormData = z.infer<typeof formSchema>;
@@ -85,6 +86,7 @@ export default function LikesDisplay({
       hideCounters: props?.hideCounters || false,
       showProgressBar: undefinedToTrueOrProp(props?.showProgressBar),
       progressBarDescription: props?.progressBarDescription || '',
+      showConfetti: props?.showConfetti || false,
     },
   });
 
@@ -239,6 +241,29 @@ export default function LikesDisplay({
             render={({ field }) => (
               <FormItem>
                 <FormLabel>Wil je de dislike button tonen?</FormLabel>
+                <Switch.Root
+                  className="block w-[50px] h-[25px] bg-stone-300 rounded-full relative focus:shadow-[0_0_0_2px] focus:shadow-black data-[state=checked]:bg-primary outline-none cursor-default"
+                  onCheckedChange={(e: boolean) => {
+                    field.onChange(e);
+                    props.onFieldChanged(field.name, e);
+                  }}
+                  checked={field.value}>
+                  <Switch.Thumb className="block w-[21px] h-[21px] bg-white rounded-full transition-transform duration-100 translate-x-0.5 will-change-transform data-[state=checked]:translate-x-[27px]" />
+                </Switch.Root>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        )}
+
+        {conditionallyRenderField(
+          'showConfetti',
+          <FormField
+            control={form.control}
+            name="showConfetti"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Toon confetti bij liken</FormLabel>
                 <Switch.Root
                   className="block w-[50px] h-[25px] bg-stone-300 rounded-full relative focus:shadow-[0_0_0_2px] focus:shadow-black data-[state=checked]:bg-primary outline-none cursor-default"
                   onCheckedChange={(e: boolean) => {

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetailwithmap/[id]/index.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetailwithmap/[id]/index.tsx
@@ -8,6 +8,7 @@ import {
   WithApiUrlProps,
   withApiUrl,
 } from '@/lib/server-side-props-definition';
+import { extractConfig } from '@/lib/sub-widget-helper';
 import { ResourceOverviewMapWidgetProps } from '@openstad-headless/leaflet-map/src/types/resource-overview-map-widget-props';
 import { ResourceDetailWidgetProps } from '@openstad-headless/resource-detail-with-map/src/resourceDetailWithMap';
 import { useRouter } from 'next/router';
@@ -20,6 +21,8 @@ import {
   TabsList,
   TabsTrigger,
 } from '../../../../../../components/ui/tabs';
+import { LikeWidgetTabProps } from '../../likes/[id]';
+import LikesDisplay from '../../likes/[id]/weergave';
 import WidgetResourcesMapButtons from '../../resourcesmap/[id]/buttons';
 import WidgetResourcesMapMap from '../../resourcesmap/[id]/map';
 import WidgetResourceDetailDisplay from './display';
@@ -84,6 +87,7 @@ export default function WidgetResourceDetail({ apiUrl }: WithApiUrlProps) {
             <TabsList className="w-full bg-white border-b-0 mb-4 rounded-md h-fit flex flex-wrap overflow-auto">
               <TabsTrigger value="resources">Resources</TabsTrigger>
               <TabsTrigger value="map">Kaart</TabsTrigger>
+              <TabsTrigger value="likes">Likes widget</TabsTrigger>
               <TabsTrigger value="publish">Publiceren</TabsTrigger>
               <TabsTrigger value="auditlog">Logboek</TabsTrigger>
             </TabsList>
@@ -146,6 +150,22 @@ export default function WidgetResourceDetail({ apiUrl }: WithApiUrlProps) {
                   <WidgetResourcesMapButtons {...totalPropPackageMap} />
                 </TabsContent>
               </Tabs>
+            </TabsContent>
+            <TabsContent value="likes" className="p-0">
+              {previewConfig && (
+                <LikesDisplay
+                  omitSchemaKeys={['resourceId']}
+                  {...extractConfig<
+                    ResourceDetailWidgetProps,
+                    LikeWidgetTabProps
+                  >({
+                    subWidgetKey: 'likeWidget',
+                    previewConfig: previewConfig,
+                    updateConfig,
+                    updatePreview,
+                  })}
+                />
+              )}
             </TabsContent>
             <TabsContent value="publish" className="p-0">
               <WidgetPublish apiUrl={apiUrl} />

--- a/packages/enquete/src/enquete.tsx
+++ b/packages/enquete/src/enquete.tsx
@@ -4,7 +4,13 @@ import Form, { FormValue } from '@openstad-headless/form/src/form';
 import { FieldProps } from '@openstad-headless/form/src/props';
 import { loadWidget } from '@openstad-headless/lib/load-widget';
 import { BaseProps, ProjectSettingProps } from '@openstad-headless/types';
-import { Banner, Button, Icon, Spacer } from '@openstad-headless/ui/src';
+import {
+  Banner,
+  Button,
+  Icon,
+  Spacer,
+  fireConfetti,
+} from '@openstad-headless/ui/src';
 import { Heading2, Heading6 } from '@utrecht/component-library-react';
 import * as React from 'react';
 import { useEffect, useRef, useState } from 'react';
@@ -152,105 +158,6 @@ function Enquete(props: EnqueteWidgetProps) {
     props.enableDraftPersistence,
     props.draftRetentionHours,
   ]);
-
-  // Confetti function for youth outro page
-  const fireConfetti = () => {
-    const canvas = document.createElement('canvas');
-    canvas.style.position = 'fixed';
-    canvas.style.top = '0';
-    canvas.style.left = '0';
-    canvas.style.width = '100%';
-    canvas.style.height = '100%';
-    canvas.style.pointerEvents = 'none';
-    canvas.style.zIndex = '9999';
-    canvas.width = window.innerWidth;
-    canvas.height = window.innerHeight;
-
-    document.body.appendChild(canvas);
-
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
-
-    const particles: Array<{
-      x: number;
-      y: number;
-      vx: number;
-      vy: number;
-      color: string;
-      size: number;
-      rotation: number;
-      rotationSpeed: number;
-    }> = [];
-
-    const colors = [
-      '#ff6b6b',
-      '#4ecdc4',
-      '#45b7d1',
-      '#f9ca24',
-      '#f0932b',
-      '#eb4d4b',
-      '#6c5ce7',
-      '#fd79a8',
-    ];
-
-    // Create particles - more particles with staggered timing
-    for (let i = 0; i < 300; i++) {
-      particles.push({
-        x: Math.random() * canvas.width * 1.2 - canvas.width * 0.1, // Spread beyond screen width
-        y: -Math.random() * 600 - 10, // Much more spread out height above screen
-        vx: (Math.random() - 0.5) * 30, // Increased horizontal spread
-        vy: Math.random() * 3 + 2,
-        color: colors[Math.floor(Math.random() * colors.length)],
-        size: Math.random() * 8 + 4,
-        rotation: Math.random() * 360,
-        rotationSpeed: (Math.random() - 0.5) * 10,
-      });
-    }
-
-    const animate = () => {
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
-
-      particles.forEach((particle, index) => {
-        particle.x += particle.vx;
-        particle.y += particle.vy;
-        particle.vy += 0.1; // gravity
-        particle.rotation += particle.rotationSpeed;
-
-        ctx.save();
-        ctx.translate(particle.x, particle.y);
-        ctx.rotate((particle.rotation * Math.PI) / 180);
-        ctx.fillStyle = particle.color;
-        ctx.fillRect(
-          -particle.size / 2,
-          -particle.size / 2,
-          particle.size,
-          particle.size
-        );
-        ctx.restore();
-
-        // Remove particles that are off screen
-        if (particle.y > canvas.height + 10) {
-          particles.splice(index, 1);
-        }
-      });
-
-      if (particles.length > 0) {
-        requestAnimationFrame(animate);
-      } else {
-        // Clean up
-        document.body.removeChild(canvas);
-      }
-    };
-
-    animate();
-
-    // Also remove after 8 seconds as a safety measure - longer duration
-    setTimeout(() => {
-      if (document.body.contains(canvas)) {
-        document.body.removeChild(canvas);
-      }
-    }, 8000);
-  };
 
   const { create: createSubmission } = datastore.useSubmissions({
     projectId: props.projectId,

--- a/packages/likes/src/likes.tsx
+++ b/packages/likes/src/likes.tsx
@@ -4,7 +4,7 @@ import { getResourceId } from '@openstad-headless/lib/get-resource-id';
 import { loadWidget } from '@openstad-headless/lib/load-widget';
 import { LocalStorage } from '@openstad-headless/lib/local-storage';
 import type { BaseProps, ProjectSettingProps } from '@openstad-headless/types';
-import { ProgressBar } from '@openstad-headless/ui/src';
+import { ProgressBar, fireConfetti } from '@openstad-headless/ui/src';
 import '@utrecht/component-library-css';
 import {
   Button,
@@ -38,6 +38,7 @@ export type LikeProps = {
   showProgressBar?: boolean;
   progressBarDescription?: string;
   disabled?: boolean;
+  showConfetti?: boolean;
   refreshResourceLikes?: () => void;
 };
 
@@ -49,6 +50,7 @@ function Likes({
   noLabel = 'Nee',
   displayDislike = false,
   showProgressBar = true,
+  showConfetti: showConfettiOnLike = false,
   disabled = false,
   refreshResourceLikes,
   ...props
@@ -136,10 +138,14 @@ function Likes({
       opinion: value,
     });
 
-    setIsBusy(false);
+    if (showConfettiOnLike && value === 'yes') {
+      fireConfetti();
+    }
+
     if (refreshResourceLikes) {
       await refreshResourceLikes();
     }
+    setIsBusy(false);
   }
 
   if (typeof props.children === 'function') {

--- a/packages/stem-begroot/src/stem-begroot.tsx
+++ b/packages/stem-begroot/src/stem-begroot.tsx
@@ -3,7 +3,12 @@ import DataStore from '@openstad-headless/data-store/src';
 import { canLikeResource, hasRole } from '@openstad-headless/lib';
 import { loadWidget } from '@openstad-headless/lib/load-widget';
 import type { BaseProps, ProjectSettingProps } from '@openstad-headless/types';
-import { Paginator, Spacer, Stepper } from '@openstad-headless/ui/src';
+import {
+  Paginator,
+  Spacer,
+  Stepper,
+  fireConfetti,
+} from '@openstad-headless/ui/src';
 import { Filters } from '@openstad-headless/ui/src/stem-begroot-and-resource-overview/filter';
 import '@utrecht/component-library-css';
 import { Button, ButtonLink, Heading } from '@utrecht/component-library-react';
@@ -103,6 +108,7 @@ export type StemBegrootWidgetProps = BaseProps &
     voteAfterLoggingIn?: boolean;
     displayModBreak?: boolean;
     randomSortRotationMs?: number;
+    showConfetti?: boolean;
   };
 
 function StemBegroot({
@@ -584,6 +590,9 @@ function StemBegroot({
         );
         const submitted = await submitVoteAndCleanup();
         if (submitted) {
+          if (props.showConfetti) {
+            fireConfetti();
+          }
           setCurrentStep(4);
         }
       })();
@@ -1401,6 +1410,9 @@ function StemBegroot({
                     if (currentStep === 3) {
                       const submitted = await submitVoteAndCleanup();
                       if (submitted) {
+                        if (props.showConfetti) {
+                          fireConfetti();
+                        }
                         setCurrentStep(4);
                       }
                     } else if (currentStep === 4) {

--- a/packages/ui/src/fire-confetti.ts
+++ b/packages/ui/src/fire-confetti.ts
@@ -1,0 +1,102 @@
+let active = false;
+
+export function fireConfetti() {
+  if (active) return;
+  active = true;
+
+  const canvas = document.createElement('canvas');
+  canvas.style.position = 'fixed';
+  canvas.style.top = '0';
+  canvas.style.left = '0';
+  canvas.style.width = '100%';
+  canvas.style.height = '100%';
+  canvas.style.pointerEvents = 'none';
+  canvas.style.zIndex = '9999';
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+
+  document.body.appendChild(canvas);
+
+  const ctx = canvas.getContext('2d');
+  if (!ctx) {
+    cleanup();
+    return;
+  }
+
+  let particles: Array<{
+    x: number;
+    y: number;
+    vx: number;
+    vy: number;
+    color: string;
+    size: number;
+    rotation: number;
+    rotationSpeed: number;
+  }> = [];
+
+  const colors = [
+    '#ff6b6b',
+    '#4ecdc4',
+    '#45b7d1',
+    '#f9ca24',
+    '#f0932b',
+    '#eb4d4b',
+    '#6c5ce7',
+    '#fd79a8',
+  ];
+
+  for (let i = 0; i < 300; i++) {
+    particles.push({
+      x: Math.random() * canvas.width * 1.2 - canvas.width * 0.1,
+      y: -Math.random() * 600 - 10,
+      vx: (Math.random() - 0.5) * 30,
+      vy: Math.random() * 3 + 2,
+      color: colors[Math.floor(Math.random() * colors.length)],
+      size: Math.random() * 8 + 4,
+      rotation: Math.random() * 360,
+      rotationSpeed: (Math.random() - 0.5) * 10,
+    });
+  }
+
+  function cleanup() {
+    active = false;
+    if (document.body.contains(canvas)) {
+      document.body.removeChild(canvas);
+    }
+  }
+
+  const animate = () => {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    for (const particle of particles) {
+      particle.x += particle.vx;
+      particle.y += particle.vy;
+      particle.vy += 0.1;
+      particle.rotation += particle.rotationSpeed;
+
+      ctx.save();
+      ctx.translate(particle.x, particle.y);
+      ctx.rotate((particle.rotation * Math.PI) / 180);
+      ctx.fillStyle = particle.color;
+      ctx.fillRect(
+        -particle.size / 2,
+        -particle.size / 2,
+        particle.size,
+        particle.size
+      );
+      ctx.restore();
+    }
+
+    particles = particles.filter((p) => p.y <= canvas.height + 10);
+
+    if (particles.length > 0) {
+      requestAnimationFrame(animate);
+    } else {
+      cleanup();
+    }
+  };
+
+  animate();
+
+  setTimeout(cleanup, 8000);
+}

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -20,3 +20,4 @@ export { List } from './list';
 export { Stepper } from './stepper';
 export { Pill } from './pill';
 export { Separator } from './separator';
+export { fireConfetti } from './fire-confetti';


### PR DESCRIPTION
Extracts the confetti animation from the enquete widget into a shared `fireConfetti` utility in `packages/ui` and wires it up as an optional setting for the likes widget (triggers on "yes" like) and stem-begroot widget (triggers on vote submit). Both widgets get a `showConfetti` toggle in the admin panel. Also adds a "Likes widget" tab to the resource-detail-with-map admin config so the confetti setting is reachable there too.