### PR TITLE
feat: API bearer tokens for reporting endpoints

### DIFF
--- a/apps/admin-server/src/components/api-token-status-badge.tsx
+++ b/apps/admin-server/src/components/api-token-status-badge.tsx
@@ -1,0 +1,26 @@
+import { ApiTokenStatus } from '@/hooks/use-api-tokens';
+import { cn } from '@/lib/utils';
+
+const STATUS_LABELS: Record<ApiTokenStatus, string> = {
+  active: 'Actief',
+  expired: 'Verlopen',
+  revoked: 'Ingetrokken',
+};
+
+const STATUS_CLASSES: Record<ApiTokenStatus, string> = {
+  active: 'bg-green-100 text-green-800 border-green-300',
+  expired: 'bg-orange-100 text-orange-800 border-orange-300',
+  revoked: 'bg-red-100 text-red-800 border-red-300',
+};
+
+export function ApiTokenStatusBadge({ status }: { status: ApiTokenStatus }) {
+  return (
+    <span
+      className={cn(
+        'inline-block px-2 py-0.5 text-xs font-medium border rounded-full whitespace-nowrap',
+        STATUS_CLASSES[status]
+      )}>
+      {STATUS_LABELS[status]}
+    </span>
+  );
+}

--- a/apps/admin-server/src/components/ui/sidenav-project.tsx
+++ b/apps/admin-server/src/components/ui/sidenav-project.tsx
@@ -360,6 +360,14 @@ export function SidenavProject({ className }: { className?: string }) {
             <span className="truncate">Notificaties en e-mails</span>
           </Button>
         </Link>
+        <Link href={`/projects/${project}/api-tokens`}>
+          <Button
+            variant={location.includes('/api-tokens') ? 'secondary' : 'ghost'}
+            size="default"
+            className="w-full flex justify-start">
+            <span className="truncate">API-tokens</span>
+          </Button>
+        </Link>
         {HasAccess(sessionData) && (
           <Link href={`/projects/${project}/duplicate`}>
             <Button

--- a/apps/admin-server/src/hooks/use-api-tokens.tsx
+++ b/apps/admin-server/src/hooks/use-api-tokens.tsx
@@ -1,5 +1,7 @@
 import useSWR from 'swr';
 
+export type ApiTokenStatus = 'active' | 'expired' | 'revoked';
+
 export type ApiToken = {
   id: number;
   userId: number;
@@ -10,6 +12,12 @@ export type ApiToken = {
   expiresAt: string;
   lastUsedAt: string | null;
   createdAt: string;
+  status: ApiTokenStatus;
+  // Only present on the project-level overview endpoint
+  owner?: { id: number; name: string | null } | null;
+  // True when the token belongs to a superuser on the admin project and is
+  // shown in another project's overview (read-only there)
+  isSuperUserToken?: boolean;
   // Only present immediately after creation
   token?: string;
 };
@@ -55,4 +63,26 @@ export default function useApiTokens(projectId?: number, userId?: number) {
   }
 
   return { ...swr, createToken, revokeToken };
+}
+
+export function useProjectApiTokens(projectId?: string | number) {
+  const url = projectId
+    ? `/api/openstad/api/project/${projectId}/api-token`
+    : null;
+
+  const swr = useSWR<ApiToken[]>(url);
+
+  async function revokeToken(tokenId: number) {
+    if (!projectId) throw new Error('Project ontbreekt');
+
+    const res = await fetch(
+      `/api/openstad/api/project/${projectId}/api-token/${tokenId}`,
+      { method: 'DELETE' }
+    );
+
+    if (!res.ok) throw new Error('Intrekken van token mislukt');
+    swr.mutate();
+  }
+
+  return { ...swr, revokeToken };
 }

--- a/apps/admin-server/src/hooks/use-api-tokens.tsx
+++ b/apps/admin-server/src/hooks/use-api-tokens.tsx
@@ -1,0 +1,58 @@
+import useSWR from 'swr';
+
+export type ApiToken = {
+  id: number;
+  userId: number;
+  projectId: number;
+  name: string | null;
+  tokenPrefix: string;
+  lastFour: string;
+  expiresAt: string;
+  lastUsedAt: string | null;
+  createdAt: string;
+  // Only present immediately after creation
+  token?: string;
+};
+
+export default function useApiTokens(projectId?: number, userId?: number) {
+  const url =
+    projectId && userId
+      ? `/api/openstad/api/project/${projectId}/user/${userId}/api-token`
+      : null;
+
+  const swr = useSWR<ApiToken[]>(url);
+
+  async function createToken(body: { months: number; name?: string }) {
+    if (!projectId || !userId)
+      throw new Error('Project of gebruiker ontbreekt');
+
+    const res = await fetch(
+      `/api/openstad/api/project/${projectId}/user/${userId}/api-token`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      }
+    );
+
+    if (!res.ok) throw new Error('Aanmaken van token mislukt');
+    const created: ApiToken = await res.json();
+    swr.mutate();
+    return created;
+  }
+
+  async function revokeToken(tokenId: number) {
+    if (!projectId || !userId)
+      throw new Error('Project of gebruiker ontbreekt');
+
+    const res = await fetch(
+      `/api/openstad/api/project/${projectId}/user/${userId}/api-token/${tokenId}`,
+      { method: 'DELETE' }
+    );
+
+    if (!res.ok) throw new Error('Intrekken van token mislukt');
+    swr.mutate();
+  }
+
+  return { ...swr, createToken, revokeToken };
+}

--- a/apps/admin-server/src/pages/projects/[project]/api-tokens.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/api-tokens.tsx
@@ -1,0 +1,131 @@
+import { ApiTokenStatusBadge } from '@/components/api-token-status-badge';
+import { Button } from '@/components/ui/button';
+import { ListHeading, Paragraph } from '@/components/ui/typography';
+import { ApiToken, useProjectApiTokens } from '@/hooks/use-api-tokens';
+import { useRouter } from 'next/router';
+import toast from 'react-hot-toast';
+
+import { PageLayout } from '../../../components/ui/page-layout';
+
+function maskToken(token: ApiToken) {
+  return `${token.tokenPrefix}...${token.lastFour}`;
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('nl-NL');
+}
+
+export default function ProjectApiTokens() {
+  const router = useRouter();
+  const { project } = router.query;
+
+  const { data: tokens, revokeToken } = useProjectApiTokens(project as string);
+
+  async function handleRevoke(tokenId: number) {
+    if (!confirm('Weet je zeker dat je dit token wilt intrekken?')) return;
+    try {
+      await revokeToken(tokenId);
+      toast.success('Token ingetrokken');
+    } catch {
+      toast.error('Intrekken van token mislukt');
+    }
+  }
+
+  return (
+    <div>
+      <PageLayout
+        breadcrumbs={[
+          {
+            name: 'Projecten',
+            url: '/projects',
+          },
+          {
+            name: 'API-tokens',
+            url: `/projects/${project}/api-tokens`,
+          },
+        ]}>
+        <div className="container py-6">
+          <div className="mb-2">
+            <span className="text-sm text-muted-foreground">
+              {`${tokens?.length ?? 0} ${tokens?.length === 1 ? 'token' : 'tokens'}`}
+            </span>
+          </div>
+
+          <div className="p-6 bg-white rounded-md clear-right">
+            <div className="grid grid-cols-2 lg:grid-cols-10 items-center py-2 px-2 border-b border-border">
+              <ListHeading className="hidden lg:flex lg:col-span-2">
+                Eigenaar
+              </ListHeading>
+              <ListHeading className="hidden lg:flex lg:col-span-2">
+                Naam
+              </ListHeading>
+              <ListHeading className="hidden lg:flex lg:col-span-2">
+                Token
+              </ListHeading>
+              <ListHeading className="hidden lg:flex lg:col-span-1">
+                Aangemaakt
+              </ListHeading>
+              <ListHeading className="hidden lg:flex lg:col-span-1">
+                Verloopt
+              </ListHeading>
+              <ListHeading className="hidden lg:flex lg:col-span-1">
+                Status
+              </ListHeading>
+            </div>
+            <ul className="admin-overview">
+              {(!tokens || tokens.length === 0) && (
+                <li className="py-3 px-2">
+                  <Paragraph className="text-muted-foreground">
+                    Geen tokens gevonden.
+                  </Paragraph>
+                </li>
+              )}
+              {tokens?.map((token) => (
+                <li
+                  key={token.id}
+                  className={`grid grid-cols-2 lg:grid-cols-10 items-center py-3 px-2 border-b ${
+                    token.status !== 'active' ? 'opacity-60' : ''
+                  }`}>
+                  <Paragraph className="truncate lg:col-span-2">
+                    {token.owner?.name || `Gebruiker ${token.userId}`}
+                    {token.isSuperUserToken && (
+                      <span className="ml-2 inline-block px-2 py-0.5 text-xs font-medium border rounded-full bg-blue-100 text-blue-800 border-blue-300 whitespace-nowrap">
+                        Superuser
+                      </span>
+                    )}
+                  </Paragraph>
+                  <Paragraph className="hidden lg:block truncate lg:col-span-2 pr-2">
+                    {token.name || '—'}
+                  </Paragraph>
+                  <Paragraph className="hidden lg:block truncate lg:col-span-2 font-mono pr-2">
+                    {maskToken(token)}
+                  </Paragraph>
+                  <Paragraph className="hidden lg:flex truncate lg:col-span-1">
+                    {formatDate(token.createdAt)}
+                  </Paragraph>
+                  <Paragraph className="hidden lg:flex truncate lg:col-span-1">
+                    {formatDate(token.expiresAt)}
+                  </Paragraph>
+                  <div className="lg:col-span-1">
+                    <ApiTokenStatusBadge status={token.status} />
+                  </div>
+                  <div className="flex justify-end lg:col-span-1">
+                    {token.status !== 'revoked' && !token.isSuperUserToken && (
+                      <Button
+                        type="button"
+                        variant="destructive"
+                        size="sm"
+                        onClick={() => handleRevoke(token.id)}>
+                        Intrekken
+                      </Button>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </PageLayout>
+    </div>
+  );
+}

--- a/apps/admin-server/src/pages/users/[user]/api-tokens.tsx
+++ b/apps/admin-server/src/pages/users/[user]/api-tokens.tsx
@@ -1,3 +1,4 @@
+import { ApiTokenStatusBadge } from '@/components/api-token-status-badge';
 import { Button } from '@/components/ui/button';
 import {
   Form,
@@ -191,9 +192,14 @@ export default function UserApiTokens() {
           {tokens.map((token) => (
             <div
               key={token.id}
-              className="flex items-center justify-between p-3 border rounded-md">
+              className={`flex items-center justify-between p-3 border rounded-md ${
+                token.status !== 'active' ? 'opacity-60' : ''
+              }`}>
               <div className="text-sm">
-                <p className="font-mono font-medium">{maskToken(token)}</p>
+                <p className="font-mono font-medium flex items-center gap-2">
+                  {maskToken(token)}
+                  <ApiTokenStatusBadge status={token.status} />
+                </p>
                 {token.name && (
                   <p className="text-muted-foreground">{token.name}</p>
                 )}
@@ -203,13 +209,15 @@ export default function UserApiTokens() {
                     ` · Laatst gebruikt: ${formatDate(token.lastUsedAt)}`}
                 </p>
               </div>
-              <Button
-                type="button"
-                variant="destructive"
-                size="sm"
-                onClick={() => handleRevoke(token.id)}>
-                Intrekken
-              </Button>
+              {token.status !== 'revoked' && (
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="sm"
+                  onClick={() => handleRevoke(token.id)}>
+                  Intrekken
+                </Button>
+              )}
             </div>
           ))}
         </div>

--- a/apps/admin-server/src/pages/users/[user]/api-tokens.tsx
+++ b/apps/admin-server/src/pages/users/[user]/api-tokens.tsx
@@ -1,0 +1,219 @@
+import { Button } from '@/components/ui/button';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Separator } from '@/components/ui/separator';
+import { Heading } from '@/components/ui/typography';
+import useApiTokens, { ApiToken } from '@/hooks/use-api-tokens';
+import useUser from '@/hooks/use-user';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'react-hot-toast';
+import * as z from 'zod';
+
+const formSchema = z.object({
+  months: z.string().min(1, 'Kies een geldigheidsperiode'),
+  name: z.string().optional(),
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+function maskToken(token: ApiToken) {
+  return `${token.tokenPrefix}...${token.lastFour}`;
+}
+
+function formatDate(iso: string) {
+  return new Date(iso).toLocaleDateString('nl-NL');
+}
+
+export default function UserApiTokens() {
+  const { data } = useUser();
+  const user = Array.isArray(data) ? data[0] : data;
+
+  const {
+    data: tokens,
+    createToken,
+    revokeToken,
+  } = useApiTokens(user?.projectId, user?.id);
+
+  const [newToken, setNewToken] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { months: '', name: '' },
+  });
+
+  async function onSubmit(values: FormValues) {
+    try {
+      const created = await createToken({
+        months: parseInt(values.months, 10),
+        name: values.name || undefined,
+      });
+      if (created.token) {
+        setNewToken(created.token);
+        setCopied(false);
+      }
+      form.reset();
+      toast.success('API-token aangemaakt');
+    } catch {
+      toast.error('Aanmaken van token mislukt');
+    }
+  }
+
+  async function handleRevoke(tokenId: number) {
+    if (!confirm('Weet je zeker dat je dit token wilt intrekken?')) return;
+    try {
+      await revokeToken(tokenId);
+      toast.success('Token ingetrokken');
+    } catch {
+      toast.error('Intrekken van token mislukt');
+    }
+  }
+
+  async function handleCopy() {
+    if (!newToken) return;
+    try {
+      await navigator.clipboard.writeText(newToken);
+      setCopied(true);
+    } catch {
+      toast.error('Kopiëren mislukt');
+    }
+  }
+
+  if (!user?.id) return null;
+
+  return (
+    <div className="p-6 bg-white rounded-md">
+      <Heading size="xl" className="mb-4">
+        API-tokens
+      </Heading>
+      <p className="text-sm text-muted-foreground mb-6">
+        Genereer een token zodat externe tools zoals Power BI authenticatie
+        kunnen uitvoeren via een Bearer-header.
+      </p>
+
+      {newToken && (
+        <div className="mb-6 p-4 border border-yellow-400 bg-yellow-50 rounded-md">
+          <p className="text-sm font-semibold text-yellow-800 mb-2">
+            Dit token wordt maar één keer getoond. Kopieer het nu.
+          </p>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 block bg-white border rounded px-3 py-2 text-sm font-mono break-all">
+              {newToken}
+            </code>
+            <Button type="button" variant="outline" onClick={handleCopy}>
+              {copied ? 'Gekopieerd!' : 'Kopieer'}
+            </Button>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="mt-2 text-xs"
+            onClick={() => setNewToken(null)}>
+            Verberg token
+          </Button>
+        </div>
+      )}
+
+      <Heading size="lg" className="mb-4">
+        Nieuw token aanmaken
+      </Heading>
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="months"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Geldigheidsperiode *</FormLabel>
+                <Select onValueChange={field.onChange} value={field.value}>
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Kies een periode" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="1">1 maand</SelectItem>
+                    <SelectItem value="3">3 maanden</SelectItem>
+                    <SelectItem value="12">12 maanden</SelectItem>
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Naam (optioneel)</FormLabel>
+                <FormControl>
+                  <Input placeholder="bijv. Power BI rapport" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button type="submit">Token aanmaken</Button>
+        </form>
+      </Form>
+
+      <Separator className="my-6" />
+
+      <Heading size="lg" className="mb-4">
+        Bestaande tokens
+      </Heading>
+
+      {!tokens || tokens.length === 0 ? (
+        <p className="text-sm text-muted-foreground">Geen tokens gevonden.</p>
+      ) : (
+        <div className="space-y-3">
+          {tokens.map((token) => (
+            <div
+              key={token.id}
+              className="flex items-center justify-between p-3 border rounded-md">
+              <div className="text-sm">
+                <p className="font-mono font-medium">{maskToken(token)}</p>
+                {token.name && (
+                  <p className="text-muted-foreground">{token.name}</p>
+                )}
+                <p className="text-muted-foreground text-xs mt-1">
+                  Verloopt: {formatDate(token.expiresAt)}
+                  {token.lastUsedAt &&
+                    ` · Laatst gebruikt: ${formatDate(token.lastUsedAt)}`}
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="destructive"
+                size="sm"
+                onClick={() => handleRevoke(token.id)}>
+                Intrekken
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin-server/src/pages/users/[user]/index.tsx
+++ b/apps/admin-server/src/pages/users/[user]/index.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import * as React from 'react';
 
 import { PageLayout } from '../../../components/ui/page-layout';
+import UserApiTokens from './api-tokens';
 import UserAuditLog from './audit-log';
 import CreateUserGeneral from './general';
 import CreateUserProjects from './projects';
@@ -31,6 +32,7 @@ export default function CreateUser() {
               <TabsTrigger value="general">Algemene instellingen</TabsTrigger>
               <TabsTrigger value="projects">Projectsrechten</TabsTrigger>
               <TabsTrigger value="auditlog">Logboek</TabsTrigger>
+              <TabsTrigger value="apitokens">API-tokens</TabsTrigger>
             </TabsList>
             <TabsContent value="general" className="p-0">
               <CreateUserGeneral />
@@ -40,6 +42,9 @@ export default function CreateUser() {
             </TabsContent>
             <TabsContent value="auditlog" className="p-0">
               <UserAuditLog />
+            </TabsContent>
+            <TabsContent value="apitokens" className="p-0">
+              <UserApiTokens />
             </TabsContent>
           </Tabs>
         </div>

--- a/apps/api-server/migrations/113-create-api-tokens.js
+++ b/apps/api-server/migrations/113-create-api-tokens.js
@@ -1,0 +1,76 @@
+const { Sequelize } = require('sequelize');
+
+module.exports = {
+  async up({ context: queryInterface }) {
+    await queryInterface.createTable('api_tokens', {
+      id: {
+        type: Sequelize.INTEGER.UNSIGNED,
+        primaryKey: true,
+        autoIncrement: true,
+      },
+      userId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+      },
+      projectId: {
+        type: Sequelize.INTEGER,
+        allowNull: false,
+      },
+      name: {
+        type: Sequelize.STRING(255),
+        allowNull: true,
+      },
+      tokenHash: {
+        type: Sequelize.STRING(64),
+        allowNull: false,
+      },
+      tokenPrefix: {
+        type: Sequelize.STRING(10),
+        allowNull: false,
+      },
+      lastFour: {
+        type: Sequelize.STRING(4),
+        allowNull: false,
+      },
+      expiresAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+      },
+      lastUsedAt: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
+      createdAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      updatedAt: {
+        type: Sequelize.DATE,
+        allowNull: false,
+        defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+      },
+      deletedAt: {
+        type: Sequelize.DATE,
+        allowNull: true,
+      },
+    });
+
+    await queryInterface.addIndex('api_tokens', ['tokenHash'], {
+      name: 'idx_api_tokens_token_hash',
+      unique: true,
+    });
+
+    await queryInterface.addIndex('api_tokens', ['userId'], {
+      name: 'idx_api_tokens_user_id',
+    });
+
+    await queryInterface.addIndex('api_tokens', ['projectId'], {
+      name: 'idx_api_tokens_project_id',
+    });
+  },
+
+  async down({ context: queryInterface }) {
+    await queryInterface.dropTable('api_tokens');
+  },
+};

--- a/apps/api-server/src/Server.js
+++ b/apps/api-server/src/Server.js
@@ -68,6 +68,9 @@ module.exports = {
     this._initBasicMiddleware();
     this._initSessionMiddleware();
 
+    // Restrict API token requests to reporting/stats routes only
+    this.app.use(require('./middleware/api-token-scope-guard'));
+
     var middleware = config.express.middleware;
 
     middleware.forEach((entry) => {

--- a/apps/api-server/src/middleware/api-token-scope-guard.js
+++ b/apps/api-server/src/middleware/api-token-scope-guard.js
@@ -1,0 +1,19 @@
+const createError = require('http-errors');
+
+/**
+ * Block requests authenticated with an API token from accessing any route
+ * other than /stats. The token scope is set to 'reports' in the user middleware.
+ */
+module.exports = function apiTokenScopeGuard(req, res, next) {
+  if (req.apiTokenScope !== 'reports') {
+    return next();
+  }
+
+  if (req.path.startsWith('/stats/') || req.path === '/stats') {
+    return next();
+  }
+
+  return next(
+    createError(403, 'API token is only valid for reporting endpoints')
+  );
+};

--- a/apps/api-server/src/middleware/audit-log.js
+++ b/apps/api-server/src/middleware/audit-log.js
@@ -7,6 +7,17 @@ const WRITE_METHODS = ['POST', 'PUT', 'DELETE'];
 function resolveModelFromPath(path) {
   const segments = path.replace(/^\//, '').split('/');
 
+  // api-token routes are nested under /project/:id/user/:id/api-token and
+  // /project/:id/api-token — the generic project rule below would resolve
+  // them as 'user' (or 'api-token' without the token id), so handle them first
+  const apiTokenIdx = segments.indexOf('api-token');
+  if (apiTokenIdx !== -1) {
+    return {
+      modelName: 'api-token',
+      modelId: segments[apiTokenIdx + 1] || null,
+    };
+  }
+
   // /api/project/:projectId/<model>/...
   const projectIdx = segments.indexOf('project');
   if (projectIdx !== -1 && segments.length > projectIdx + 2) {

--- a/apps/api-server/src/middleware/user.js
+++ b/apps/api-server/src/middleware/user.js
@@ -1,4 +1,5 @@
 const config = require('config');
+const crypto = require('crypto');
 const jwt = require('jsonwebtoken');
 const merge = require('merge');
 const db = require('../db');
@@ -17,25 +18,31 @@ module.exports = async function getUser(req, res, next) {
   try {
     if (!req.headers['authorization']) {
       return nextWithEmptyUser(req, res, next);
-    } else {
-      const allowedUploadPaths = ['/upload/images', '/upload/documents'];
-
-      const isUploadRequest = allowedUploadPaths.some((path) =>
-        req.path.endsWith(path)
-      );
-
-      if (isUploadRequest) {
-        const payload = {
-          userId: '9999999',
-          authProvider: 'upload-service',
-          exp: Math.floor(Date.now() / 1000) + 5 * 60,
-        };
-
-        const uploadJwt = jwt.sign(payload, config.auth.jwtSecret);
-
-        req.headers['authorization'] = `Bearer ${uploadJwt}`;
-      }
     }
+
+    // Opaque API token path (Bearer osr_…) — bypasses JWT and auth-server round-trip
+    if (/^bearer osr_/i.test(req.headers['authorization'])) {
+      return handleApiToken(req, res, next);
+    }
+
+    const allowedUploadPaths = ['/upload/images', '/upload/documents'];
+
+    const isUploadRequest = allowedUploadPaths.some((path) =>
+      req.path.endsWith(path)
+    );
+
+    if (isUploadRequest) {
+      const payload = {
+        userId: '9999999',
+        authProvider: 'upload-service',
+        exp: Math.floor(Date.now() / 1000) + 5 * 60,
+      };
+
+      const uploadJwt = jwt.sign(payload, config.auth.jwtSecret);
+
+      req.headers['authorization'] = `Bearer ${uploadJwt}`;
+    }
+
     let { userId, isFixed, authProvider } = parseAuthHeader(
       req.headers['authorization']
     );
@@ -69,6 +76,58 @@ module.exports = async function getUser(req, res, next) {
     next(error);
   }
 };
+
+/**
+ * Authenticate using an opaque API token (osr_…) stored hashed in api_tokens.
+ * Skips the auth-server round-trip; loads the owner User directly from DB.
+ */
+async function handleApiToken(req, res, next) {
+  try {
+    const rawToken = req.headers['authorization'].replace(/^bearer /i, '');
+    const tokenHash = crypto
+      .createHash('sha256')
+      .update(rawToken)
+      .digest('hex');
+
+    const apiToken = await db.ApiToken.findOne({ where: { tokenHash } });
+
+    if (!apiToken || apiToken.expiresAt < new Date()) {
+      return nextWithEmptyUser(req, res, next);
+    }
+
+    const owner = await db.User.findOne({ where: { id: apiToken.userId } });
+    if (!owner) {
+      return nextWithEmptyUser(req, res, next);
+    }
+
+    // Enforce the token's project binding: stats routes check role only
+    // (hasRole(req.user, 'editor')), so without this check a token from one
+    // project could read another project's stats. Only superusers (admin on
+    // the admin project) may cross project boundaries, mirroring the JWT path.
+    const isSuperUser =
+      owner.projectId == config.admin.projectId &&
+      ['admin', 'superuser'].includes(owner.role);
+    if (
+      !isSuperUser &&
+      (!req.project || req.project.id != apiToken.projectId)
+    ) {
+      return nextWithEmptyUser(req, res, next);
+    }
+
+    req.user = owner;
+    req.apiTokenScope = 'reports';
+
+    // Update lastUsedAt asynchronously — do not block the request
+    apiToken.update({ lastUsedAt: new Date() }).catch(() => {});
+
+    return next();
+  } catch (err) {
+    console.error(
+      `[${new Date().toISOString()}][auth-middleware] handleApiToken error: ${err?.message}`
+    );
+    return nextWithEmptyUser(req, res, next);
+  }
+}
 
 /**
  * Continue with empty user if user is not set

--- a/apps/api-server/src/middleware/user.js
+++ b/apps/api-server/src/middleware/user.js
@@ -4,6 +4,7 @@ const jwt = require('jsonwebtoken');
 const merge = require('merge');
 const db = require('../db');
 const authSettings = require('../util/auth-settings');
+const auditLogService = require('../services/audit-log');
 
 let adapters = {};
 
@@ -92,6 +93,10 @@ async function handleApiToken(req, res, next) {
     const apiToken = await db.ApiToken.findOne({ where: { tokenHash } });
 
     if (!apiToken || apiToken.expiresAt < new Date()) {
+      if (apiToken) {
+        // Token exists but is expired: audit the first rejected use
+        logExpiredTokenUse(req, apiToken).catch(() => {});
+      }
       return nextWithEmptyUser(req, res, next);
     }
 
@@ -127,6 +132,34 @@ async function handleApiToken(req, res, next) {
     );
     return nextWithEmptyUser(req, res, next);
   }
+}
+
+/**
+ * Write a single 'token_expired' audit entry the first time an expired token
+ * is used. Expiry itself is passive (no event fires when a token expires), so
+ * the first rejected use is the auditable moment. Later uses are not logged
+ * again to avoid noise from external tools that keep polling with a dead token.
+ */
+async function logExpiredTokenUse(req, apiToken) {
+  const existing = await db.AuditLog.findOne({
+    where: {
+      modelName: 'api-token',
+      modelId: apiToken.id,
+      action: 'token_expired',
+    },
+  });
+  if (existing) return;
+
+  const entry = auditLogService.buildEntry(req, {
+    action: 'token_expired',
+    modelName: 'api-token',
+    modelId: apiToken.id,
+    source: 'api',
+    statusCode: 401,
+  });
+  // req.params is not populated at middleware level; take it from the token
+  entry.projectId = apiToken.projectId;
+  auditLogService.logDirect(entry);
 }
 
 /**

--- a/apps/api-server/src/models/ApiToken.js
+++ b/apps/api-server/src/models/ApiToken.js
@@ -1,0 +1,64 @@
+module.exports = function (db, sequelize, DataTypes) {
+  var ApiToken = sequelize.define(
+    'api_token',
+    {
+      userId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      projectId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      name: {
+        type: DataTypes.STRING(255),
+        allowNull: true,
+      },
+      tokenHash: {
+        type: DataTypes.STRING(64),
+        allowNull: false,
+        unique: true,
+      },
+      tokenPrefix: {
+        type: DataTypes.STRING(10),
+        allowNull: false,
+      },
+      lastFour: {
+        type: DataTypes.STRING(4),
+        allowNull: false,
+      },
+      expiresAt: {
+        type: DataTypes.DATE,
+        allowNull: false,
+      },
+      lastUsedAt: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
+    },
+    {
+      tableName: 'api_tokens',
+      timestamps: true,
+      paranoid: true,
+    }
+  );
+
+  ApiToken.auth = ApiToken.prototype.auth = {
+    listableBy: 'admin',
+    viewableBy: 'admin',
+    createableBy: 'admin',
+    updateableBy: 'never',
+    deleteableBy: 'admin',
+  };
+
+  ApiToken.scopes = function () {};
+
+  ApiToken.associate = function (models) {
+    ApiToken.belongsTo(models.User, {
+      foreignKey: 'userId',
+      as: 'owner',
+    });
+  };
+
+  return ApiToken;
+};

--- a/apps/api-server/src/routes/api/api-token.js
+++ b/apps/api-server/src/routes/api/api-token.js
@@ -1,0 +1,133 @@
+const express = require('express');
+const crypto = require('crypto');
+const createError = require('http-errors');
+const db = require('../../db');
+const hasRole = require('../../lib/sequelize-authorization/lib/hasRole');
+
+const router = express.Router({ mergeParams: true });
+
+const VALID_MONTHS = { 1: 1, 3: 3, 12: 12 };
+
+function mintToken() {
+  const raw = crypto.randomBytes(32).toString('base64url');
+  const plaintext = 'osr_' + raw;
+  const tokenHash = crypto.createHash('sha256').update(plaintext).digest('hex');
+  const tokenPrefix = plaintext.slice(0, 8);
+  const lastFour = plaintext.slice(-4);
+  return { plaintext, tokenHash, tokenPrefix, lastFour };
+}
+
+function computeExpiresAt(months) {
+  const d = new Date();
+  d.setMonth(d.getMonth() + months);
+  return d;
+}
+
+function maskToken(apiToken) {
+  return {
+    id: apiToken.id,
+    userId: apiToken.userId,
+    projectId: apiToken.projectId,
+    name: apiToken.name,
+    tokenPrefix: apiToken.tokenPrefix,
+    lastFour: apiToken.lastFour,
+    expiresAt: apiToken.expiresAt,
+    lastUsedAt: apiToken.lastUsedAt,
+    createdAt: apiToken.createdAt,
+  };
+}
+
+// Require admin or editor role on all api-token endpoints
+router.use(function (req, res, next) {
+  if (!hasRole(req.user, ['admin', 'editor'])) {
+    return next(createError(403, 'Insufficient permissions'));
+  }
+  if (!req.project) {
+    return next(createError(404, 'Project not found'));
+  }
+  return next();
+});
+
+// POST /project/:projectId/user/:userId/api-token — create a token (returned in plaintext once)
+router.post('/', async function (req, res, next) {
+  try {
+    const userId = parseInt(req.params.userId, 10);
+    const projectId = req.project.id;
+    const { months: monthsStr, name } = req.body;
+
+    const months = VALID_MONTHS[String(monthsStr)];
+    if (!months) {
+      return next(
+        createError(400, 'Invalid validity period. Choose 1, 3, or 12 months.')
+      );
+    }
+
+    // Verify the target user belongs to this project
+    const targetUser = await db.User.findOne({
+      where: { id: userId, projectId },
+    });
+    if (!targetUser) {
+      return next(createError(404, 'User not found in this project'));
+    }
+
+    const { plaintext, tokenHash, tokenPrefix, lastFour } = mintToken();
+    const expiresAt = computeExpiresAt(months);
+
+    const token = await db.ApiToken.create({
+      userId,
+      projectId,
+      name: name || null,
+      tokenHash,
+      tokenPrefix,
+      lastFour,
+      expiresAt,
+    });
+
+    return res.status(201).json({
+      ...maskToken(token),
+      token: plaintext, // returned in plaintext ONCE
+    });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+// GET /project/:projectId/user/:userId/api-token — list masked tokens
+router.get('/', async function (req, res, next) {
+  try {
+    const userId = parseInt(req.params.userId, 10);
+    const projectId = req.project.id;
+
+    const tokens = await db.ApiToken.findAll({
+      where: { userId, projectId },
+    });
+
+    return res.json(tokens.map(maskToken));
+  } catch (err) {
+    return next(err);
+  }
+});
+
+// DELETE /project/:projectId/user/:userId/api-token/:tokenId — revoke (soft-delete)
+router.delete('/:tokenId(\\d+)', async function (req, res, next) {
+  try {
+    const userId = parseInt(req.params.userId, 10);
+    const projectId = req.project.id;
+    const tokenId = parseInt(req.params.tokenId, 10);
+
+    const token = await db.ApiToken.findOne({
+      where: { id: tokenId, userId, projectId },
+    });
+
+    if (!token) {
+      return next(createError(404, 'Token not found'));
+    }
+
+    await token.destroy(); // paranoid soft-delete
+    return res.json({ status: 'ok' });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+module.exports = router;

--- a/apps/api-server/src/routes/api/api-token.js
+++ b/apps/api-server/src/routes/api/api-token.js
@@ -1,3 +1,4 @@
+const config = require('config');
 const express = require('express');
 const crypto = require('crypto');
 const createError = require('http-errors');
@@ -23,6 +24,13 @@ function computeExpiresAt(months) {
   return d;
 }
 
+function computeStatus(apiToken) {
+  if (apiToken.deletedAt) return 'revoked';
+  if (apiToken.expiresAt && new Date(apiToken.expiresAt) < new Date())
+    return 'expired';
+  return 'active';
+}
+
 function maskToken(apiToken) {
   return {
     id: apiToken.id,
@@ -34,11 +42,12 @@ function maskToken(apiToken) {
     expiresAt: apiToken.expiresAt,
     lastUsedAt: apiToken.lastUsedAt,
     createdAt: apiToken.createdAt,
+    status: computeStatus(apiToken),
   };
 }
 
 // Require admin or editor role on all api-token endpoints
-router.use(function (req, res, next) {
+function requireProjectAdminOrEditor(req, res, next) {
   if (!hasRole(req.user, ['admin', 'editor'])) {
     return next(createError(403, 'Insufficient permissions'));
   }
@@ -46,7 +55,9 @@ router.use(function (req, res, next) {
     return next(createError(404, 'Project not found'));
   }
   return next();
-});
+}
+
+router.use(requireProjectAdminOrEditor);
 
 // POST /project/:projectId/user/:userId/api-token — create a token (returned in plaintext once)
 router.post('/', async function (req, res, next) {
@@ -92,7 +103,8 @@ router.post('/', async function (req, res, next) {
   }
 });
 
-// GET /project/:projectId/user/:userId/api-token — list masked tokens
+// GET /project/:projectId/user/:userId/api-token — list masked tokens,
+// including revoked and expired ones (status field tells them apart)
 router.get('/', async function (req, res, next) {
   try {
     const userId = parseInt(req.params.userId, 10);
@@ -100,6 +112,8 @@ router.get('/', async function (req, res, next) {
 
     const tokens = await db.ApiToken.findAll({
       where: { userId, projectId },
+      paranoid: false,
+      order: [['createdAt', 'DESC']],
     });
 
     return res.json(tokens.map(maskToken));
@@ -130,4 +144,91 @@ router.delete('/:tokenId(\\d+)', async function (req, res, next) {
   }
 });
 
+// Project-level overview routes: /project/:projectId/api-token
+const projectRouter = express.Router({ mergeParams: true });
+
+projectRouter.use(requireProjectAdminOrEditor);
+
+// GET /project/:projectId/api-token — all tokens for the project, including
+// revoked and expired ones, with owner name and computed status
+projectRouter.get('/', async function (req, res, next) {
+  try {
+    const projectId = req.project.id;
+    const adminProjectId = config.admin.projectId;
+
+    // Superuser tokens live on the admin project but can read every
+    // project's stats, so they belong in every project's overview
+    const projectIds =
+      projectId == adminProjectId ? [projectId] : [projectId, adminProjectId];
+
+    const tokens = await db.ApiToken.findAll({
+      where: { projectId: projectIds },
+      paranoid: false,
+      include: [
+        {
+          model: db.User,
+          as: 'owner',
+          attributes: ['id', 'nickName', 'name', 'email', 'role'],
+          paranoid: false,
+        },
+      ],
+      order: [['createdAt', 'DESC']],
+    });
+
+    // Admin-project tokens only grant cross-project access when the owner is
+    // a superuser (mirrors the auth middleware check); hide the rest
+    const visible = tokens.filter(
+      (token) =>
+        token.projectId == projectId ||
+        ['admin', 'superuser'].includes(token.owner && token.owner.role)
+    );
+
+    return res.json(
+      visible.map((token) => ({
+        ...maskToken(token),
+        isSuperUserToken: token.projectId != projectId,
+        owner: token.owner
+          ? {
+              id: token.owner.id,
+              name:
+                token.owner.displayName ||
+                token.owner.name ||
+                token.owner.email ||
+                null,
+            }
+          : null,
+      }))
+    );
+  } catch (err) {
+    return next(err);
+  }
+});
+
+// DELETE below intentionally matches on the viewed project's id only: a
+// superuser token shown in another project's overview cannot be revoked by
+// that project's admins/editors — only from the admin project or the owner's
+// user page.
+
+// DELETE /project/:projectId/api-token/:tokenId — revoke from the overview
+projectRouter.delete('/:tokenId(\\d+)', async function (req, res, next) {
+  try {
+    const projectId = req.project.id;
+    const tokenId = parseInt(req.params.tokenId, 10);
+
+    const token = await db.ApiToken.findOne({
+      where: { id: tokenId, projectId },
+    });
+
+    if (!token) {
+      return next(createError(404, 'Token not found'));
+    }
+
+    await token.destroy(); // paranoid soft-delete
+    return res.json({ status: 'ok' });
+  } catch (err) {
+    return next(err);
+  }
+});
+
 module.exports = router;
+module.exports.projectRouter = projectRouter;

--- a/apps/api-server/src/routes/api/index.js
+++ b/apps/api-server/src/routes/api/index.js
@@ -55,6 +55,10 @@ router.use(
   '/project/:projectId(\\d+)/user/:userId(\\d+)/activity',
   require('./user-activity')
 );
+router.use(
+  '/project/:projectId(\\d+)/user/:userId(\\d+)/api-token',
+  require('./api-token')
+);
 router.use('/user', require('./user'));
 
 // submissions

--- a/apps/api-server/src/routes/api/index.js
+++ b/apps/api-server/src/routes/api/index.js
@@ -59,6 +59,10 @@ router.use(
   '/project/:projectId(\\d+)/user/:userId(\\d+)/api-token',
   require('./api-token')
 );
+router.use(
+  '/project/:projectId(\\d+)/api-token',
+  require('./api-token').projectRouter
+);
 router.use('/user', require('./user'));
 
 // submissions


### PR DESCRIPTION
## Summary

Admins can generate opaque API bearer tokens (`osr_…`) for users, so external tools such as Power BI can read reporting/stats endpoints without a browser login.

### Token lifecycle
- **Create** from the admin user detail page (API-tokens tab): required validity of 1, 3, or 12 months, optional name. The plaintext token is shown exactly once; only a sha256 hash is stored.
- **Authenticate** with `Authorization: Bearer osr_…`. Tokens are scoped to reporting: only `/stats/...` routes are allowed (403 elsewhere).
- **Project binding**: a token only reads stats of its own project. Superuser tokens (admin on the admin project) may cross project boundaries, mirroring the JWT path.
- **Expire**: expired tokens are rejected (401). The first rejected use of an expired token writes a single `token_expired` audit entry.
- **Revoke** (paranoid soft-delete) takes effect immediately; revoked tokens keep their history.

### Admin UI
- Per-user "API-tokens" tab: create form, show-once warning, masked token list with status badges (actief / verlopen / ingetrokken).
- New project-level overview page (sidebar → API-tokens) listing all tokens for the project — including revoked and expired — with owner, dates, status badge, and revoke. Superuser tokens are shown with a "Superuser" badge and cannot be revoked from another project's overview.

### Audit trail
- api-token routes are now attributed correctly in the audit log (`modelName: 'api-token'` instead of `user`).
- The plaintext token is never logged (already covered by the audit service's sensitive-field redaction).

### Notes for review
- Validity is **required** (1/3/12 months) — stricter than the "optionally set an expiration date" wording in #1645, so no never-expiring tokens exist.
- "Expirations are logged" is implemented as logging the first rejected use of an expired token; expiry itself is passive and fires no event.

Closes #1643
Closes #1644
Closes #1645
Closes #1646
