### PR TITLE
Fix/likes n plus 1 api calls

### DIFF
--- a/apps/api-server/src/routes/api/vote.js
+++ b/apps/api-server/src/routes/api/vote.js
@@ -425,7 +425,7 @@ router.route('/*').post(rateLimiter(), async function (req, res, next) {
 
               const maxResources = req.project.config.votes.maxResources;
               const withExisting = req.project.config.votes.withExisting;
-              if (maxResources && withExisting === 'replace') {
+              if (maxResources && withExisting !== 'error') {
                 const createCount = actions.filter(
                   (a) => a.action === 'create'
                 ).length;

--- a/apps/api-server/src/routes/api/vote.js
+++ b/apps/api-server/src/routes/api/vote.js
@@ -250,6 +250,7 @@ router.route('/*').post(rateLimiter(), async function (req, res, next) {
         }
 
         const existingVotes = existing.map((entry) => entry.toJSON());
+        const replaceAll = req.query.replaceAll === 'true';
         let votes = req.body || [];
         if (!Array.isArray(votes)) votes = [votes];
 
@@ -263,7 +264,7 @@ router.route('/*').post(rateLimiter(), async function (req, res, next) {
           checked: null,
         }));
 
-        if (req.project.config.votes.withExisting == 'merge') {
+        if (req.project.config.votes.withExisting == 'merge' && replaceAll) {
           if (
             existingVotes.find((newVote) =>
               votes.find((oldVote) => oldVote.resourceId == newVote.resourceId)
@@ -343,7 +344,7 @@ router.route('/*').post(rateLimiter(), async function (req, res, next) {
           }
         }
 
-        if (req.project.config.votes.voteType == 'count') {
+        if (req.project.config.votes.voteType == 'count' && replaceAll) {
           if (
             votes.length < req.project.config.votes.minResources ||
             votes.length > req.project.config.votes.maxResources
@@ -398,6 +399,59 @@ router.route('/*').post(rateLimiter(), async function (req, res, next) {
 
           case 'count':
           case 'countPerTag':
+            if (replaceAll) {
+              votes.map((vote) =>
+                actions.push({ action: 'create', vote: vote })
+              );
+              existingVotes.map((vote) =>
+                actions.push({ action: 'delete', vote: vote })
+              );
+            } else {
+              votes.forEach((vote) => {
+                let existingVote = existingVotes.find(
+                  (entry) => entry.resourceId == vote.resourceId
+                );
+                if (existingVote) {
+                  if (existingVote.opinion == vote.opinion) {
+                    actions.push({ action: 'delete', vote: existingVote });
+                  } else {
+                    existingVote.opinion = vote.opinion;
+                    actions.push({ action: 'update', vote: existingVote });
+                  }
+                } else {
+                  actions.push({ action: 'create', vote: vote });
+                }
+              });
+
+              const maxResources = req.project.config.votes.maxResources;
+              const withExisting = req.project.config.votes.withExisting;
+              if (maxResources && withExisting === 'replace') {
+                const createCount = actions.filter(
+                  (a) => a.action === 'create'
+                ).length;
+                const deleteCount = actions.filter(
+                  (a) => a.action === 'delete'
+                ).length;
+                const newTotal =
+                  existingVotes.length + createCount - deleteCount;
+
+                if (newTotal > maxResources) {
+                  const excess = newTotal - maxResources;
+                  const alreadyHandled = new Set(
+                    actions.map((a) => a.vote.id).filter(Boolean)
+                  );
+                  const candidates = existingVotes
+                    .filter((v) => !alreadyHandled.has(v.id))
+                    .sort((a, b) => a.id - b.id);
+
+                  for (let i = 0; i < excess && i < candidates.length; i++) {
+                    actions.push({ action: 'delete', vote: candidates[i] });
+                  }
+                }
+              }
+            }
+            break;
+
           case 'budgeting':
           case 'budgetingPerTag':
             votes.map((vote) => actions.push({ action: 'create', vote: vote }));

--- a/packages/data-store/src/api/resources.js
+++ b/packages/data-store/src/api/resources.js
@@ -140,7 +140,7 @@ export default {
     if (resources.some((r) => !('resourceId' in r) || !('opinion' in r)))
       throw new Error('Ontbrekende velden resourceId of opinion');
 
-    let url = `/api/project/${projectId}/vote`;
+    let url = `/api/project/${projectId}/vote?replaceAll=true`;
     let headers = {
       'Content-Type': 'application/json',
     };

--- a/packages/data-store/src/hooks/use-resource.js
+++ b/packages/data-store/src/hooks/use-resource.js
@@ -8,7 +8,14 @@ export default function useResource(props) {
   const { data, error, isLoading } = self.useSWR(
     { projectId, resourceId },
     'resource.fetch',
-    initialData ? { fallbackData: initialData, revalidateOnMount: false } : {}
+    initialData
+      ? {
+          fallbackData: initialData,
+          revalidateOnMount: false,
+          revalidateOnFocus: false,
+          revalidateOnReconnect: false,
+        }
+      : {}
   );
 
   let resource = data || {};

--- a/packages/data-store/src/hooks/use-resource.js
+++ b/packages/data-store/src/hooks/use-resource.js
@@ -6,19 +6,11 @@ export default function useResource(props) {
   const initialData = props.initialData;
 
   const { data, error, isLoading } = self.useSWR(
-    { projectId, resourceId },
-    'resource.fetch',
-    initialData
-      ? {
-          fallbackData: initialData,
-          revalidateOnMount: false,
-          revalidateOnFocus: false,
-          revalidateOnReconnect: false,
-        }
-      : {}
+    initialData ? null : { projectId, resourceId },
+    'resource.fetch'
   );
 
-  let resource = data || {};
+  let resource = initialData ? { ...initialData } : data || {};
   resource.update = function (newData) {
     return self.mutate({ projectId, resourceId }, 'resource.update', newData, {
       action: 'update',
@@ -30,7 +22,7 @@ export default function useResource(props) {
     });
   };
   resource.submitLike = function (vote) {
-    self.mutate({ projectId, resourceId }, 'resource.submitLike', vote, {
+    return self.mutate({ projectId, resourceId }, 'resource.submitLike', vote, {
       action: 'submitLike',
       revalidate: true,
       populateCache: false,

--- a/packages/data-store/src/hooks/use-resource.js
+++ b/packages/data-store/src/hooks/use-resource.js
@@ -6,11 +6,12 @@ export default function useResource(props) {
   const initialData = props.initialData;
 
   const { data, error, isLoading } = self.useSWR(
-    initialData ? null : { projectId, resourceId },
-    'resource.fetch'
+    { projectId, resourceId },
+    'resource.fetch',
+    initialData ? { fallbackData: initialData, revalidateOnMount: false } : {}
   );
 
-  let resource = initialData ? { ...initialData } : data || {};
+  let resource = data || {};
   resource.update = function (newData) {
     return self.mutate({ projectId, resourceId }, 'resource.update', newData, {
       action: 'update',

--- a/packages/data-store/src/hooks/use-resource.js
+++ b/packages/data-store/src/hooks/use-resource.js
@@ -3,13 +3,14 @@ export default function useResource(props) {
 
   const projectId = props.projectId;
   const resourceId = props.resourceId;
+  const initialData = props.initialData;
+
   const { data, error, isLoading } = self.useSWR(
-    { projectId, resourceId },
+    initialData ? null : { projectId, resourceId },
     'resource.fetch'
   );
 
-  // add functionality
-  let resource = data || {};
+  let resource = initialData ? { ...initialData } : data || {};
   resource.update = function (newData) {
     return self.mutate({ projectId, resourceId }, 'resource.update', newData, {
       action: 'update',

--- a/packages/data-store/src/hooks/use-resources.js
+++ b/packages/data-store/src/hooks/use-resources.js
@@ -60,7 +60,12 @@ export default function useResources(
   };
 
   // Primary paginated call
-  const { data, error, isLoading } = self.useSWR(
+  const {
+    data,
+    error,
+    isLoading,
+    mutate: revalidateList,
+  } = self.useSWR(
     { ...filterParams, page, pageSize },
     'resources.fetch',
     options
@@ -142,5 +147,6 @@ export default function useResources(
     isLoading: isLoading || (fetchAll && allIsLoading),
     submitVotes,
     create,
+    revalidate: () => revalidateList(),
   };
 }

--- a/packages/data-store/src/index.js
+++ b/packages/data-store/src/index.js
@@ -143,11 +143,8 @@ function DataStore(props = {}) {
         Object.keys(windowGlobal.OpenStadSWR).indexOf(
           JSON.stringify(cacheKey, null, 2)
         ) != -1,
-      async (currentData) => currentData, // optimistic ui as fetcher
-      {
-        revalidate: true,
-        rollbackOnError: true,
-      }
+      undefined,
+      { revalidate: true }
     );
   };
 }

--- a/packages/data-store/src/index.js
+++ b/packages/data-store/src/index.js
@@ -93,7 +93,9 @@ function DataStore(props = {}) {
 
     let key = self.createKey(props, fetcherAsString);
 
-    windowGlobal.OpenStadSWR[JSON.stringify(key, null, 2)] = true;
+    if (!options.fallbackData) {
+      windowGlobal.OpenStadSWR[JSON.stringify(key, null, 2)] = true;
+    }
 
     const swrOpts = {};
     if (options.fallbackData) swrOpts.fallbackData = options.fallbackData;

--- a/packages/data-store/src/index.js
+++ b/packages/data-store/src/index.js
@@ -93,23 +93,10 @@ function DataStore(props = {}) {
 
     let key = self.createKey(props, fetcherAsString);
 
-    if (!options.fallbackData) {
-      windowGlobal.OpenStadSWR[JSON.stringify(key, null, 2)] = true;
-    }
+    windowGlobal.OpenStadSWR[JSON.stringify(key, null, 2)] = true;
 
-    const swrOpts = {};
-    if (options.fallbackData) swrOpts.fallbackData = options.fallbackData;
-    if (options.revalidateOnMount !== undefined)
-      swrOpts.revalidateOnMount = options.revalidateOnMount;
-    if (options.revalidateOnFocus !== undefined)
-      swrOpts.revalidateOnFocus = options.revalidateOnFocus;
-    if (options.revalidateOnReconnect !== undefined)
-      swrOpts.revalidateOnReconnect = options.revalidateOnReconnect;
-
-    return useSWR(
-      key,
-      () => fetcher(props, { ...options, keepPreviousData: true }),
-      swrOpts
+    return useSWR(key, () =>
+      fetcher(props, { ...options, keepPreviousData: true })
     );
   };
 

--- a/packages/data-store/src/index.js
+++ b/packages/data-store/src/index.js
@@ -95,8 +95,15 @@ function DataStore(props = {}) {
 
     windowGlobal.OpenStadSWR[JSON.stringify(key, null, 2)] = true;
 
-    return useSWR(key, () =>
-      fetcher(props, { ...options, keepPreviousData: true })
+    const swrOpts = {};
+    if (options.fallbackData) swrOpts.fallbackData = options.fallbackData;
+    if (options.revalidateOnMount !== undefined)
+      swrOpts.revalidateOnMount = options.revalidateOnMount;
+
+    return useSWR(
+      key,
+      () => fetcher(props, { ...options, keepPreviousData: true }),
+      swrOpts
     );
   };
 
@@ -143,8 +150,11 @@ function DataStore(props = {}) {
         Object.keys(windowGlobal.OpenStadSWR).indexOf(
           JSON.stringify(cacheKey, null, 2)
         ) != -1,
-      undefined,
-      { revalidate: true }
+      async (currentData) => currentData,
+      {
+        revalidate: true,
+        rollbackOnError: true,
+      }
     );
   };
 }

--- a/packages/data-store/src/index.js
+++ b/packages/data-store/src/index.js
@@ -99,6 +99,10 @@ function DataStore(props = {}) {
     if (options.fallbackData) swrOpts.fallbackData = options.fallbackData;
     if (options.revalidateOnMount !== undefined)
       swrOpts.revalidateOnMount = options.revalidateOnMount;
+    if (options.revalidateOnFocus !== undefined)
+      swrOpts.revalidateOnFocus = options.revalidateOnFocus;
+    if (options.revalidateOnReconnect !== undefined)
+      swrOpts.revalidateOnReconnect = options.revalidateOnReconnect;
 
     return useSWR(
       key,

--- a/packages/data-store/src/merge-data.js
+++ b/packages/data-store/src/merge-data.js
@@ -1,6 +1,8 @@
 import merge from 'merge';
 
 export default function mergeData(currentData, newData, action) {
+  if (currentData == null) return newData;
+
   let result;
 
   switch (action) {
@@ -95,10 +97,19 @@ export default function mergeData(currentData, newData, action) {
       } else {
         let delta = { [newData.opinion]: currentData[newData.opinion] + 1 };
         let userVote = currentData.userVote;
-        if (userVote) {
-          delta[userVote.opinion] = currentData[userVote.opinion] - 1;
+        let isToggleOff = userVote && userVote.opinion === newData.opinion;
+        if (isToggleOff) {
+          delta[newData.opinion] = currentData[newData.opinion] - 1;
+        } else {
+          if (userVote) {
+            delta[userVote.opinion] = currentData[userVote.opinion] - 1;
+          }
+          delta.userVote = { opinion: newData.opinion };
         }
         result = merge.recursive({}, currentData, delta);
+        if (isToggleOff) {
+          result.userVote = null;
+        }
       }
       break;
 

--- a/packages/likes/src/likes.tsx
+++ b/packages/likes/src/likes.tsx
@@ -23,9 +23,11 @@ export type LikeWidgetProps = BaseProps &
   ProjectSettingProps & {
     resourceId?: string;
     resourceIdRelativePath?: string;
+    datastore?: any;
+    initialResource?: any; // pre-fetched resource data, skips individual API call
     children?:
       | React.ReactNode
-      | ((doVote: (value: string) => void) => React.ReactNode);
+      | ((doVote: (value: string) => void, resource?: any) => React.ReactNode);
   };
 
 export type LikeProps = {
@@ -63,12 +65,12 @@ function Likes({
 
   const necessaryVotes = props.resources?.minimumYesVotes || 50;
 
-  // Pass explicitely because datastore is not ts, we will not get a hint if the props have changed
-
-  const datastore: any = new DataStore({
-    projectId: props.projectId,
-    api: props.api,
-  });
+  const datastore: any =
+    props.datastore ||
+    new DataStore({
+      projectId: props.projectId,
+      api: props.api,
+    });
 
   const storage = new LocalStorage({ projectId: props.projectId });
 
@@ -76,6 +78,7 @@ function Likes({
   const { data: resource } = datastore.useResource({
     projectId: props.projectId,
     resourceId,
+    initialData: props.initialResource,
   });
 
   const [isBusy, setIsBusy] = useState(false);
@@ -132,9 +135,7 @@ function Likes({
     let change: { [key: string]: any } = {};
     if (resource.userVote) change[resource.userVote.opinion] = -1;
 
-    await resource.submitLike({
-      opinion: value,
-    });
+    await resource.submitLike({ opinion: value });
 
     setIsBusy(false);
     if (refreshResourceLikes) {
@@ -143,7 +144,9 @@ function Likes({
   }
 
   if (typeof props.children === 'function') {
-    return <>{props.children((value: string) => doVote(null, value))}</>;
+    return (
+      <>{props.children((value: string) => doVote(null, value), resource)}</>
+    );
   }
 
   return (

--- a/packages/resource-overview/src/resource-overview.tsx
+++ b/packages/resource-overview/src/resource-overview.tsx
@@ -1007,6 +1007,7 @@ function ResourceOverviewInner({
     data: resourcesWithPagination,
     allData: allResourcesData,
     isLoading,
+    revalidate: revalidateResources,
   } = datastore.useResources({
     pageSize,
     ...props,
@@ -1259,7 +1260,7 @@ function ResourceOverviewInner({
   };
 
   const refreshLikes = () => {
-    datastore.refresh();
+    revalidateResources();
   };
 
   const overviewSection = (

--- a/packages/resource-overview/src/resource-overview.tsx
+++ b/packages/resource-overview/src/resource-overview.tsx
@@ -371,7 +371,16 @@ const defaultItemRenderer = (
   const MapIconImage = firstTag && firstTag.mapIcon ? firstTag.mapIcon : false;
   const selectedOpinion = resource?.userVote?.opinion;
 
-  const TileFooter = ({ doVote }: { doVote?: (value: string) => any }) => {
+  const TileFooter = ({
+    doVote,
+    resource: likeResource,
+  }: {
+    doVote?: (value: string) => any;
+    resource?: any;
+  }) => {
+    const displayResource = likeResource || resource;
+    const opinion = displayResource?.userVote?.opinion;
+
     const vote = async (sentiment: string) => {
       if (doVote) {
         await doVote(sentiment);
@@ -389,20 +398,20 @@ const defaultItemRenderer = (
             <Icon
               icon="ri-thumb-up-line"
               variant="big"
-              text={resource.yes}
+              text={displayResource.yes}
               description="Stemmen voor"
               onClick={() => vote('yes')}
-              className={selectedOpinion === 'yes' ? 'selected' : ''}
+              className={opinion === 'yes' ? 'selected' : ''}
             />
 
             {props.likeWidget?.displayDislike && (
               <Icon
                 icon="ri-thumb-down-line"
                 variant="big"
-                text={resource.no}
+                text={displayResource.no}
                 description="Stemmen tegen"
                 onClick={() => vote('no')}
-                className={selectedOpinion === 'no' ? 'selected' : ''}
+                className={opinion === 'no' ? 'selected' : ''}
               />
             )}
           </>
@@ -412,30 +421,28 @@ const defaultItemRenderer = (
           <div className="micro-score-container">
             <Icon
               icon={`${
-                selectedOpinion === 'yes'
-                  ? 'ri-triangle-fill'
-                  : 'ri-triangle-line'
+                opinion === 'yes' ? 'ri-triangle-fill' : 'ri-triangle-line'
               } micro-score-triangle`}
               variant="big"
               description="Stemmen voor"
               onClick={() => vote('yes')}
               className={`micro-score-vote micro-score-vote--yes ${
-                selectedOpinion === 'yes' ? 'selected' : ''
+                opinion === 'yes' ? 'selected' : ''
               }`}
             />
-            <Paragraph className="votes-score">{resource.netVotes}</Paragraph>
+            <Paragraph className="votes-score">
+              {displayResource.netVotes}
+            </Paragraph>
             {props.likeWidget?.displayDislike && (
               <Icon
                 icon={`${
-                  selectedOpinion === 'no'
-                    ? 'ri-triangle-fill'
-                    : 'ri-triangle-line'
+                  opinion === 'no' ? 'ri-triangle-fill' : 'ri-triangle-line'
                 } micro-score-triangle micro-score-triangle-down`}
                 variant="big"
                 description="Stemmen tegen"
                 onClick={() => vote('no')}
                 className={`micro-score-vote micro-score-vote--no ${
-                  selectedOpinion === 'no' ? 'selected' : ''
+                  opinion === 'no' ? 'selected' : ''
                 }`}
               />
             )}
@@ -446,7 +453,7 @@ const defaultItemRenderer = (
           <Icon
             icon="ri-message-line"
             variant="big"
-            text={resource.commentCount}
+            text={displayResource.commentCount}
             description="Aantal reacties"
           />
         ) : null}
@@ -551,9 +558,13 @@ const defaultItemRenderer = (
               resourceId={resource.id}
               projectId={props.projectId}
               {...props}
+              datastore={(props as any).datastore}
+              initialResource={resource}
               disabled={!canLike}
               refreshResourceLikes={refreshLikes}>
-              {(doVote) => <TileFooter doVote={doVote} />}
+              {(doVote, likeResource) => (
+                <TileFooter doVote={doVote} resource={likeResource} />
+              )}
             </Likes>
           ) : (
             <TileFooter />
@@ -1281,6 +1292,7 @@ function ResourceOverviewInner({
                   selectedProjects,
                   displayOverviewTagGroups,
                   overviewTagGroups,
+                  datastore,
                 },
                 () => {
                   onResourceClick(resource, index);

--- a/packages/resource-overview/src/resource-overview.tsx
+++ b/packages/resource-overview/src/resource-overview.tsx
@@ -384,6 +384,7 @@ const defaultItemRenderer = (
     const vote = async (sentiment: string) => {
       if (doVote) {
         await doVote(sentiment);
+        refreshLikes && (await refreshLikes());
       }
     };
 

--- a/packages/resource-overview/src/resource-overview.tsx
+++ b/packages/resource-overview/src/resource-overview.tsx
@@ -384,7 +384,6 @@ const defaultItemRenderer = (
     const vote = async (sentiment: string) => {
       if (doVote) {
         await doVote(sentiment);
-        refreshLikes && (await refreshLikes());
       }
     };
 


### PR DESCRIPTION
The Likes widget created a new DataStore per render in the resource overview, causing ~24 API calls per page load instead of ~4. On production this triggered rate limiting. It now reuses the parent's DataStore and skips individual resource fetches by passing pre-fetched list data via `initialData`. The resources list is revalidated after each vote using the bound SWR mutate from `useResources`.

The vote API for `count/countPerTag` now supports individual like/unlike per resource without replacing all existing votes. Bulk replace is kept for stem-begroot via `?replaceAll=true`. When individual voting exceeds `maxResources`, the oldest vote is automatically removed.

Tested with #1632 merged in since that PR contains related `mergeData` toggle-off logic.