### PR TITLE
fix(audit-log): close audit gaps and harden JSON writes

### DIFF
--- a/apps/api-server/src/lib/resource-create-scope.js
+++ b/apps/api-server/src/lib/resource-create-scope.js
@@ -1,0 +1,19 @@
+// Returns a copy of the scope array without the onlyVisible scope.
+// onlyVisible filters resources to what a user may see, which is right for
+// reads but wrong right after a create: a pending resource (publishDate null)
+// gets filtered out and findByPk returns null. Dropping it lets the creator
+// get their own resource back.
+function stripVisibilityScope(scope) {
+  if (!Array.isArray(scope)) return scope;
+  return scope.filter(
+    (entry) =>
+      !(
+        entry &&
+        typeof entry === 'object' &&
+        Array.isArray(entry.method) &&
+        entry.method[0] === 'onlyVisible'
+      )
+  );
+}
+
+module.exports = { stripVisibilityScope };

--- a/apps/api-server/src/lib/resource-create-scope.test.js
+++ b/apps/api-server/src/lib/resource-create-scope.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { stripVisibilityScope } from './resource-create-scope.js';
+
+describe('stripVisibilityScope', () => {
+  it('removes the onlyVisible scope and keeps the rest', () => {
+    const scope = [
+      'defaultScope',
+      'api',
+      { method: ['onlyVisible', null, 'anonymous'] },
+      { method: ['includeTags'] },
+    ];
+    const result = stripVisibilityScope(scope);
+    expect(result).toEqual([
+      'defaultScope',
+      'api',
+      { method: ['includeTags'] },
+    ]);
+  });
+
+  it('returns an equivalent scope when onlyVisible is absent', () => {
+    const scope = ['defaultScope', 'api', { method: ['includeStatuses'] }];
+    expect(stripVisibilityScope(scope)).toEqual(scope);
+  });
+
+  it('does not mutate the input array', () => {
+    const scope = ['defaultScope', { method: ['onlyVisible', 1, 'admin'] }];
+    const copy = [...scope];
+    stripVisibilityScope(scope);
+    expect(scope).toEqual(copy);
+  });
+
+  it('handles non-array input gracefully', () => {
+    expect(stripVisibilityScope(undefined)).toBeUndefined();
+    expect(stripVisibilityScope(null)).toBeNull();
+  });
+
+  it('keeps string scopes untouched even if named alike', () => {
+    const scope = ['defaultScope', 'api'];
+    expect(stripVisibilityScope(scope)).toEqual(['defaultScope', 'api']);
+  });
+});

--- a/apps/api-server/src/middleware/audit-log.js
+++ b/apps/api-server/src/middleware/audit-log.js
@@ -94,7 +94,18 @@ module.exports = function auditLogMiddleware(serviceOverride) {
 
       const statusCode = res.statusCode;
 
+      // Log failed writes too: a row may already be committed before the
+      // error. data is the error payload here, not the model, so no newData.
       if (isWrite && statusCode >= 400) {
+        service.log(req, {
+          action: method,
+          modelName: resolved.modelName,
+          modelId: resolved.modelId ? parseInt(resolved.modelId) : null,
+          previousData: previousSnapshot,
+          newData: null,
+          source: 'api',
+          statusCode,
+        });
         return originalJson(data);
       }
 

--- a/apps/api-server/src/middleware/audit-log.test.js
+++ b/apps/api-server/src/middleware/audit-log.test.js
@@ -149,19 +149,70 @@ describe('audit-log middleware', () => {
     );
   });
 
-  it('does not log when status code >= 400', () => {
+  it('logs failed writes (status >= 400) with statusCode and no newData', () => {
     const req = createMockReq({
       method: 'POST',
       path: '/project/1/resource',
     });
     const res = createMockRes();
-    res.statusCode = 400;
+    res.statusCode = 500;
     const next = vi.fn();
 
     middleware(req, res, next);
-    res.json({ error: 'Bad request' });
+    res.json({ error: 'Cannot set properties of null' });
 
-    expect(mockService.log).not.toHaveBeenCalled();
+    expect(mockService.log).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'POST',
+        modelName: 'resource',
+        statusCode: 500,
+        newData: null,
+      })
+    );
+  });
+
+  it('logs failed PUT with previous snapshot and the path modelId', () => {
+    const req = createMockReq({
+      method: 'PUT',
+      path: '/project/1/resource/42',
+      results: { dataValues: { id: 42, title: 'Old Title' } },
+    });
+    const res = createMockRes();
+    const next = vi.fn();
+
+    middleware(req, res, next);
+    // simulate the route assigning results before the handler throws
+    req.results = { dataValues: { id: 42, title: 'Old Title' } };
+    res.statusCode = 422;
+    res.json({ error: 'Validation error' });
+
+    expect(mockService.log).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        action: 'PUT',
+        modelName: 'resource',
+        modelId: 42,
+        statusCode: 422,
+        newData: null,
+        previousData: { id: 42, title: 'Old Title' },
+      })
+    );
+  });
+
+  it('still logs admin GET reads regardless of status (read behaviour unchanged)', () => {
+    const req = createMockReq({ method: 'GET' });
+    const res = createMockRes();
+    res.statusCode = 404;
+    const next = vi.fn();
+
+    middleware(req, res, next);
+    res.json({ error: 'Not found' });
+
+    expect(mockService.log).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ action: 'GET', modelName: 'resource' })
+    );
   });
 
   it('logs any path segment as modelName', () => {

--- a/apps/api-server/src/routes/api/resource.js
+++ b/apps/api-server/src/routes/api/resource.js
@@ -18,6 +18,7 @@ const {
   logSpamAnalysis,
   removeSpamMetaFields,
 } = require('../../services/spam-detector');
+const { stripVisibilityScope } = require('../../lib/resource-create-scope');
 
 const router = express.Router({ mergeParams: true });
 const userhasModeratorRights = (user) => {
@@ -490,9 +491,17 @@ router
     db.Resource.authorizeData(data, 'create', req.user, null, req.project)
       .create(data)
       .then((resourceInstance) => {
-        db.Resource.scope(...req.scope)
+        // Re-fetch without onlyVisible so the creator gets their own resource
+        // back, even when it is still pending (publishDate is null).
+        const createScope = stripVisibilityScope(req.scope);
+        db.Resource.scope(...createScope)
           .findByPk(resourceInstance.id)
           .then(async (result) => {
+            if (!result) {
+              return next(
+                createError(500, 'Failed to load resource after creation')
+              );
+            }
             result.project = req.project;
             await attachModeratorOnlyExtraDataKeys(result);
             req.results = result;

--- a/apps/api-server/src/services/audit-log.js
+++ b/apps/api-server/src/services/audit-log.js
@@ -65,8 +65,27 @@ function getClientIp(req) {
   return req.ip || null;
 }
 
+// Keep strings valid for a MySQL JSON column. Strip NULL bytes and other C0
+// control chars (but keep tab, newline, carriage return) and replace lone
+// surrogates, otherwise the write fails on a binary character set.
+function toJsonSafeString(value) {
+  // toWellFormed handles the surrogates; the regex strips C0 control chars.
+  let safe = value
+    .toWellFormed()
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F]/g, '');
+  if (safe.length > MAX_TEXT_LENGTH) {
+    safe = safe.substring(0, MAX_TEXT_LENGTH) + '...';
+  }
+  return safe;
+}
+
 function sanitizeData(data, _seen) {
-  if (!data || typeof data !== 'object') return data;
+  if (typeof Buffer !== 'undefined' && Buffer.isBuffer(data)) {
+    return toJsonSafeString(data.toString('base64'));
+  }
+  if (!data || typeof data !== 'object') {
+    return typeof data === 'string' ? toJsonSafeString(data) : data;
+  }
 
   const plain = data.dataValues || data;
   const seen = _seen || new WeakSet();
@@ -78,8 +97,10 @@ function sanitizeData(data, _seen) {
     if (SENSITIVE_FIELDS.includes(key) || IGNORED_FIELDS.includes(key))
       continue;
 
-    if (typeof value === 'string' && value.length > MAX_TEXT_LENGTH) {
-      sanitized[key] = value.substring(0, MAX_TEXT_LENGTH) + '...';
+    if (typeof value === 'string') {
+      sanitized[key] = toJsonSafeString(value);
+    } else if (typeof Buffer !== 'undefined' && Buffer.isBuffer(value)) {
+      sanitized[key] = toJsonSafeString(value.toString('base64'));
     } else if (Array.isArray(value)) {
       sanitized[key] = value.map((item) =>
         item && typeof item === 'object' ? sanitizeData(item, seen) : item

--- a/apps/api-server/src/services/audit-log.test.js
+++ b/apps/api-server/src/services/audit-log.test.js
@@ -77,6 +77,44 @@ describe('audit-log service', () => {
       const result = sanitizeData(data);
       expect(result.tags).toEqual(['a', 'b', 'c']);
     });
+
+    it('converts Buffer values to a base64 string (no binary in JSON)', () => {
+      const data = { attachment: Buffer.from('hello') };
+      const result = sanitizeData(data);
+      expect(result.attachment).toBe(Buffer.from('hello').toString('base64'));
+      expect(() => JSON.stringify(result)).not.toThrow();
+    });
+
+    it('strips NULL bytes and C0 control characters from strings', () => {
+      const data = { name: 'a\u0000b\u0001c\u001Fd' };
+      const result = sanitizeData(data);
+      expect(result.name).toBe('abcd');
+    });
+
+    it('keeps tab, newline and carriage return', () => {
+      const data = { text: 'line1\nline2\tend\r' };
+      const result = sanitizeData(data);
+      expect(result.text).toBe('line1\nline2\tend\r');
+    });
+
+    it('replaces lone surrogates but keeps valid surrogate pairs', () => {
+      const data = { broken: 'x\uD800y', emoji: '😀' };
+      const result = sanitizeData(data);
+      expect(result.broken).toBe('x�y');
+      expect(result.emoji).toBe('😀');
+    });
+
+    it('produces JSON-serializable output for binary submittedData', () => {
+      const data = {
+        submittedData: {
+          field: 'ok\u0000bad',
+          blob: Buffer.from([0xff, 0xfe, 0x00]),
+        },
+      };
+      const result = sanitizeData(data);
+      expect(() => JSON.stringify(result)).not.toThrow();
+      expect(result.submittedData.field).toBe('okbad');
+    });
   });
 
   describe('getChangedFields', () => {


### PR DESCRIPTION
We received a ticket where a resource submission existed in the database but had no audit log entry. Investigation revealed three separate defects in the audit/resource layer:

1. Failed writes were never audited. The audit middleware skipped any write with status ≥ 400. But Resource.create() commits the row before the post-create steps run, so a later failure (500) left a committed row with no audit trail.

2. findByPk returned null right after create. The post-create re-fetch reused the onlyVisible scope, which filters out a freshly created pending submission (publishDate === null) for an anonymous creator this publishDate would be null, which resulted in a TypeError (and 500 response) on result.project. We strip the visibility scope on re-fetch (the creator always gets their own resource back) and added a null-guard.
 
3. Audit writes silently failed on binary data. MySQL JSON columns rejected non-UTF-8 values (Cannot create a JSON value from a string with CHARACTER SET 'binary'), so audit entries for submissions with binary/garbage fields were lost. sanitizeData now makes values JSON/UTF-8 safe.

These changes together prevent an issue where a row could be written without a corresponding audit record.