### PR TITLE
Fix/dw general bugs v2

### DIFF
--- a/packages/comments/src/parts/comment.tsx
+++ b/packages/comments/src/parts/comment.tsx
@@ -8,7 +8,7 @@ import {
   Paragraph,
 } from '@utrecht/component-library-react';
 import '@utrecht/design-tokens/dist/root.css';
-import React, { useContext } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { useState } from 'react';
 
 import hasRole from '../../../lib/has-role';
@@ -69,6 +69,20 @@ function Comment({
   const [hasUserDisliked, setHasUserDisliked] = useState<boolean>(
     args.comment.hasUserDisliked || false
   );
+
+  useEffect(() => {
+    setYesVotes(args.comment.yes || 0);
+    setNoVotes(args.comment.no || 0);
+    setNetVotes(args.comment.netVotes || 0);
+    setHasUserLiked(args.comment.hasUserLiked || false);
+    setHasUserDisliked(args.comment.hasUserDisliked || false);
+  }, [
+    args.comment.yes,
+    args.comment.no,
+    args.comment.netVotes,
+    args.comment.hasUserLiked,
+    args.comment.hasUserDisliked,
+  ]);
 
   function toggleReplyForm() {
     // todo: scrollto

--- a/packages/data-store/src/api/resources.js
+++ b/packages/data-store/src/api/resources.js
@@ -1,8 +1,9 @@
-function resolveRandomSortSeed(randomSortRotationMs) {
+export function resolveRandomSortSeed(randomSortRotationMs, forceNew) {
   const storedSeed = localStorage.getItem('pseudoRandomSortSeed');
   const storedTimestamp = localStorage.getItem('pseudoRandomSortSeedTimestamp');
 
   const needsNewSeed =
+    forceNew ||
     !storedSeed ||
     (randomSortRotationMs &&
       (!storedTimestamp ||

--- a/packages/data-store/src/hooks/use-resources.js
+++ b/packages/data-store/src/hooks/use-resources.js
@@ -17,6 +17,7 @@ export default function useResources(
     allowMultipleProjects = false,
     fetchAll = false,
     randomSortRotationMs = 0,
+    randomSortKey = undefined,
   },
   options
 ) {
@@ -57,6 +58,7 @@ export default function useResources(
     projectIds,
     allowMultipleProjects,
     randomSortRotationMs,
+    randomSortKey,
   };
 
   // Primary paginated call

--- a/packages/data-store/src/merge-data.js
+++ b/packages/data-store/src/merge-data.js
@@ -95,10 +95,19 @@ export default function mergeData(currentData, newData, action) {
       } else {
         let delta = { [newData.opinion]: currentData[newData.opinion] + 1 };
         let userVote = currentData.userVote;
-        if (userVote) {
-          delta[userVote.opinion] = currentData[userVote.opinion] - 1;
+        let isToggleOff = userVote && userVote.opinion === newData.opinion;
+        if (isToggleOff) {
+          delta[newData.opinion] = currentData[newData.opinion] - 1;
+        } else {
+          if (userVote) {
+            delta[userVote.opinion] = currentData[userVote.opinion] - 1;
+          }
+          delta.userVote = { opinion: newData.opinion };
         }
         result = merge.recursive({}, currentData, delta);
+        if (isToggleOff) {
+          result.userVote = null;
+        }
       }
       break;
 

--- a/packages/document-map/src/gesture.js
+++ b/packages/document-map/src/gesture.js
@@ -28,7 +28,8 @@ L.LRMapInteraction = L.Class.extend({
     this._isTouch = this.options.isTouch;
 
     this.options.messageString =
-      this.options.messageString || 'Use two fingers to move and zoom the map.';
+      this.options.messageString ||
+      'Gebruik twee vingers om de kaart te bewegen en te zoomen.';
 
     if (this._isTouch) {
       this._map.dragging.disable();

--- a/packages/leaflet-map/src/base-map.tsx
+++ b/packages/leaflet-map/src/base-map.tsx
@@ -634,13 +634,20 @@ const BaseMap = ({
     const el = containerWrapperRef.current;
     if (!el) return;
 
+    const unitPattern =
+      /\d+(px|%|vh|vw|em|rem|ex|ch|vmin|vmax|cm|mm|in|pt|pc)$/;
     const heightValue = height
-      ? height.match(/\d+(px|%|vh|vw|em|rem|ex|ch|vmin|vmax|cm|mm|in|pt|pc)$/)
+      ? height.match(unitPattern)
         ? height
         : `${height}px`
       : 'auto';
+    const widthValue = width
+      ? width.match(unitPattern)
+        ? width
+        : `${width}px`
+      : '100%';
 
-    el.style.setProperty('--basemap-map-width', width);
+    el.style.setProperty('--basemap-map-width', widthValue);
     el.style.setProperty('--basemap-map-height', heightValue);
     el.style.setProperty(
       '--basemap-map-aspect-ratio',

--- a/packages/leaflet-map/src/css/base-map.css
+++ b/packages/leaflet-map/src/css/base-map.css
@@ -35,6 +35,35 @@
   display: none;
 }
 
+.osc-base-map-widget-container .leaflet-control-zoom {
+  display: flex;
+  flex-direction: column;
+  border: 2px solid rgba(0, 0, 0, 0.2);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.osc-base-map-widget-container .leaflet-control-zoom a {
+  width: 30px;
+  height: 30px;
+  line-height: 30px;
+  text-align: center;
+  text-decoration: none;
+  color: black;
+  background-color: white;
+  display: block;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.osc-base-map-widget-container .leaflet-control-zoom a:hover {
+  background-color: #f4f4f4;
+}
+
+.osc-base-map-widget-container .leaflet-control-zoom-in {
+  border-bottom: 1px solid #ccc;
+}
+
 .leaflet-popup .leaflet-popup-content {
   display: flex;
   flex-direction: column;

--- a/packages/resource-overview/src/resource-overview.css
+++ b/packages/resource-overview/src/resource-overview.css
@@ -93,10 +93,11 @@
   .image-container
   .osc-image-footer
   .osc-resource-overview-content-item-status {
-  display: inline-block;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
   margin: 0;
   padding: 0.25rem 0.5rem;
-  border-radius: 2px;
   background-color: transparent;
   font-size: 14px;
 }

--- a/packages/resource-overview/src/resource-overview.tsx
+++ b/packages/resource-overview/src/resource-overview.tsx
@@ -6,6 +6,8 @@ import {
 } from '@openstad-headless/admin-server/src/components/ui/tabs';
 //@ts-ignore D.type def missing, will disappear when datastore is ts
 import DataStore from '@openstad-headless/data-store/src';
+//@ts-ignore
+import { resolveRandomSortSeed } from '@openstad-headless/data-store/src/api/resources';
 import { ResourceOverviewMap } from '@openstad-headless/leaflet-map/src/resource-overview-map';
 import {
   ResourceOverviewMapWidgetProps,
@@ -905,6 +907,7 @@ function ResourceOverviewInner({
   const [sort, setSort] = useState<string | undefined>(
     props.defaultSorting || undefined
   );
+  const [randomSortKey, setRandomSortKey] = useState<number>(0);
   const [location, setLocation] = useState<PostcodeAutoFillLocation>(undefined);
 
   const [resources, setResources] = useState<Array<any>>([]);
@@ -1010,6 +1013,7 @@ function ResourceOverviewInner({
     lng: location?.lng,
     maxDistance: location ? (location.proximity || 999) * 1000 : undefined,
     sort,
+    randomSortKey: sort === 'random' ? randomSortKey : undefined,
     projectIds: projectIds || [],
     allowMultipleProjects: selectedProjects && selectedProjects.length > 1,
     fetchAll: needsAllResourcesFetch
@@ -1410,6 +1414,10 @@ function ResourceOverviewInner({
                     'score',
                   ].includes(f.sort)
                 ) {
+                  if (f.sort === 'random') {
+                    resolveRandomSortSeed(0, true);
+                    setRandomSortKey((k) => k + 1);
+                  }
                   setSort(f.sort);
                 }
                 setSearch(f.search.text);

--- a/packages/stem-begroot/src/step-1/begroot-detail-dialog/stem-begroot-detail-dialog.tsx
+++ b/packages/stem-begroot/src/step-1/begroot-detail-dialog/stem-begroot-detail-dialog.tsx
@@ -342,11 +342,11 @@ export const StemBegrootResourceDetailDialog = ({
                           </>
                         ) : null}
 
-                        {displayRanking ? (
+                        {displayRanking && resource?.extraData?.ranking ? (
                           <Icon
                             icon="ri-trophy-line"
                             variant="regular"
-                            text={resource?.extraData?.ranking || 0}
+                            text={resource?.extraData?.ranking}
                           />
                         ) : null}
                       </div>

--- a/packages/ui/src/form-elements/document-upload/document-upload.css
+++ b/packages/ui/src/form-elements/document-upload/document-upload.css
@@ -19,3 +19,12 @@ html [data-filepond-item-state*='invalid'] .filepond--item-panel {
 html .filepond--file-status * {
   white-space: normal;
 }
+
+html .filepond--item-panel {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+html .filepond--list-scroller {
+  width: 100%;
+}

--- a/packages/ui/src/stem-begroot-and-resource-overview/filter/index.css
+++ b/packages/ui/src/stem-begroot-and-resource-overview/filter/index.css
@@ -58,6 +58,7 @@
   display: flex;
   flex-direction: row;
   gap: 1rem;
+  white-space: nowrap;
 }
 
 .active-tags {


### PR DESCRIPTION
This PR fixes 10 bugs from the Druten-Wijchen spreadsheet:

  - Like votes update immediately in the counter, toggle off on second click, and persist after posting a reply
  - Map zoom buttons stack vertically instead of overlapping each other
  - Map width from admin (e.g. "600") renders as 600px instead of being ignored
  - Random sort produces a new order on each "Toepassen" click
  - Status labels on overview cards wrap properly when a resource has multiple statuses
  - Trophy icon in begrootmodule detail dialog only shows when ranking data exists
  - Document map gesture overlay shows Dutch text instead of English
  - Filter button text no longer breaks across two lines