### PR TITLE
feat(api): log pages that successfully load a widget

### DIFF
--- a/apps/api-server/migrations/113-create-widget-loads.js
+++ b/apps/api-server/migrations/113-create-widget-loads.js
@@ -1,0 +1,62 @@
+module.exports = {
+  async up({ context: queryInterface }) {
+    await queryInterface.createTable('widget_loads', {
+      id: {
+        type: require('sequelize').INTEGER,
+        autoIncrement: true,
+        primaryKey: true,
+      },
+      projectId: {
+        type: require('sequelize').INTEGER,
+        allowNull: false,
+        references: { model: 'projects', key: 'id' },
+        onDelete: 'CASCADE',
+      },
+      widgetId: {
+        type: require('sequelize').INTEGER,
+        allowNull: false,
+        references: { model: 'widgets', key: 'id' },
+        onDelete: 'CASCADE',
+      },
+      url: {
+        type: require('sequelize').STRING(2048),
+        allowNull: false,
+      },
+      urlHash: {
+        type: require('sequelize').CHAR(64),
+        allowNull: false,
+      },
+      count: {
+        type: require('sequelize').INTEGER,
+        allowNull: false,
+        defaultValue: 1,
+      },
+      lastSeen: {
+        type: require('sequelize').DATE,
+        allowNull: false,
+        defaultValue: require('sequelize').fn('NOW'),
+      },
+      createdAt: {
+        type: require('sequelize').DATE,
+        allowNull: false,
+      },
+      updatedAt: {
+        type: require('sequelize').DATE,
+        allowNull: false,
+      },
+    });
+
+    await queryInterface.addIndex(
+      'widget_loads',
+      ['projectId', 'widgetId', 'urlHash'],
+      {
+        unique: true,
+        name: 'widget_loads_unique',
+      }
+    );
+  },
+
+  async down({ context: queryInterface }) {
+    await queryInterface.dropTable('widget_loads');
+  },
+};

--- a/apps/api-server/src/models/WidgetLoad.js
+++ b/apps/api-server/src/models/WidgetLoad.js
@@ -1,0 +1,59 @@
+module.exports = function (db, sequelize, DataTypes) {
+  let WidgetLoad = sequelize.define(
+    'widget_load',
+    {
+      projectId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      widgetId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      url: {
+        type: DataTypes.STRING(2048),
+        allowNull: false,
+      },
+      urlHash: {
+        type: DataTypes.CHAR(64),
+        allowNull: false,
+      },
+      count: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        defaultValue: 1,
+      },
+      lastSeen: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+    },
+    {
+      tableName: 'widget_loads',
+      paranoid: false,
+      indexes: [
+        {
+          unique: true,
+          fields: ['projectId', 'widgetId', 'urlHash'],
+          name: 'widget_loads_unique',
+        },
+      ],
+    }
+  );
+
+  WidgetLoad.associate = function (models) {
+    WidgetLoad.belongsTo(models.Project, { foreignKey: 'projectId' });
+    WidgetLoad.belongsTo(models.Widget, { foreignKey: 'widgetId' });
+  };
+
+  WidgetLoad.auth = WidgetLoad.prototype.auth = {
+    listableBy: 'admin',
+    viewableBy: 'admin',
+    createableBy: 'admin',
+    updateableBy: 'admin',
+    deleteableBy: 'admin',
+  };
+
+  return WidgetLoad;
+};

--- a/apps/api-server/src/routes/widget/widget.js
+++ b/apps/api-server/src/routes/widget/widget.js
@@ -12,6 +12,11 @@ const widgetDefinitions = getWidgetSettings();
 
 const reactCheck = require('../../util/react-check');
 const prefillAllowedDomains = require('../../services/prefillAllowedDomains');
+const {
+  normalizeWidgetUrl,
+  hashWidgetUrl,
+  recordWidgetLoad,
+} = require('../../services/normalize-widget-url');
 
 let router = express.Router({ mergeParams: true });
 
@@ -453,6 +458,16 @@ function getWidgetJavascriptOutput(
               : ''
           }
 
+          try {
+            var reportLoadUrl = currentScript.src.split('?')[0] + '/report-load';
+            var reportLoadBody = JSON.stringify({ url: window.location.href });
+            if (navigator.sendBeacon) {
+              navigator.sendBeacon(reportLoadUrl, new Blob([reportLoadBody], { type: 'application/json' }));
+            } else {
+              fetch(reportLoadUrl, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: reportLoadBody, keepalive: true }).catch(function(){});
+            }
+          } catch (e) {}
+
           const redirectUri = new URL(encodeURI(window.location.href));
           redirectUri.searchParams.delete('openstadlogout');
           redirectUri.searchParams.delete('openstadlogintoken');
@@ -614,6 +629,52 @@ router.post('/:widgetId([a-zA-Z0-9]+)/report-block', async (req, res) => {
   } catch (e) {
     console.log('[widget] Could not save domain block:', e.message);
     res.status(500).json({ error: 'Could not save domain block' });
+  }
+});
+
+const reportLoadCooldowns = new Map();
+const REPORT_LOAD_COOLDOWN_MS = 5 * 60 * 1000;
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, timestamp] of reportLoadCooldowns) {
+    if (now - timestamp > REPORT_LOAD_COOLDOWN_MS) {
+      reportLoadCooldowns.delete(key);
+    }
+  }
+}, 60 * 1000);
+
+router.post('/:widgetId([a-zA-Z0-9]+)/report-load', async (req, res) => {
+  const { widgetId } = req.params;
+  const { url } = req.body || {};
+
+  if (!url || typeof url !== 'string') {
+    return res.status(400).json({ error: 'Missing url' });
+  }
+
+  const normalizedUrl = normalizeWidgetUrl(url);
+  if (!normalizedUrl) {
+    return res.status(400).json({ error: 'Invalid url' });
+  }
+
+  const cooldownKey = `${widgetId}:${hashWidgetUrl(normalizedUrl)}`;
+  const lastReport = reportLoadCooldowns.get(cooldownKey);
+  if (lastReport && Date.now() - lastReport < REPORT_LOAD_COOLDOWN_MS) {
+    return res.status(200).json({ ok: true });
+  }
+  reportLoadCooldowns.set(cooldownKey, Date.now());
+
+  try {
+    const result = await recordWidgetLoad(db, { widgetId, rawUrl: url });
+
+    if (result.status === 'not-found') {
+      return res.status(404).json({ error: 'Widget not found' });
+    }
+
+    res.status(200).json({ ok: true });
+  } catch (e) {
+    console.log('[widget] Could not save widget load:', e.message);
+    res.status(500).json({ error: 'Could not save widget load' });
   }
 });
 

--- a/apps/api-server/src/services/normalize-widget-url.js
+++ b/apps/api-server/src/services/normalize-widget-url.js
@@ -1,0 +1,91 @@
+const crypto = require('crypto');
+
+const MAX_URL_LENGTH = 2048;
+
+// Normalize the page url a widget was loaded on: keep origin + path only
+// (query string and fragment are stripped, so tokens/PII in the query are never stored)
+function normalizeWidgetUrl(raw) {
+  if (!raw || typeof raw !== 'string') return null;
+
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch (e) {
+    return null;
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return null;
+  }
+
+  let pathname = parsed.pathname;
+  if (pathname.length > 1) {
+    pathname = pathname.replace(/\/+$/, '');
+  }
+  if (pathname === '') pathname = '/';
+
+  return (parsed.origin.toLowerCase() + pathname).substring(0, MAX_URL_LENGTH);
+}
+
+function hashWidgetUrl(url) {
+  return crypto.createHash('sha256').update(url).digest('hex');
+}
+
+// Record a successful widget load: one row per (projectId, widgetId, normalized url),
+// bumping count + lastSeen on repeat visits
+async function recordWidgetLoad(db, { widgetId, rawUrl }) {
+  const url = normalizeWidgetUrl(rawUrl);
+  if (!url) {
+    return { status: 'invalid-url' };
+  }
+
+  const widget = await db.Widget.findOne({
+    where: { id: widgetId },
+    include: [db.Project],
+  });
+
+  if (!widget || !widget.project) {
+    return { status: 'not-found' };
+  }
+
+  const urlHash = hashWidgetUrl(url);
+  const where = {
+    projectId: widget.project.id,
+    widgetId: parseInt(widgetId, 10),
+    urlHash,
+  };
+
+  const existing = await db.WidgetLoad.findOne({ where });
+  if (existing) {
+    await existing.update({
+      count: existing.count + 1,
+      lastSeen: new Date(),
+    });
+    return { status: 'updated' };
+  }
+
+  try {
+    await db.WidgetLoad.create({ ...where, url });
+  } catch (err) {
+    // Race: a concurrent request created the row first; fall back to an increment
+    if (err && err.name === 'SequelizeUniqueConstraintError') {
+      const fallback = await db.WidgetLoad.findOne({ where });
+      if (fallback) {
+        await fallback.update({
+          count: fallback.count + 1,
+          lastSeen: new Date(),
+        });
+      }
+      return { status: 'updated' };
+    }
+    throw err;
+  }
+
+  return { status: 'created' };
+}
+
+module.exports = {
+  normalizeWidgetUrl,
+  hashWidgetUrl,
+  recordWidgetLoad,
+};

--- a/apps/api-server/src/services/normalize-widget-url.test.js
+++ b/apps/api-server/src/services/normalize-widget-url.test.js
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import { hashWidgetUrl, normalizeWidgetUrl } from './normalize-widget-url.js';
+
+describe('normalizeWidgetUrl', () => {
+  it('strips query string and fragment', () => {
+    expect(normalizeWidgetUrl('https://openstad.org/test?p=4#section')).toBe(
+      'https://openstad.org/test'
+    );
+  });
+
+  it('keeps origin + path for a plain url', () => {
+    expect(normalizeWidgetUrl('https://openstad.org/test/pagina')).toBe(
+      'https://openstad.org/test/pagina'
+    );
+  });
+
+  it('lowercases scheme and host but preserves path case', () => {
+    expect(normalizeWidgetUrl('HTTPS://OpenStad.ORG/Test/Pagina')).toBe(
+      'https://openstad.org/Test/Pagina'
+    );
+  });
+
+  it('strips trailing slashes except for the root path', () => {
+    expect(normalizeWidgetUrl('https://openstad.org/test/')).toBe(
+      'https://openstad.org/test'
+    );
+    expect(normalizeWidgetUrl('https://openstad.org/test///')).toBe(
+      'https://openstad.org/test'
+    );
+    expect(normalizeWidgetUrl('https://openstad.org/')).toBe(
+      'https://openstad.org/'
+    );
+    expect(normalizeWidgetUrl('https://openstad.org')).toBe(
+      'https://openstad.org/'
+    );
+  });
+
+  it('drops default ports but keeps custom ports', () => {
+    expect(normalizeWidgetUrl('https://openstad.org:443/test')).toBe(
+      'https://openstad.org/test'
+    );
+    expect(normalizeWidgetUrl('http://localhost:3000/test')).toBe(
+      'http://localhost:3000/test'
+    );
+  });
+
+  it('returns null for unparseable input', () => {
+    expect(normalizeWidgetUrl('not a url')).toBeNull();
+    expect(normalizeWidgetUrl('')).toBeNull();
+    expect(normalizeWidgetUrl(null)).toBeNull();
+    expect(normalizeWidgetUrl(undefined)).toBeNull();
+    expect(normalizeWidgetUrl(42)).toBeNull();
+  });
+
+  it('returns null for non-http(s) schemes', () => {
+    expect(normalizeWidgetUrl('ftp://openstad.org/test')).toBeNull();
+    expect(normalizeWidgetUrl('file:///etc/passwd')).toBeNull();
+    expect(normalizeWidgetUrl('javascript:alert(1)')).toBeNull();
+    expect(normalizeWidgetUrl('about:blank')).toBeNull();
+  });
+
+  it('truncates to 2048 characters', () => {
+    const longPath = '/' + 'a'.repeat(3000);
+    const result = normalizeWidgetUrl(`https://openstad.org${longPath}`);
+    expect(result.length).toBe(2048);
+    expect(result.startsWith('https://openstad.org/aaa')).toBe(true);
+  });
+});
+
+describe('hashWidgetUrl', () => {
+  it('returns a deterministic 64 character hex string', () => {
+    const hash = hashWidgetUrl('https://openstad.org/test');
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(hashWidgetUrl('https://openstad.org/test')).toBe(hash);
+  });
+
+  it('differs per input', () => {
+    expect(hashWidgetUrl('https://openstad.org/test')).not.toBe(
+      hashWidgetUrl('https://openstad.org/anders')
+    );
+  });
+});

--- a/apps/api-server/src/services/widget-load.test.js
+++ b/apps/api-server/src/services/widget-load.test.js
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { hashWidgetUrl, recordWidgetLoad } from './normalize-widget-url.js';
+
+function createMockDb({ widget, existingLoad } = {}) {
+  return {
+    Project: {},
+    Widget: {
+      findOne: vi.fn().mockResolvedValue(widget ?? null),
+    },
+    WidgetLoad: {
+      findOne: vi.fn().mockResolvedValue(existingLoad ?? null),
+      create: vi.fn().mockResolvedValue({}),
+    },
+  };
+}
+
+const widget = { id: 12, project: { id: 3 } };
+
+describe('recordWidgetLoad', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates a row with the normalized url and hash for a new url', async () => {
+    const db = createMockDb({ widget });
+
+    const result = await recordWidgetLoad(db, {
+      widgetId: '12',
+      rawUrl: 'https://openstad.org/test?p=4#x',
+    });
+
+    expect(result.status).toBe('created');
+    expect(db.WidgetLoad.create).toHaveBeenCalledWith({
+      projectId: 3,
+      widgetId: 12,
+      url: 'https://openstad.org/test',
+      urlHash: hashWidgetUrl('https://openstad.org/test'),
+    });
+  });
+
+  it('updates count and lastSeen for a known url', async () => {
+    const existingLoad = {
+      count: 4,
+      update: vi.fn().mockResolvedValue({}),
+    };
+    const db = createMockDb({ widget, existingLoad });
+
+    const result = await recordWidgetLoad(db, {
+      widgetId: '12',
+      rawUrl: 'https://openstad.org/test',
+    });
+
+    expect(result.status).toBe('updated');
+    expect(existingLoad.update).toHaveBeenCalledWith({
+      count: 5,
+      lastSeen: expect.any(Date),
+    });
+    expect(db.WidgetLoad.create).not.toHaveBeenCalled();
+  });
+
+  it('returns not-found for an unknown widget', async () => {
+    const db = createMockDb({ widget: null });
+
+    const result = await recordWidgetLoad(db, {
+      widgetId: '999',
+      rawUrl: 'https://openstad.org/test',
+    });
+
+    expect(result.status).toBe('not-found');
+    expect(db.WidgetLoad.findOne).not.toHaveBeenCalled();
+    expect(db.WidgetLoad.create).not.toHaveBeenCalled();
+  });
+
+  it('returns invalid-url for an unusable url without touching the db', async () => {
+    const db = createMockDb({ widget });
+
+    const result = await recordWidgetLoad(db, {
+      widgetId: '12',
+      rawUrl: 'javascript:alert(1)',
+    });
+
+    expect(result.status).toBe('invalid-url');
+    expect(db.Widget.findOne).not.toHaveBeenCalled();
+    expect(db.WidgetLoad.create).not.toHaveBeenCalled();
+  });
+
+  it('falls back to an update when create hits the unique index (race)', async () => {
+    const db = createMockDb({ widget });
+    const racedRow = {
+      count: 1,
+      update: vi.fn().mockResolvedValue({}),
+    };
+    db.WidgetLoad.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(racedRow);
+    db.WidgetLoad.create.mockRejectedValue(
+      Object.assign(new Error('duplicate'), {
+        name: 'SequelizeUniqueConstraintError',
+      })
+    );
+
+    const result = await recordWidgetLoad(db, {
+      widgetId: '12',
+      rawUrl: 'https://openstad.org/test',
+    });
+
+    expect(result.status).toBe('updated');
+    expect(racedRow.update).toHaveBeenCalledWith({
+      count: 2,
+      lastSeen: expect.any(Date),
+    });
+  });
+
+  it('rethrows unexpected create errors', async () => {
+    const db = createMockDb({ widget });
+    db.WidgetLoad.create.mockRejectedValue(new Error('db down'));
+
+    await expect(
+      recordWidgetLoad(db, {
+        widgetId: '12',
+        rawUrl: 'https://openstad.org/test',
+      })
+    ).rejects.toThrow('db down');
+  });
+});


### PR DESCRIPTION
We serve widgets to external websites, but we currently have **zero visibility into where they are actually embedded**. The allowlist tells us which domains *may* load widgets, not which pages actually do.

This matters for two reasons:

1. **Release confidence.** When we ship a new release, we have no way of knowing which live pages to check. With this data we can list every page that loaded a widget in a given timeframe (e.g. the last two weeks) and run automated tests against exactly those pages.

2. **Operational insight.** Knowing where widgets run helps us answer basic questions we currently can't: which projects are actively used, on which sites, and since when. Combined with the existing `domain_blocks` table (failed attempts), we now see both sides: where widgets load and where they're being blocked.

Technical implementation:

The widget embed script reports its page URL to a new `report-load` endpoint after passing the allowlist check. URLs are stored in a new `widget_loads` table, normalized (origin + path only, no query strings — so no tokens/PII) and deduplicated per project/widget/page with a `count` and `lastSeen`. Same pattern as the existing `report-block` flow, including cooldown throttling.