### PR TITLE
Feature/lightbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ docker-compose.override.yml
 # Package lock files per app should not be committed, we use a monorepo approach with a package-lock.json at the root
 apps/*/package-lock.json
 /packages/ui/dist
+.worktrees

--- a/packages/resource-detail/src/resource-detail.tsx
+++ b/packages/resource-detail/src/resource-detail.tsx
@@ -19,6 +19,7 @@ import {
   Icon,
   IconButton,
   Image,
+  Lightbox,
   Pill,
   Spacer,
 } from '@openstad-headless/ui/src';
@@ -161,6 +162,7 @@ function ResourceDetail({
   const [refreshComments, setRefreshComments] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const [showAccordion, setShowAccordion] = useState(false);
+  const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
   const descriptionRef = React.useRef<HTMLDivElement>(null);
   const id = useId();
 
@@ -353,9 +355,15 @@ function ResourceDetail({
     );
 
     return clickableImage ? (
-      <a href={src} target="_blank" rel="noreferrer">
+      <div
+        style={{ cursor: 'zoom-in' }}
+        onClick={() => setLightboxSrc(src)}
+        role="button"
+        tabIndex={0}
+        aria-label="Afbeelding uitvergroot bekijken"
+        onKeyDown={(e) => e.key === 'Enter' && setLightboxSrc(src)}>
         {imageElement}
-      </a>
+      </div>
     ) : (
       imageElement
     );
@@ -454,6 +462,9 @@ function ResourceDetail({
 
   return (
     <section className="osc-resource-detail-widget-container">
+      {lightboxSrc && (
+        <Lightbox src={lightboxSrc} onClose={() => setLightboxSrc(null)} />
+      )}
       {displayDeleteEditButtonOnTop && <GroupButtonDeleteEdit />}
       <div
         className={`osc ${

--- a/packages/resource-detail/src/resource-detail.tsx
+++ b/packages/resource-detail/src/resource-detail.tsx
@@ -163,6 +163,7 @@ function ResourceDetail({
   const [expanded, setExpanded] = useState(false);
   const [showAccordion, setShowAccordion] = useState(false);
   const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
+  const [lightboxAlt, setLightboxAlt] = useState<string | undefined>(undefined);
   const descriptionRef = React.useRef<HTMLDivElement>(null);
   const id = useId();
 
@@ -321,7 +322,8 @@ function ResourceDetail({
   const renderImage = (
     src: string,
     clickableImage: boolean,
-    imageDescription?: string
+    imageDescription?: string,
+    imageAlt?: string
   ) => {
     const imageElement = (
       <>
@@ -357,11 +359,17 @@ function ResourceDetail({
     return clickableImage ? (
       <div
         style={{ cursor: 'zoom-in' }}
-        onClick={() => setLightboxSrc(src)}
+        onClick={() => {
+          setLightboxSrc(src);
+          setLightboxAlt(imageAlt);
+        }}
         role="button"
         tabIndex={0}
         aria-label="Afbeelding uitvergroot bekijken"
-        onKeyDown={(e) => e.key === 'Enter' && setLightboxSrc(src)}>
+        onKeyDown={(e) =>
+          (e.key === 'Enter' || e.key === ' ') &&
+          (setLightboxSrc(src), setLightboxAlt(imageAlt))
+        }>
         {imageElement}
       </div>
     ) : (
@@ -463,7 +471,11 @@ function ResourceDetail({
   return (
     <section className="osc-resource-detail-widget-container">
       {lightboxSrc && (
-        <Lightbox src={lightboxSrc} onClose={() => setLightboxSrc(null)} />
+        <Lightbox
+          src={lightboxSrc}
+          alt={lightboxAlt}
+          onClose={() => setLightboxSrc(null)}
+        />
       )}
       {displayDeleteEditButtonOnTop && <GroupButtonDeleteEdit />}
       <div
@@ -485,7 +497,7 @@ function ResourceDetail({
                     previous: 'Vorige afbeelding',
                   }}
                   itemRenderer={(i) =>
-                    renderImage(i.url, clickableImage, i.description)
+                    renderImage(i.url, clickableImage, i.description, i.alt)
                   }
                 />
               )}

--- a/packages/resource-overview/src/gridder-resource-detail.tsx
+++ b/packages/resource-overview/src/gridder-resource-detail.tsx
@@ -4,6 +4,7 @@ import { ProjectSettingProps } from '@openstad-headless/types/project-setting-pr
 import {
   IconButton,
   Image,
+  Lightbox,
   Pill,
   SecondaryButton,
   Spacer,
@@ -19,7 +20,7 @@ import {
   Paragraph,
 } from '@utrecht/component-library-react';
 import '@utrecht/design-tokens/dist/root.css';
-import React from 'react';
+import React, { useState } from 'react';
 
 import { canLikeResource, hasRole } from '../../lib';
 import { Icon } from '../../ui/src/icon';
@@ -64,6 +65,8 @@ export const GridderResourceDetail = ({
   currentUser,
   ...props
 }: GridderResourceDetailProps) => {
+  const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
+
   // When resource is correctly typed the we will not need :any
 
   let resourceFilteredTags =
@@ -128,9 +131,15 @@ export const GridderResourceDetail = ({
     const imageComponent = <Image src={image} className="--aspectRatio-16-9" />;
 
     return clickableImage ? (
-      <a href={image} target="_blank" rel="noreferrer">
+      <div
+        style={{ cursor: 'zoom-in' }}
+        onClick={() => setLightboxSrc(image)}
+        role="button"
+        tabIndex={0}
+        aria-label="Afbeelding uitvergroot bekijken"
+        onKeyDown={(e) => e.key === 'Enter' && setLightboxSrc(image)}>
         {imageComponent}
-      </a>
+      </div>
     ) : (
       imageComponent
     );
@@ -138,6 +147,9 @@ export const GridderResourceDetail = ({
 
   return (
     <>
+      {lightboxSrc && (
+        <Lightbox src={lightboxSrc} onClose={() => setLightboxSrc(null)} />
+      )}
       <div className="osc-gridder-resource-detail">
         <section className={`osc-gridder-resource-detail-photo ${hasImages}`}>
           {renderImage(

--- a/packages/resource-overview/src/gridder-resource-detail.tsx
+++ b/packages/resource-overview/src/gridder-resource-detail.tsx
@@ -66,6 +66,7 @@ export const GridderResourceDetail = ({
   ...props
 }: GridderResourceDetailProps) => {
   const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
+  const [lightboxAlt, setLightboxAlt] = useState<string | undefined>(undefined);
 
   // When resource is correctly typed the we will not need :any
 
@@ -127,17 +128,27 @@ export const GridderResourceDetail = ({
   const hasImages = !!resourceImages ? '' : 'resource-has-no-images';
   const canLike = canLikeResource(resource);
 
-  const renderImage = (image: string, clickableImage: boolean) => {
+  const renderImage = (
+    image: string,
+    clickableImage: boolean,
+    alt?: string
+  ) => {
     const imageComponent = <Image src={image} className="--aspectRatio-16-9" />;
 
     return clickableImage ? (
       <div
         style={{ cursor: 'zoom-in' }}
-        onClick={() => setLightboxSrc(image)}
+        onClick={() => {
+          setLightboxSrc(image);
+          setLightboxAlt(alt);
+        }}
         role="button"
         tabIndex={0}
         aria-label="Afbeelding uitvergroot bekijken"
-        onKeyDown={(e) => e.key === 'Enter' && setLightboxSrc(image)}>
+        onKeyDown={(e) =>
+          (e.key === 'Enter' || e.key === ' ') &&
+          (setLightboxSrc(image), setLightboxAlt(alt))
+        }>
         {imageComponent}
       </div>
     ) : (
@@ -148,13 +159,18 @@ export const GridderResourceDetail = ({
   return (
     <>
       {lightboxSrc && (
-        <Lightbox src={lightboxSrc} onClose={() => setLightboxSrc(null)} />
+        <Lightbox
+          src={lightboxSrc}
+          alt={lightboxAlt}
+          onClose={() => setLightboxSrc(null)}
+        />
       )}
       <div className="osc-gridder-resource-detail">
         <section className={`osc-gridder-resource-detail-photo ${hasImages}`}>
           {renderImage(
             resource.images?.at(0)?.url || defaultImage,
-            clickableImage
+            clickableImage,
+            resource.images?.at(0)?.alt
           )}
 
           <div className="osc-gridder-resource-detail-budget-theme-bar">

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -20,3 +20,4 @@ export { List } from './list';
 export { Stepper } from './stepper';
 export { Pill } from './pill';
 export { Separator } from './separator';
+export { Lightbox } from './lightbox';

--- a/packages/ui/src/infoImage/index.tsx
+++ b/packages/ui/src/infoImage/index.tsx
@@ -54,19 +54,25 @@ const InfoImage = ({
     imageDescription?: string
   ) => (
     <figure className="info-image-container">
-      <img
-        src={image}
-        alt={imageAlt}
-        onClick={
-          imageClickable
-            ? () => {
-                setLightboxSrc(image);
-                setLightboxAlt(imageAlt);
-              }
-            : undefined
-        }
-        className={imageClickable ? 'clickable-image' : undefined}
-      />
+      {imageClickable ? (
+        <div
+          style={{ cursor: 'zoom-in' }}
+          onClick={() => {
+            setLightboxSrc(image);
+            setLightboxAlt(imageAlt);
+          }}
+          role="button"
+          tabIndex={0}
+          aria-label="Afbeelding uitvergroot bekijken"
+          onKeyDown={(e) =>
+            (e.key === 'Enter' || e.key === ' ') &&
+            (setLightboxSrc(image), setLightboxAlt(imageAlt))
+          }>
+          <img src={image} alt={imageAlt} className="clickable-image" />
+        </div>
+      ) : (
+        <img src={image} alt={imageAlt} />
+      )}
       {imageDescription && <figcaption>{imageDescription}</figcaption>}
       {addSpacer && <Spacer size={0.5} />}
     </figure>

--- a/packages/ui/src/infoImage/index.tsx
+++ b/packages/ui/src/infoImage/index.tsx
@@ -3,9 +3,10 @@ import {
   Paragraph,
   Strong,
 } from '@utrecht/component-library-react';
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Carousel } from '../carousel';
+import { Lightbox } from '../lightbox';
 import { Spacer } from '../spacer';
 
 type ImageType = {
@@ -33,6 +34,9 @@ const InfoImage = ({
   addSpacer = false,
   imageClickable = false,
 }: InfoImageProps) => {
+  const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
+  const [lightboxAlt, setLightboxAlt] = useState<string | undefined>(undefined);
+
   let imageArray: ImageType[] = images && images.length > 0 ? images : [];
   if (!imageArray.length && imageFallback) {
     imageArray = [
@@ -54,7 +58,12 @@ const InfoImage = ({
         src={image}
         alt={imageAlt}
         onClick={
-          imageClickable ? () => window.open(image, '_blank') : undefined
+          imageClickable
+            ? () => {
+                setLightboxSrc(image);
+                setLightboxAlt(imageAlt);
+              }
+            : undefined
         }
         className={imageClickable ? 'clickable-image' : undefined}
       />
@@ -63,23 +72,34 @@ const InfoImage = ({
     </figure>
   );
 
-  return createImageSlider && imageArray.length > 0 ? (
-    <Carousel
-      items={images}
-      buttonText={{
-        next: 'Volgende afbeelding',
-        previous: 'Vorige afbeelding',
-      }}
-      pager={true}
-      itemRenderer={(img) =>
-        renderImage(img.url, img.imageAlt, img.imageDescription)
-      }
-    />
-  ) : imageArray.length > 0 ? (
-    imageArray.map((img) =>
-      renderImage(img.url, img.imageAlt, img.imageDescription)
-    )
-  ) : null;
+  return (
+    <>
+      {lightboxSrc && (
+        <Lightbox
+          src={lightboxSrc}
+          alt={lightboxAlt}
+          onClose={() => setLightboxSrc(null)}
+        />
+      )}
+      {createImageSlider && imageArray.length > 0 ? (
+        <Carousel
+          items={images}
+          buttonText={{
+            next: 'Volgende afbeelding',
+            previous: 'Vorige afbeelding',
+          }}
+          pager={true}
+          itemRenderer={(img) =>
+            renderImage(img.url, img.imageAlt, img.imageDescription)
+          }
+        />
+      ) : imageArray.length > 0 ? (
+        imageArray.map((img) =>
+          renderImage(img.url, img.imageAlt, img.imageDescription)
+        )
+      ) : null}
+    </>
+  );
 };
 
 export { InfoImage };

--- a/packages/ui/src/lightbox/index.css
+++ b/packages/ui/src/lightbox/index.css
@@ -1,0 +1,47 @@
+.osc-lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  animation: osc-lightbox-fade-in 150ms ease;
+}
+
+.osc-lightbox-image {
+  max-width: 90vw;
+  max-height: 90vh;
+  object-fit: contain;
+  border-radius: 4px;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.6);
+  cursor: default;
+}
+
+.osc-lightbox-close {
+  position: fixed;
+  top: 16px;
+  right: 20px;
+  background: rgba(255, 255, 255, 0.15);
+  border: none;
+  color: white;
+  font-size: 20px;
+  line-height: 1;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 150ms ease;
+}
+
+.osc-lightbox-close:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+@keyframes osc-lightbox-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}

--- a/packages/ui/src/lightbox/index.css
+++ b/packages/ui/src/lightbox/index.css
@@ -2,11 +2,33 @@
   position: fixed;
   inset: 0;
   background-color: rgba(0, 0, 0, 0.85);
-  display: flex;
-  align-items: center;
-  justify-content: center;
   z-index: 9999;
   animation: osc-lightbox-fade-in 150ms ease;
+}
+
+.osc-lightbox-content {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 10000;
+  outline: none;
+}
+
+.osc-lightbox-content:focus {
+  outline: none;
+}
+
+.osc-lightbox-title {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .osc-lightbox-image {
@@ -15,7 +37,7 @@
   object-fit: contain;
   border-radius: 4px;
   box-shadow: 0 8px 40px rgba(0, 0, 0, 0.6);
-  cursor: default;
+  display: block;
 }
 
 .osc-lightbox-close {
@@ -42,6 +64,10 @@
 }
 
 @keyframes osc-lightbox-fade-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }

--- a/packages/ui/src/lightbox/index.tsx
+++ b/packages/ui/src/lightbox/index.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect } from 'react';
+import * as RadixDialog from '@radix-ui/react-dialog';
+import React from 'react';
 
 import './index.css';
 
@@ -9,33 +10,24 @@ type LightboxProps = {
 };
 
 export const Lightbox = ({ src, alt = '', onClose }: LightboxProps) => {
-  useEffect(() => {
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
-    };
-    document.addEventListener('keydown', handleKey);
-    return () => document.removeEventListener('keydown', handleKey);
-  }, [onClose]);
-
   return (
-    <div
-      className="osc-lightbox-overlay"
-      onClick={onClose}
-      role="dialog"
-      aria-modal="true"
-      aria-label="Afbeelding uitvergroot">
-      <button
-        className="osc-lightbox-close"
-        onClick={onClose}
-        aria-label="Sluiten">
-        ✕
-      </button>
-      <img
-        className="osc-lightbox-image"
-        src={src}
-        alt={alt}
-        onClick={(e) => e.stopPropagation()}
-      />
-    </div>
+    <RadixDialog.Root open onOpenChange={(open) => !open && onClose()}>
+      <RadixDialog.Portal>
+        <div className="openstad">
+          <RadixDialog.Overlay className="osc-lightbox-overlay" />
+          <RadixDialog.Content className="osc-lightbox-content">
+            <RadixDialog.Title className="osc-lightbox-title">
+              Afbeelding uitvergroot
+            </RadixDialog.Title>
+            <RadixDialog.Close
+              className="osc-lightbox-close"
+              aria-label="Sluiten">
+              ✕
+            </RadixDialog.Close>
+            <img className="osc-lightbox-image" src={src} alt={alt} />
+          </RadixDialog.Content>
+        </div>
+      </RadixDialog.Portal>
+    </RadixDialog.Root>
   );
 };

--- a/packages/ui/src/lightbox/index.tsx
+++ b/packages/ui/src/lightbox/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { createPortal } from 'react-dom';
+
 import './index.css';
 
 type LightboxProps = {
@@ -17,9 +17,17 @@ export const Lightbox = ({ src, alt = '', onClose }: LightboxProps) => {
     return () => document.removeEventListener('keydown', handleKey);
   }, [onClose]);
 
-  return createPortal(
-    <div className="osc-lightbox-overlay" onClick={onClose} role="dialog" aria-modal="true" aria-label="Afbeelding uitvergroot">
-      <button className="osc-lightbox-close" onClick={onClose} aria-label="Sluiten">
+  return (
+    <div
+      className="osc-lightbox-overlay"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Afbeelding uitvergroot">
+      <button
+        className="osc-lightbox-close"
+        onClick={onClose}
+        aria-label="Sluiten">
         ✕
       </button>
       <img
@@ -28,7 +36,6 @@ export const Lightbox = ({ src, alt = '', onClose }: LightboxProps) => {
         alt={alt}
         onClick={(e) => e.stopPropagation()}
       />
-    </div>,
-    document.body
+    </div>
   );
 };

--- a/packages/ui/src/lightbox/index.tsx
+++ b/packages/ui/src/lightbox/index.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import './index.css';
+
+type LightboxProps = {
+  src: string;
+  alt?: string;
+  onClose: () => void;
+};
+
+export const Lightbox = ({ src, alt = '', onClose }: LightboxProps) => {
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  return createPortal(
+    <div className="osc-lightbox-overlay" onClick={onClose} role="dialog" aria-modal="true" aria-label="Afbeelding uitvergroot">
+      <button className="osc-lightbox-close" onClick={onClose} aria-label="Sluiten">
+        ✕
+      </button>
+      <img
+        className="osc-lightbox-image"
+        src={src}
+        alt={alt}
+        onClick={(e) => e.stopPropagation()}
+      />
+    </div>,
+    document.body
+  );
+};

--- a/packages/ui/types/lightbox/index.d.ts
+++ b/packages/ui/types/lightbox/index.d.ts
@@ -1,0 +1,9 @@
+import React from 'react';
+import './index.css';
+type LightboxProps = {
+    src: string;
+    alt?: string;
+    onClose: () => void;
+};
+export declare const Lightbox: ({ src, alt, onClose }: LightboxProps) => React.JSX.Element;
+export {};


### PR DESCRIPTION
This pull request introduces a new `Lightbox` component to provide an improved image viewing experience across multiple components. Images that were previously opened in a new tab are now displayed in an accessible, modal-style overlay when clicked. The implementation includes the new component, its styles, and updates to several UI and feature components to use the new lightbox functionality.

**New Lightbox Feature:**

* Added a reusable `Lightbox` component in `packages/ui/src/lightbox/index.tsx` for displaying images in a modal overlay, with keyboard and click-to-close support.
* Introduced associated styles in `packages/ui/src/lightbox/index.css` for overlay appearance, transitions, and close button.
* Exported the `Lightbox` component from the UI package for use in other components.

**Integration into Feature Components:**

* Updated `ResourceDetail` (`packages/resource-detail/src/resource-detail.tsx`) and `GridderResourceDetail` (`packages/resource-overview/src/gridder-resource-detail.tsx`) to use the `Lightbox` component for image enlargement, replacing previous anchor tag behavior. [[1]](diffhunk://#diff-60208907a8555873999749f691dc20e804edb1c1f26fb595c35a866b9d20112eR22) [[2]](diffhunk://#diff-60208907a8555873999749f691dc20e804edb1c1f26fb595c35a866b9d20112eR165) [[3]](diffhunk://#diff-60208907a8555873999749f691dc20e804edb1c1f26fb595c35a866b9d20112eL356-R366) [[4]](diffhunk://#diff-60208907a8555873999749f691dc20e804edb1c1f26fb595c35a866b9d20112eR465-R467) [[5]](diffhunk://#diff-0bc184d4bbc357b2f08be6402a1265fcee66bcc0175ea2ec05015922b6ee13adR7) [[6]](diffhunk://#diff-0bc184d4bbc357b2f08be6402a1265fcee66bcc0175ea2ec05015922b6ee13adL22-R23) [[7]](diffhunk://#diff-0bc184d4bbc357b2f08be6402a1265fcee66bcc0175ea2ec05015922b6ee13adR68-R69) [[8]](diffhunk://#diff-0bc184d4bbc357b2f08be6402a1265fcee66bcc0175ea2ec05015922b6ee13adL131-R152)

**Integration into UI Components:**

* Enhanced the `InfoImage` component (`packages/ui/src/infoImage/index.tsx`) to use the `Lightbox` for clickable images, supporting both single and carousel images, and handling alt text. [[1]](diffhunk://#diff-03a84ea7e21ec6e157642ea2eda0375344179bd18ee564c7f21c02eada641773L6-R9) [[2]](diffhunk://#diff-03a84ea7e21ec6e157642ea2eda0375344179bd18ee564c7f21c02eada641773R37-R39) [[3]](diffhunk://#diff-03a84ea7e21ec6e157642ea2eda0375344179bd18ee564c7f21c02eada641773L57-R66) [[4]](diffhunk://#diff-03a84ea7e21ec6e157642ea2eda0375344179bd18ee564c7f21c02eada641773L66-R84) [[5]](diffhunk://#diff-03a84ea7e21ec6e157642ea2eda0375344179bd18ee564c7f21c02eada641773L82-R102)