### PR TITLE
feat(resource-detail): accessible document download links

### DIFF
--- a/packages/resource-detail/cypress/component/utils.cy.tsx
+++ b/packages/resource-detail/cypress/component/utils.cy.tsx
@@ -1,0 +1,40 @@
+import { formatDocumentLabel } from '../../src/utils';
+
+describe('formatDocumentLabel', () => {
+  it('humanizes underscores and derives the type from the URL', () => {
+    expect(
+      formatDocumentLabel('Groenontwerp_Burggraafstraat_pdf', 'https://example.com/files/groenontwerp.pdf')
+    ).to.equal('Groenontwerp Burggraafstraat (PDF)');
+  });
+
+  it('only strips a trailing suffix when it is a known extension', () => {
+    expect(
+      formatDocumentLabel('20250630_Paneel_1_Ontwerp_pdf', 'https://example.com/p1.pdf')
+    ).to.equal('20250630 Paneel 1 Ontwerp (PDF)');
+  });
+
+  it('handles hyphen-underscore combinations', () => {
+    expect(
+      formatDocumentLabel('Reactienota_Rechters-_en_Kanunnikenbuurt_pdf', 'https://example.com/r.pdf')
+    ).to.equal('Reactienota Rechters en Kanunnikenbuurt (PDF)');
+  });
+
+  it('supports regular dotted file names', () => {
+    expect(formatDocumentLabel('rapport_2026.pdf', '')).to.equal('Rapport 2026 (PDF)');
+  });
+
+  it('ignores query strings in the URL', () => {
+    expect(
+      formatDocumentLabel('verslag_docx', 'https://example.com/verslag.docx?v=2')
+    ).to.equal('Verslag (DOCX)');
+  });
+
+  it('falls back to the URL file name when the name is empty', () => {
+    expect(formatDocumentLabel('', 'https://example.com/files/begroting_2026.pdf'))
+      .to.equal('Begroting 2026 (PDF)');
+  });
+
+  it('omits the type suffix when no extension can be derived', () => {
+    expect(formatDocumentLabel('Toelichting bewonersavond', '')).to.equal('Toelichting bewonersavond');
+  });
+});

--- a/packages/resource-detail/src/resource-detail.tsx
+++ b/packages/resource-detail/src/resource-detail.tsx
@@ -39,6 +39,7 @@ import React, { useEffect, useId, useState } from 'react';
 import { ShareLinks } from '../../apostrophe-widgets/share-links/src/share-links';
 import { canLikeResource, hasRole } from '../../lib';
 import './resource-detail.css';
+import { formatDocumentLabel } from './utils';
 
 type booleanProps = {
   [K in
@@ -746,8 +747,8 @@ function ResourceDetail({
                             download
                             href={document.url}
                             key={index}>
-                            <Icon icon="ri-download-2-fill" />
-                            {document.name}
+                            <Icon icon="ri-download-2-fill" iconOnly />
+                            {formatDocumentLabel(document.name, document.url)}
                           </ButtonLink>
                         )
                       )}

--- a/packages/resource-detail/src/utils.ts
+++ b/packages/resource-detail/src/utils.ts
@@ -1,0 +1,38 @@
+const KNOWN_EXTENSIONS = [
+  'pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx',
+  'csv', 'txt', 'zip', 'png', 'jpg', 'jpeg', 'gif', 'svg',
+];
+
+// Builds an accessible, human-readable label for a document link.
+// The stored file name may not contain the original dot (extensions can
+// appear as a "_pdf" style suffix), so the file type is preferably
+// derived from the document URL. A trailing "_<ext>" suffix is only
+// stripped when it matches a known extension, to avoid removing
+// legitimate words from titles.
+export function formatDocumentLabel(name?: string, url?: string): string {
+  const rawName = name || '';
+  const urlPath = (url || '').split('?')[0].split('#')[0];
+  const urlExtension = urlPath.includes('.')
+    ? urlPath.split('.').pop()?.toLowerCase() ?? ''
+    : '';
+
+  let base = rawName.replace(/\.[^.]+$/, '');
+
+  const knownSuffix = new RegExp(`[_-](${KNOWN_EXTENSIONS.join('|')})$`, 'i');
+  const suffixMatch = base.match(knownSuffix);
+  base = base.replace(knownSuffix, '');
+
+  if (!base && urlPath) {
+    base = urlPath.split('/').pop()?.replace(/\.[^.]+$/, '') ?? '';
+  }
+
+  const extension =
+    (KNOWN_EXTENSIONS.includes(urlExtension) ? urlExtension : '') ||
+    (suffixMatch ? suffixMatch[1].toLowerCase() : '') ||
+    (rawName.includes('.') ? rawName.split('.').pop()?.toLowerCase() ?? '' : '');
+
+  const title = base.replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim();
+  const capitalized = title.charAt(0).toUpperCase() + title.slice(1);
+
+  return extension ? `${capitalized} (${extension.toUpperCase()})` : capitalized;
+}

--- a/packages/resource-detail/src/utils.ts
+++ b/packages/resource-detail/src/utils.ts
@@ -3,36 +3,75 @@ const KNOWN_EXTENSIONS = [
   'csv', 'txt', 'zip', 'png', 'jpg', 'jpeg', 'gif', 'svg',
 ];
 
-// Builds an accessible, human-readable label for a document link.
-// The stored file name may not contain the original dot (extensions can
-// appear as a "_pdf" style suffix), so the file type is preferably
-// derived from the document URL. A trailing "_<ext>" suffix is only
-// stripped when it matches a known extension, to avoid removing
-// legitimate words from titles.
+// Returns the lowercase extension of a path, or '' if there is none.
+function getExtension(path: string): string {
+  if (!path.includes('.')) return '';
+  return path.split('.').pop()?.toLowerCase() ?? '';
+}
+
+// Strips query string and hash from a URL, then returns its extension.
+function getExtensionFromUrl(url: string): string {
+  const path = url.split('?')[0].split('#')[0];
+  return getExtension(path);
+}
+
+// Returns the file name (without extension) from a URL path, used as a
+// fallback when the document has no stored name.
+function getFileNameFromUrl(url: string): string {
+  const path = url.split('?')[0].split('#')[0];
+  if (!path) return '';
+  return path.split('/').pop()?.replace(/\.[^.]+$/, '') ?? '';
+}
+
+// Removes a trailing "_pdf" / "-docx" style suffix, but only when it
+// matches a known extension (so legitimate words in titles are kept).
+// Returns the cleaned base and the matched extension, if any.
+function stripKnownSuffix(name: string): { base: string; extension: string } {
+  const pattern = new RegExp(`[_-](${KNOWN_EXTENSIONS.join('|')})$`, 'i');
+  const match = name.match(pattern);
+  return {
+    base: name.replace(pattern, ''),
+    extension: match ? match[1].toLowerCase() : '',
+  };
+}
+
+// Determines the file type. The stored name may not contain a real
+// extension (it can be transformed to a "_pdf" style suffix), so the URL
+// is the most reliable source. Priority: URL > stripped suffix > name.
+function deriveExtension(
+  urlExtension: string,
+  suffixExtension: string,
+  rawName: string
+): string {
+  if (KNOWN_EXTENSIONS.includes(urlExtension)) return urlExtension;
+  if (suffixExtension) return suffixExtension;
+  return getExtension(rawName);
+}
+
+// Turns underscores/hyphens into spaces and capitalizes the first letter.
+function humanizeBase(base: string): string {
+  const words = base.replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim();
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+// Builds an accessible, human-readable label for a document link,
+// e.g. "Groenontwerp Burggraafstraat (PDF)".
 export function formatDocumentLabel(name?: string, url?: string): string {
   const rawName = name || '';
-  const urlPath = (url || '').split('?')[0].split('#')[0];
-  const urlExtension = urlPath.includes('.')
-    ? urlPath.split('.').pop()?.toLowerCase() ?? ''
-    : '';
+  const documentUrl = url || '';
 
-  let base = rawName.replace(/\.[^.]+$/, '');
+  const withoutDottedExtension = rawName.replace(/\.[^.]+$/, '');
+  const { base: strippedBase, extension: suffixExtension } =
+    stripKnownSuffix(withoutDottedExtension);
 
-  const knownSuffix = new RegExp(`[_-](${KNOWN_EXTENSIONS.join('|')})$`, 'i');
-  const suffixMatch = base.match(knownSuffix);
-  base = base.replace(knownSuffix, '');
+  const base = strippedBase || getFileNameFromUrl(documentUrl);
 
-  if (!base && urlPath) {
-    base = urlPath.split('/').pop()?.replace(/\.[^.]+$/, '') ?? '';
-  }
+  const extension = deriveExtension(
+    getExtensionFromUrl(documentUrl),
+    suffixExtension,
+    rawName
+  );
 
-  const extension =
-    (KNOWN_EXTENSIONS.includes(urlExtension) ? urlExtension : '') ||
-    (suffixMatch ? suffixMatch[1].toLowerCase() : '') ||
-    (rawName.includes('.') ? rawName.split('.').pop()?.toLowerCase() ?? '' : '');
-
-  const title = base.replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim();
-  const capitalized = title.charAt(0).toUpperCase() + title.slice(1);
-
-  return extension ? `${capitalized} (${extension.toUpperCase()})` : capitalized;
+  const title = humanizeBase(base);
+  return extension ? `${title} (${extension.toUpperCase()})` : title;
 }


### PR DESCRIPTION
## What

Document download links in the resource detail widget now show a humanized,
accessible label instead of the raw stored file name.

### Before
<img width="652" height="318" alt="Bijlage voor" src="https://github.com/user-attachments/assets/aed7f066-4a36-4e27-a1f8-38493189735f" />

### After
<img width="577" height="291" alt="bijlage na" src="https://github.com/user-attachments/assets/c4773bb8-c021-48f8-8fa2-86c268729fe1" />

## Why

Relates to #1669 (Part 1). Raw stored names contain underscores and an
`_pdf`-style suffix instead of a real extension (the `/document` upload
endpoint applies `sanitizeFileName` to the full original name, dot included),
which is hard to read and doesn't meet WCAG 2.1 SC 2.4.4 — the link text
should convey what file the user is about to download.

## How

- New `formatDocumentLabel` helper: underscores/hyphens → spaces, extension
  stripped, file type derived from the document URL (the stored name has no
  real extension). Trailing `_<ext>` suffixes are only stripped when they
  match a known extension list, so legitimate words in titles are never
  removed.
- The decorative download icon is now hidden from assistive technology via
  the existing `iconOnly` prop.
- Covered by component tests (`cypress/component/utils.cy.tsx`, 7 cases) and
  verified against the existing `resource-detail.cy.tsx` spec.

## Notes

- No styling changes — label text and accessibility attributes only, so theme
  inheritance via the host site's design tokens is unaffected.
- File size is intentionally not included yet: it is not stored at upload
  time. Part 2 (#1669) adds `size`/`mimeType` to the upload response and
  document entries, after which the label becomes `Title (PDF, 1,2 MB)`.
- Screenshots are from the unstyled dev environment; see #1669 for how the
  links look with a municipality theme applied.