### PR TITLE
feat: collapse a fully-selected tag type into one label on resource detail

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/display.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/display.tsx
@@ -10,13 +10,22 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Separator } from '@/components/ui/separator';
 import { Heading } from '@/components/ui/typography';
+import useTags from '@/hooks/use-tags';
 import { useFieldDebounce } from '@/hooks/useFieldDebounce';
 import { YesNoSelect, undefinedToTrueOrProp } from '@/lib/form-widget-helpers';
 import { EditFieldProps } from '@/lib/form-widget-helpers/EditFieldProps';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ResourceDetailWidgetProps } from '@openstad-headless/resource-detail/src/resource-detail';
+import { useRouter } from 'next/router';
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
@@ -82,6 +91,8 @@ const formSchema = z.object({
   displayDeleteButton: z.boolean().optional(),
   displayDeleteEditButtonOnTop: z.boolean().optional(),
   displayTimeline: z.boolean().optional(),
+  collapseTagType: z.string().optional(),
+  collapseTagLabel: z.string().optional(),
   selectedSocialShareOptions: z.array(z.enum(shareOptions)).optional(),
 });
 
@@ -95,6 +106,16 @@ export default function WidgetResourceDetailDisplay(
   async function onSubmit(values: FormData) {
     props.updateConfig({ ...props, ...values });
   }
+
+  const router = useRouter();
+  const { project } = router.query;
+  const { data: allTags } = useTags(project as string);
+  const tagTypes: string[] = Array.isArray(allTags)
+    ? allTags.reduce((types: string[], tag: any) => {
+        if (tag?.type && !types.includes(tag.type)) types.push(tag.type);
+        return types;
+      }, [])
+    : [];
 
   const { onFieldChange } = useFieldDebounce(props.onFieldChanged);
 
@@ -138,6 +159,8 @@ export default function WidgetResourceDetailDisplay(
       displayDeleteEditButtonOnTop:
         props?.displayDeleteEditButtonOnTop || false,
       displayTimeline: props?.displayTimeline || false,
+      collapseTagType: props?.collapseTagType ?? '',
+      collapseTagLabel: props?.collapseTagLabel ?? '',
       selectedSocialShareOptions:
         typeof props?.selectedSocialShareOptions === 'undefined'
           ? defaultShareValues
@@ -349,6 +372,72 @@ export default function WidgetResourceDetailDisplay(
               </FormItem>
             )}
           />
+
+          {form.watch('displayTags') && (
+            <div className="bg-stone-100 p-4 rounded-md border border-stone-200 col-span-full lg:w-3/4 grid grid-cols-1 lg:grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="collapseTagType"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Tag type samenvouwen bij volledige selectie
+                    </FormLabel>
+                    <FormDescription>
+                      Wanneer een inzending álle tags van dit type heeft, wordt
+                      in plaats van alle losse tags één label getoond.
+                    </FormDescription>
+                    <Select
+                      value={field.value || ''}
+                      onValueChange={(value) => {
+                        const next = value === 'none' ? '' : value;
+                        field.onChange(next);
+                        props.onFieldChanged?.('collapseTagType', next);
+                      }}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Geen" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="none">Geen</SelectItem>
+                        {tagTypes.map((type) => (
+                          <SelectItem key={type} value={type}>
+                            {type}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {!!form.watch('collapseTagType') && (
+                <FormField
+                  control={form.control}
+                  name="collapseTagLabel"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Label bij volledige selectie</FormLabel>
+                      <FormDescription>
+                        Bijvoorbeeld &apos;helestad&apos;.
+                      </FormDescription>
+                      <FormControl>
+                        <Input
+                          type="text"
+                          {...field}
+                          onChange={(e) => {
+                            onFieldChange(field.name, e.target.value);
+                            field.onChange(e);
+                          }}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              )}
+            </div>
+          )}
 
           <FormField
             control={form.control}

--- a/docs/superpowers/specs/2026-06-17-collapse-tag-type-resource-detail-design.md
+++ b/docs/superpowers/specs/2026-06-17-collapse-tag-type-resource-detail-design.md
@@ -1,0 +1,107 @@
+# Collapse a fully-selected tag type into one label on the resource-detail page
+
+**Date:** 2026-06-17
+**Status:** Approved
+
+## Problem
+
+On a resource form, a tag field (type `tags`) can offer a "Selecteer alles" (Select all)
+checkbox with a custom label (e.g. `helestad`). Ticking it stores **all** of the real tags
+of that type (e.g. all `staddelen` districts) on the resource — the `select_all` value itself
+is never persisted (see `packages/ui/src/form-elements/checkbox/index.tsx:290-320`).
+
+On the resource-detail page, the Tags section therefore lists every individual district pill
+and never shows the "helestad" label, because `helestad` is not a tag. Users want: when a
+resource has the whole set, show a single label pill instead of the full list.
+
+## Behavior
+
+When a resource has **every** tag of a configured tag type, the detail page's Tags section
+renders **one** pill with a custom label, dropping the individual pills of that type. Tags of
+other types render unchanged. If only some tags of that type are selected, they render
+individually as today.
+
+## Components
+
+### 1. Admin config — resourcedetail "Weergave" (Display) tab
+
+File: `apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/display.tsx`
+
+Two new optional fields:
+
+- **`collapseTagType`** — `Select` dropdown of the project's tag types, built like the form's
+  "Welk type tag" dropdown: `useTags(project)` → unique `type`s
+  (`apps/admin-server/src/pages/projects/[project]/widgets/resourceform/[id]/items.tsx:1404`).
+  Includes a "Geen / uit" option (value `''`) to disable.
+- **`collapseTagLabel`** — text input for the replacement label (e.g. `helestad`).
+
+zod schema additions:
+
+```ts
+collapseTagType: z.string().optional(),
+collapseTagLabel: z.string().optional(),
+```
+
+Defaults read `props?.collapseTagType ?? ''` and `props?.collapseTagLabel ?? ''`.
+
+### 2. Props / types — resource-detail
+
+File: `packages/resource-detail/src/resource-detail.tsx`
+
+Add to `ResourceDetailWidgetProps` and the component destructure:
+
+```ts
+collapseTagType?: string;
+collapseTagLabel?: string;
+```
+
+### 3. Widget render — Tags block (~line 688)
+
+File: `packages/resource-detail/src/resource-detail.tsx`
+
+- Add an unconditional top-level hook:
+  `const { data: collapseTags } = datastore.useTags({ projectId, type: collapseTagType });`
+  (Hooks must be called unconditionally. When `collapseTagType` is empty the result is unused.)
+- Replace the inline tags render with:
+
+```
+base       = resource.tags.filter(t => t.type !== 'status')
+ofType     = base.filter(t => t.type === collapseTagType)
+collapse   = !!collapseTagType && !!collapseTagLabel
+             && Array.isArray(collapseTags) && collapseTags.length > 0
+             && ofType.length === collapseTags.length
+
+if collapse:
+  render <Pill text={collapseTagLabel} />  +  base.filter(t => t.type !== collapseTagType) sorted by seqnr
+else:
+  render base sorted by seqnr   (current behavior)
+```
+
+### 4. Frontend defaults
+
+The resourcedetail `defaultConfig` in
+`apps/api-server/src/routes/widget/widget-settings.js` only contains
+`projectId: null` — display fields (e.g. `displayTags`) are **not** listed there and
+rely on the widget component's own parameter defaults. To stay consistent with that
+pattern, the new keys are **not** added to `widget-settings.js`; the component defaults
+(`collapseTagType = ''`, `collapseTagLabel = ''`) cover the "feature off" case.
+
+## Edge cases
+
+- `collapseTags.length === 0` → never collapse (avoids collapsing during load / empty type).
+- `collapseTagType` set but `collapseTagLabel` empty → behaves normally (no collapse).
+- Status tags remain excluded (`type !== 'status'`).
+- A type with exactly 1 tag, selected, counts as "all" and collapses. Accepted (matches
+  select-all semantics); a `> 1` guard can be added later if undesired.
+- If a new tag of the type is later added, older "all" resources no longer match and expand
+  to individual pills — correct, since they no longer hold the full set.
+
+## Testing
+
+Playwright (WebKit) against the local admin preview at
+`/projects/2/widgets/resourcedetail/3`:
+
+1. With `collapseTagType=staddelen`, `collapseTagLabel=helestad` and a resource holding all
+   `staddelen` tags → exactly one `helestad` pill, no individual district pills.
+2. Remove one district tag (partial) → individual pills return, no `helestad` pill.
+3. Feature off (`collapseTagType=''`) → unchanged from current behavior.

--- a/packages/resource-detail/src/resource-detail.tsx
+++ b/packages/resource-detail/src/resource-detail.tsx
@@ -86,6 +86,8 @@ export type ResourceDetailWidgetProps = {
     backUrlText?: string;
     urlWithResourceFormForEditing?: string;
     displayDeleteButton?: boolean;
+    collapseTagType?: string;
+    collapseTagLabel?: string;
   } & MapPropsType &
   booleanProps & {
     likeWidget?: Omit<
@@ -148,6 +150,8 @@ function ResourceDetail({
   displayDeleteButton = true,
   displayDeleteEditButtonOnTop = false,
   displayTimeline = false,
+  collapseTagType = '',
+  collapseTagLabel = '',
   selectedSocialShareOptions = [
     'facebook',
     'x',
@@ -184,6 +188,13 @@ function ResourceDetail({
   } = datastore.useResource({
     projectId: props.projectId,
     resourceId: resourceId,
+  });
+
+  // Tags of the type configured for "collapse": when a resource holds the full
+  // set, the Tags section renders a single label pill instead of every tag.
+  const { data: collapseTags } = datastore.useTags({
+    projectId: props.projectId,
+    type: collapseTagType,
   });
 
   const showDate = (date: string) => {
@@ -693,23 +704,56 @@ function ResourceDetail({
 
                   <Spacer size={0.5} />
                   <div className="resource-detail-pil-list-content">
-                    {(
-                      resource.tags as Array<{
+                    {(() => {
+                      type TagItem = {
                         type: string;
                         name: string;
                         seqnr?: number;
-                      }>
-                    )
-                      ?.filter((t) => t.type !== 'status')
-                      ?.sort((a: { seqnr?: number }, b: { seqnr?: number }) => {
+                      };
+                      const sortBySeqnr = (
+                        a: { seqnr?: number },
+                        b: { seqnr?: number }
+                      ) => {
                         if (a.seqnr === undefined || a.seqnr === null) return 1;
                         if (b.seqnr === undefined || b.seqnr === null)
                           return -1;
                         return a.seqnr - b.seqnr;
-                      })
-                      ?.map((t) => (
-                        <Pill text={t.name} />
-                      ))}
+                      };
+
+                      const visibleTags = (
+                        (resource.tags as Array<TagItem>) || []
+                      ).filter((t) => t.type !== 'status');
+
+                      // Collapse: when the resource holds every tag of the
+                      // configured type, show a single label pill instead.
+                      const tagsOfCollapseType = visibleTags.filter(
+                        (t) => t.type === collapseTagType
+                      );
+                      const shouldCollapse =
+                        !!collapseTagType &&
+                        !!collapseTagLabel &&
+                        Array.isArray(collapseTags) &&
+                        collapseTags.length > 0 &&
+                        tagsOfCollapseType.length === collapseTags.length;
+
+                      if (shouldCollapse) {
+                        const remaining = visibleTags
+                          .filter((t) => t.type !== collapseTagType)
+                          .sort(sortBySeqnr);
+                        return (
+                          <>
+                            <Pill text={collapseTagLabel} />
+                            {remaining.map((t) => (
+                              <Pill text={t.name} />
+                            ))}
+                          </>
+                        );
+                      }
+
+                      return visibleTags
+                        .sort(sortBySeqnr)
+                        .map((t) => <Pill text={t.name} />);
+                    })()}
                   </div>
                   <Spacer size={2} />
                 </div>


### PR DESCRIPTION
## What

On the resource-detail page, when a resource holds **every** tag of a configured tag type, the Tags section now renders a **single custom label pill** instead of listing each individual tag.

This surfaces the form's "Selecteer alles" (Select all) intent. A tag field can offer a select-all checkbox with a custom label (e.g. `helestad` for all `staddelen` districts). Ticking it stores all the real tags on the resource — the select-all value itself is never persisted — so the detail page previously listed every district and never showed the `helestad` label. Now an admin can opt in to collapse that set into the label.

## Changes

- **`packages/resource-detail/src/resource-detail.tsx`** — new `collapseTagType` / `collapseTagLabel` props; fetch the configured tag type via `datastore.useTags` and, when the resource has the full set, render one label pill (other tag types unchanged).
- **admin Weergave (Display) tab** (`resourcedetail/[id]/display.tsx`) — tag-type dropdown + label input, shown when *Gekoppelde tags weergeven* is enabled, with live-preview wiring.
- Design spec under `docs/superpowers/specs/`.

Feature is **off by default** (empty type = no collapse).

## Behaviour

```
resource has ALL tags of collapseTagType  ->  one <Pill text=collapseTagLabel> + other-type tags
otherwise                                  ->  individual pills (unchanged)
```

## Testing

Verified live in the admin preview (Playwright/WebKit, project 2 / resourcedetail widget 3):
- **Off / default:** all 11 `staddelen` pills render — unchanged.
- **Configured** (`staddelen` → `helestad`): preview collapses to a single `helestad` pill; no page errors.
- Collapse only fires when the project's full tag-type set matches the resource's tags, so partial selections keep listing individual pills.

## Notes
- Widget `dist/` is gitignored; rebuild the `resource-detail` package to pick this up locally (served via the packages bind-mount, no container rebuild needed).
