### PR TITLE
feat: collapse fully selected tag groups to a single label

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/display.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/display.tsx
@@ -83,6 +83,9 @@ const formSchema = z.object({
   displayDeleteEditButtonOnTop: z.boolean().optional(),
   displayTimeline: z.boolean().optional(),
   selectedSocialShareOptions: z.array(z.enum(shareOptions)).optional(),
+  collapseFullySelectedTagGroups: z
+    .array(z.object({ type: z.string(), label: z.string() }))
+    .optional(),
 });
 
 const defaultShareValues: ShareOption[] = [...shareOptions];
@@ -142,6 +145,8 @@ export default function WidgetResourceDetailDisplay(
         typeof props?.selectedSocialShareOptions === 'undefined'
           ? defaultShareValues
           : props?.selectedSocialShareOptions || [],
+      collapseFullySelectedTagGroups:
+        props?.collapseFullySelectedTagGroups || [],
     },
   });
 
@@ -604,6 +609,78 @@ export default function WidgetResourceDetailDisplay(
               )}
             />
           )}
+
+          <FormField
+            control={form.control}
+            name="collapseFullySelectedTagGroups"
+            render={({ field }) => (
+              <FormItem className="col-span-full">
+                <FormLabel>
+                  Volledig geselecteerde tag groep samenvoegen
+                </FormLabel>
+                <div className="flex flex-col gap-2">
+                  {(field.value || []).map((entry, i) => (
+                    <div key={i} className="flex gap-2 items-center">
+                      <Input
+                        placeholder="Tag groep type"
+                        value={entry.type}
+                        onChange={(e) => {
+                          const updated = [...(field.value || [])];
+                          updated[i] = { ...updated[i], type: e.target.value };
+                          field.onChange(updated);
+                          props.onFieldChanged(
+                            'collapseFullySelectedTagGroups',
+                            updated
+                          );
+                        }}
+                      />
+                      <Input
+                        placeholder="Label (bijv. Hele stad)"
+                        value={entry.label}
+                        onChange={(e) => {
+                          const updated = [...(field.value || [])];
+                          updated[i] = { ...updated[i], label: e.target.value };
+                          field.onChange(updated);
+                          props.onFieldChanged(
+                            'collapseFullySelectedTagGroups',
+                            updated
+                          );
+                        }}
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={() => {
+                          const updated = (field.value || []).filter(
+                            (_, j) => j !== i
+                          );
+                          field.onChange(updated);
+                          props.onFieldChanged(
+                            'collapseFullySelectedTagGroups',
+                            updated
+                          );
+                        }}>
+                        ✕
+                      </Button>
+                    </div>
+                  ))}
+                  <Button
+                    type="button"
+                    className="w-fit bg-secondary text-black hover:text-white"
+                    onClick={() => {
+                      const updated = [
+                        ...(field.value || []),
+                        { type: '', label: '' },
+                      ];
+                      field.onChange(updated);
+                    }}>
+                    Groep toevoegen
+                  </Button>
+                </div>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
 
           <Button className="w-fit col-span-full" type="submit">
             Opslaan

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourceoverview/[id]/tags.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourceoverview/[id]/tags.tsx
@@ -54,6 +54,9 @@ const formSchema = z.object({
   displayTagGroupName: z.boolean(),
   filterBehavior: z.string().optional(),
   onlyShowTheseTagIds: z.string().optional(),
+  collapseFullySelectedTagGroups: z
+    .array(z.object({ type: z.string(), label: z.string() }))
+    .optional(),
 });
 
 type Tag = {
@@ -99,6 +102,8 @@ export default function WidgetResourceOverviewTags(
       tagGroups: props.tagGroups || [],
       displayTagGroupName: props?.displayTagGroupName || false,
       onlyShowTheseTagIds: props?.onlyShowTheseTagIds || '',
+      collapseFullySelectedTagGroups:
+        props?.collapseFullySelectedTagGroups || [],
     },
   });
 
@@ -414,6 +419,85 @@ export default function WidgetResourceOverviewTags(
                 ),
               },
             ]}
+          />
+
+          <Spacer />
+
+          <FormField
+            control={form.control}
+            name="collapseFullySelectedTagGroups"
+            render={({ field }) => (
+              <FormItem className="col-span-full">
+                <FormLabel>
+                  Volledig geselecteerde tag groep samenvoegen
+                </FormLabel>
+                <FormDescription>
+                  Als een inzending alle tags van een groep heeft, toon dan
+                  alleen het ingestelde label (bijv. &ldquo;Hele stad&rdquo;) in
+                  plaats van de individuele tags.
+                </FormDescription>
+                <div className="flex flex-col gap-2">
+                  {(field.value || []).map((entry, i) => (
+                    <div key={i} className="flex gap-2 items-center">
+                      <Input
+                        placeholder="Tag groep type"
+                        value={entry.type}
+                        onChange={(e) => {
+                          const updated = [...(field.value || [])];
+                          updated[i] = { ...updated[i], type: e.target.value };
+                          field.onChange(updated);
+                          props.onFieldChanged(
+                            'collapseFullySelectedTagGroups',
+                            updated
+                          );
+                        }}
+                      />
+                      <Input
+                        placeholder="Label (bijv. Hele stad)"
+                        value={entry.label}
+                        onChange={(e) => {
+                          const updated = [...(field.value || [])];
+                          updated[i] = { ...updated[i], label: e.target.value };
+                          field.onChange(updated);
+                          props.onFieldChanged(
+                            'collapseFullySelectedTagGroups',
+                            updated
+                          );
+                        }}
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={() => {
+                          const updated = (field.value || []).filter(
+                            (_, j) => j !== i
+                          );
+                          field.onChange(updated);
+                          props.onFieldChanged(
+                            'collapseFullySelectedTagGroups',
+                            updated
+                          );
+                        }}>
+                        ✕
+                      </Button>
+                    </div>
+                  ))}
+                  <Button
+                    type="button"
+                    className="w-fit bg-secondary text-black hover:text-white"
+                    onClick={() => {
+                      const updated = [
+                        ...(field.value || []),
+                        { type: '', label: '' },
+                      ];
+                      field.onChange(updated);
+                    }}>
+                    Groep toevoegen
+                  </Button>
+                </div>
+                <FormMessage />
+              </FormItem>
+            )}
           />
 
           <Button className="w-fit col-span-full" type="submit">

--- a/packages/resource-detail/src/resource-detail.tsx
+++ b/packages/resource-detail/src/resource-detail.tsx
@@ -76,6 +76,7 @@ export type ResourceDetailWidgetProps = {
   selectedSocialShareOptions?: Array<
     'facebook' | 'x' | 'mail' | 'whatsapp' | 'linkedin' | 'copylink'
   >;
+  collapseFullySelectedTagGroups?: { type: string; label: string }[];
 } & BaseProps &
   ProjectSettingProps & {
     projectId?: string;
@@ -184,6 +185,11 @@ function ResourceDetail({
   } = datastore.useResource({
     projectId: props.projectId,
     resourceId: resourceId,
+  });
+
+  const { data: allProjectTags } = datastore.useTags({
+    projectId: props.projectId,
+    type: '',
   });
 
   const showDate = (date: string) => {
@@ -693,23 +699,57 @@ function ResourceDetail({
 
                   <Spacer size={0.5} />
                   <div className="resource-detail-pil-list-content">
-                    {(
-                      resource.tags as Array<{
+                    {(() => {
+                      type TagItem = {
+                        id?: number;
                         type: string;
                         name: string;
                         seqnr?: number;
-                      }>
-                    )
-                      ?.filter((t) => t.type !== 'status')
-                      ?.sort((a: { seqnr?: number }, b: { seqnr?: number }) => {
-                        if (a.seqnr === undefined || a.seqnr === null) return 1;
-                        if (b.seqnr === undefined || b.seqnr === null)
-                          return -1;
-                        return a.seqnr - b.seqnr;
-                      })
-                      ?.map((t) => (
-                        <Pill text={t.name} />
-                      ))}
+                      };
+                      const resourceTags = (resource.tags as TagItem[]) || [];
+                      const collapseGroups =
+                        props.collapseFullySelectedTagGroups || [];
+                      const suppressedTypes = new Set<string>();
+                      const collapsePills: { type: string; name: string }[] =
+                        [];
+
+                      collapseGroups.forEach(({ type, label }) => {
+                        const allOfType =
+                          (allProjectTags as TagItem[])?.filter(
+                            (t) => t.type === type
+                          ) || [];
+                        if (!allOfType.length) return;
+                        const resourceOfTypeIds = new Set(
+                          resourceTags
+                            .filter((t) => t.type === type)
+                            .map((t) => t.id)
+                        );
+                        const hasAll = allOfType.every((t) =>
+                          resourceOfTypeIds.has(t.id)
+                        );
+                        if (hasAll) {
+                          suppressedTypes.add(type);
+                          collapsePills.push({ type, name: label });
+                        }
+                      });
+
+                      const visibleTags = resourceTags
+                        .filter(
+                          (t) =>
+                            t.type !== 'status' && !suppressedTypes.has(t.type)
+                        )
+                        .sort((a, b) => {
+                          if (a.seqnr === undefined || a.seqnr === null)
+                            return 1;
+                          if (b.seqnr === undefined || b.seqnr === null)
+                            return -1;
+                          return a.seqnr - b.seqnr;
+                        });
+
+                      return [...collapsePills, ...visibleTags].map((t, i) => (
+                        <Pill key={i} text={t.name} />
+                      ));
+                    })()}
                   </div>
                   <Spacer size={2} />
                 </div>

--- a/packages/resource-overview/src/resource-overview.tsx
+++ b/packages/resource-overview/src/resource-overview.tsx
@@ -176,6 +176,12 @@ export type ResourceOverviewWidgetProps = BaseProps &
       LikeWidgetProps,
       keyof BaseProps | keyof ProjectSettingProps | 'resourceId'
     >;
+    collapseFullySelectedTagGroups?: { type: string; label: string }[];
+    /** Internal: all project tags grouped by type, passed to the renderer */
+    allTagsByType?: Record<
+      string,
+      { id: number; name: string; type: string }[]
+    >;
   };
 
 //Temp: Header can only be made when the map works so for now a banner
@@ -485,16 +491,35 @@ const defaultItemRenderer = (
               <>
                 <Spacer size={0.5} />
                 <div className="pill-grid">
-                  {(
-                    resourceFilteredTags as Array<{
-                      type: string;
-                      name: string;
-                    }>
-                  )
-                    ?.filter((t) => t.type !== 'status')
-                    ?.map((t) => (
-                      <Pill text={t.name} />
-                    ))}
+                  {(() => {
+                    type TagItem = { id?: number; type: string; name: string };
+                    const collapseGroups =
+                      props.collapseFullySelectedTagGroups || [];
+                    const atByType = props.allTagsByType || {};
+                    const suppressedTypes = new Set<string>();
+                    const collapsePills: TagItem[] = [];
+                    collapseGroups.forEach(({ type, label }) => {
+                      const allOfType = atByType[type] || [];
+                      if (!allOfType.length) return;
+                      const resourceOfTypeIds = new Set(
+                        resourceFilteredTags
+                          .filter((t: TagItem) => t.type === type)
+                          .map((t: TagItem) => t.id)
+                      );
+                      if (allOfType.every((t) => resourceOfTypeIds.has(t.id))) {
+                        suppressedTypes.add(type);
+                        collapsePills.push({ type, name: label });
+                      }
+                    });
+                    const visibleTags = (
+                      resourceFilteredTags as TagItem[]
+                    ).filter(
+                      (t) => t.type !== 'status' && !suppressedTypes.has(t.type)
+                    );
+                    return [...collapsePills, ...visibleTags].map((t, i) => (
+                      <Pill key={i} text={t.name} />
+                    ));
+                  })()}
                 </div>
               </>
             )}
@@ -633,16 +658,35 @@ const defaultItemRenderer = (
               <>
                 <Spacer size={0.5} />
                 <div className="pill-grid">
-                  {(
-                    resourceFilteredTags as Array<{
-                      type: string;
-                      name: string;
-                    }>
-                  )
-                    ?.filter((t) => t.type !== 'status')
-                    ?.map((t) => (
-                      <Pill text={t.name} />
-                    ))}
+                  {(() => {
+                    type TagItem = { id?: number; type: string; name: string };
+                    const collapseGroups =
+                      props.collapseFullySelectedTagGroups || [];
+                    const atByType = props.allTagsByType || {};
+                    const suppressedTypes = new Set<string>();
+                    const collapsePills: TagItem[] = [];
+                    collapseGroups.forEach(({ type, label }) => {
+                      const allOfType = atByType[type] || [];
+                      if (!allOfType.length) return;
+                      const resourceOfTypeIds = new Set(
+                        resourceFilteredTags
+                          .filter((t: TagItem) => t.type === type)
+                          .map((t: TagItem) => t.id)
+                      );
+                      if (allOfType.every((t) => resourceOfTypeIds.has(t.id))) {
+                        suppressedTypes.add(type);
+                        collapsePills.push({ type, name: label });
+                      }
+                    });
+                    const visibleTags = (
+                      resourceFilteredTags as TagItem[]
+                    ).filter(
+                      (t) => t.type !== 'status' && !suppressedTypes.has(t.type)
+                    );
+                    return [...collapsePills, ...visibleTags].map((t, i) => (
+                      <Pill key={i} text={t.name} />
+                    ));
+                  })()}
                 </div>
               </>
             )}
@@ -845,6 +889,17 @@ function ResourceOverviewInner({
     projectId: props.projectId,
     type: '',
   });
+
+  // Build a type → tags map for configured collapse groups
+  const allTagsByType = useMemo(() => {
+    const map: Record<string, { id: number; name: string; type: string }[]> =
+      {};
+    if (!props.collapseFullySelectedTagGroups?.length) return map;
+    props.collapseFullySelectedTagGroups.forEach(({ type }) => {
+      map[type] = (allTags as any[]).filter((t: any) => t.type === type);
+    });
+    return map;
+  }, [allTags, props.collapseFullySelectedTagGroups]);
 
   // Order limitation tags by their type so it can be directly used to filter shown tags in their type
   const groupedTagsForLimitation: { [key: string]: number[] } = useMemo(() => {
@@ -1285,6 +1340,7 @@ function ResourceOverviewInner({
                   selectedProjects,
                   displayOverviewTagGroups,
                   overviewTagGroups,
+                  allTagsByType,
                 },
                 () => {
                   onResourceClick(resource, index);


### PR DESCRIPTION
## Summary

When a submission contains **every** tag of a configured tag group, show a single configurable label (e.g. "Hele stad") instead of the individual tags — on the **resource detail page** and in **both resource-overview card renderers**. Partial selections keep showing the individual tags.

Configurable per tag group in the `resourcedetail` and `resourceoverview` widget admin (group type + collapse label, with a "Groep toevoegen" button for multiple groups).

Config shape: `collapseFullySelectedTagGroups: Array<{ type: string; label: string }>`.

## Touchpoints

- `packages/resource-detail/src/resource-detail.tsx` — collapse render + `datastore.useTags` lookup of all project tags
- `packages/resource-overview/src/resource-overview.tsx` — both card renderers + `allTagsByType` memo
- `apps/admin-server/.../widgets/resourcedetail/[id]/display.tsx` — admin config
- `apps/admin-server/.../widgets/resourceoverview/[id]/tags.tsx` — admin config

## Verification

- ✅ `tsc && vite build` passes for both `resource-detail` and `resource-overview`
- ✅ Prettier clean; Husky pre-commit passed
- ⚠️ **Browser E2E not yet done** — the local admin widget-editor routes currently 404 for *all* widgets (reproduced with an untouched `resourceform` widget), a pre-existing dev-environment issue unrelated to this change. Headed Playwright verification (config UI render + frontend collapse behavior) is pending an admin-server restart/rebuild.

## Notes

Extracted cleanly from earlier WIP — the timeline/agenda and proximity-filter features that lived in the same files are intentionally left out.

The admin config inputs call `props.onFieldChanged(...)` directly (matches the existing pattern in these forms). If these config pages are ever rendered in a preview context, switch to `onFieldChanged?.(...)` to avoid the known `onFieldChanged is not a function` crash.
