### PR TITLE
Op 799/reduce verbose logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,6 @@ SMTP_PASSWORD=PASSWORD
 FORCE_HTTP=true
 SERVER_IP=IPNUMBER
 DISABLE_RATE_LIMITER="false"
+
+# Set 'true' for debugging when NODE_ENV is set to 'production'
+# VERBOSE_LOGGING=false

--- a/apps/auth-server/routes/routes.js
+++ b/apps/auth-server/routes/routes.js
@@ -131,15 +131,20 @@ module.exports = function (app) {
   /**
    * Log urls
    */
-  app.use((req, res, next) => {
-    res.on('finish', () => {
-      const ts = new Date().toISOString();
-      const clientId = req.client?.id || '';
-      const log = `[${ts}] ${req.method}:${req.url} ${res.statusCode}${clientId ? ` clientId=${clientId}` : ''}`;
-      console.log(log);
+  if (
+    process.env.NODE_ENV !== 'production' ||
+    process.env.VERBOSE_LOGGING === 'true'
+  ) {
+    app.use((req, res, next) => {
+      res.on('finish', () => {
+        const ts = new Date().toISOString();
+        const clientId = req.client?.id || '';
+        const log = `\[${ts}] ${req.method}:${req.url} ${res.statusCode}${clientId ? ` clientId=${clientId}` : ''}`;
+        console.log(log);
+      });
+      next();
     });
-    next();
-  });
+  }
 
   app.get('/', authLocal.index);
 

--- a/doc/setup-options.md
+++ b/doc/setup-options.md
@@ -41,6 +41,8 @@ DB_AUTH_METHOD = ''
 
 WHITELISTED_EMAILS=''
 
+VERBOSE_LOGGING = false
+
 // api server
 API_DOMAIN = 'api.' + process.env.BASE_DOMAIN
 API_URL = 'http://' + API_DOMAIN

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -236,6 +236,7 @@ services:
       - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-openstad-auth-server}
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://openstad-otel-collector:4317}
       - OTEL_ENABLED=${OTEL_ENABLED_AUTH:-false}
+      - VERBOSE_LOGGING=${VERBOSE_LOGGING:-false}
     ports:
       - '${AUTH_PORT}:${AUTH_PORT}'
     volumes:

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -300,6 +300,9 @@ async function setupEnvVars() {
   process.env.MAIL_MS_CLIENT_SECRET = process.env.MAIL_MS_CLIENT_SECRET || '';
   process.env.MAIL_MS_TENANT_ID = process.env.MAIL_MS_TENANT_ID || '';
   process.env.WHITELISTED_EMAILS = process.env.WHITELISTED_EMAILS || '';
+
+  // debugging
+  process.env.VERBOSE_LOGGING = process.env.VERBOSE_LOGGING || false;
 }
 
 async function writeEnvFile() {
@@ -345,6 +348,8 @@ FORCE_HTTP=${process.env.FORCE_HTTP}
 MYSQL_USER=${process.env.DB_USERNAME}
 MYSQL_PASSWORD=${process.env.DB_PASSWORD}
 MYSQL_ROOT_PASSWORD=${process.env.DB_PASSWORD}
+
+VERBOSE_LOGGING=${process.env.VERBOSE_LOGGING}
 
 #api server
 API_URL=${process.env.API_URL}


### PR DESCRIPTION
Reduce verbose logging on the auth-server; not all requests should be logged when `NODE_ENV=production`.

A new environment variable is introduced to re-enable these logs in a production environment, for debugging purposes: `VERBOSE_LOGGING`.