### PR TITLE
feat: allow uniquecode error message to be overridden per client

### DIFF
--- a/apps/auth-server/controllers/auth/code.js
+++ b/apps/auth-server/controllers/auth/code.js
@@ -48,6 +48,12 @@ exports.login = (req, res, next) => {
 };
 
 exports.postLogin = (req, res, next) => {
+  const config = req.client.config ? req.client.config : {};
+  const configAuthType =
+    config.authTypes && config.authTypes[authType]
+      ? config.authTypes[authType]
+      : {};
+
   passport.authenticate(
     'uniqueCode',
     { session: false },
@@ -57,7 +63,9 @@ exports.postLogin = (req, res, next) => {
         logAuthEvent(req, 'login_failed', {
           data: { method: 'uniqueCode' },
         });
-        req.flash('error', { msg: authCodeConfig.errorMessage });
+        req.flash('error', {
+          msg: configAuthType.errorMessage || authCodeConfig.errorMessage,
+        });
         const redirectUrl = req.query.redirect_uri
           ? req.query.redirect_uri
           : req.client.redirectUrl;


### PR DESCRIPTION
The uniquecode login error message was hardcoded in `config/auth.js` and could not be changed per client. Now it checks `client.config.authTypes.UniqueCode.errorMessage` first and falls back to the default if not set. Same pattern already used for other fields like title, description, and buttonText.