### PR TITLE
feat(resource-detail): collapse fully-selected tag type into expandable label pill

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/display.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourcedetail/[id]/display.tsx
@@ -10,13 +10,22 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Separator } from '@/components/ui/separator';
 import { Heading } from '@/components/ui/typography';
+import useTags from '@/hooks/use-tags';
 import { useFieldDebounce } from '@/hooks/useFieldDebounce';
 import { YesNoSelect, undefinedToTrueOrProp } from '@/lib/form-widget-helpers';
 import { EditFieldProps } from '@/lib/form-widget-helpers/EditFieldProps';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { ResourceDetailWidgetProps } from '@openstad-headless/resource-detail/src/resource-detail';
+import { useRouter } from 'next/router';
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
@@ -82,6 +91,8 @@ const formSchema = z.object({
   displayDeleteButton: z.boolean().optional(),
   displayDeleteEditButtonOnTop: z.boolean().optional(),
   displayTimeline: z.boolean().optional(),
+  collapseTagType: z.string().optional(),
+  collapseTagLabel: z.string().optional(),
   selectedSocialShareOptions: z.array(z.enum(shareOptions)).optional(),
 });
 
@@ -95,6 +106,16 @@ export default function WidgetResourceDetailDisplay(
   async function onSubmit(values: FormData) {
     props.updateConfig({ ...props, ...values });
   }
+
+  const router = useRouter();
+  const { project } = router.query;
+  const { data: allTags } = useTags(project as string);
+  const tagTypes: string[] = Array.isArray(allTags)
+    ? allTags.reduce((types: string[], tag: any) => {
+        if (tag?.type && !types.includes(tag.type)) types.push(tag.type);
+        return types;
+      }, [])
+    : [];
 
   const { onFieldChange } = useFieldDebounce(props.onFieldChanged);
 
@@ -138,6 +159,8 @@ export default function WidgetResourceDetailDisplay(
       displayDeleteEditButtonOnTop:
         props?.displayDeleteEditButtonOnTop || false,
       displayTimeline: props?.displayTimeline || false,
+      collapseTagType: props?.collapseTagType ?? '',
+      collapseTagLabel: props?.collapseTagLabel ?? '',
       selectedSocialShareOptions:
         typeof props?.selectedSocialShareOptions === 'undefined'
           ? defaultShareValues
@@ -349,6 +372,76 @@ export default function WidgetResourceDetailDisplay(
               </FormItem>
             )}
           />
+
+          {form.watch('displayTags') && (
+            <div className="bg-stone-100 p-4 rounded-md border border-stone-200 col-span-full lg:w-3/4 grid grid-cols-1 lg:grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="collapseTagType"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Tag type samenvouwen bij volledige selectie
+                    </FormLabel>
+                    <FormDescription>
+                      Wanneer een inzending álle tags van dit type heeft, wordt
+                      in plaats van alle losse tags één label getoond.
+                    </FormDescription>
+                    <Select
+                      value={field.value || ''}
+                      onValueChange={(value) => {
+                        const next = value === 'none' ? '' : value;
+                        field.onChange(next);
+                        props.onFieldChanged?.('collapseTagType', next);
+                      }}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Geen" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="none">Geen</SelectItem>
+                        {tagTypes.map((type) => (
+                          <SelectItem key={type} value={type}>
+                            {type}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {!!form.watch('collapseTagType') && (
+                <FormField
+                  control={form.control}
+                  name="collapseTagLabel"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>
+                        Label bij volledige selectie (terugval)
+                      </FormLabel>
+                      <FormDescription>
+                        Standaard wordt het &apos;Selecteer alles&apos;-label
+                        uit het formulier gebruikt. Dit veld wordt alleen
+                        gebruikt als dat formulier-label niet is ingesteld.
+                      </FormDescription>
+                      <FormControl>
+                        <Input
+                          type="text"
+                          {...field}
+                          onChange={(e) => {
+                            onFieldChange(field.name, e.target.value);
+                            field.onChange(e);
+                          }}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              )}
+            </div>
+          )}
 
           <FormField
             control={form.control}

--- a/packages/data-store/src/api/index.js
+++ b/packages/data-store/src/api/index.js
@@ -19,6 +19,7 @@ import user from './user';
 import userActivity from './user-activity';
 import userVote from './user-vote';
 import widget from './widget';
+import widgets from './widgets';
 
 const windowGlobal = typeof window !== 'undefined' ? window : {};
 
@@ -128,6 +129,10 @@ function API(props = {}) {
 
   self.widget = {
     fetch: widget.fetch.bind(self),
+  };
+
+  self.widgets = {
+    fetch: widgets.fetch.bind(self),
   };
 
   self.areas = {

--- a/packages/data-store/src/api/widgets.js
+++ b/packages/data-store/src/api/widgets.js
@@ -1,0 +1,6 @@
+export default {
+  fetch: async function ({ projectId }) {
+    let url = `/api/project/${projectId}/widgets`;
+    return this.fetch(url);
+  },
+};

--- a/packages/data-store/src/hooks/use-tags.js
+++ b/packages/data-store/src/hooks/use-tags.js
@@ -3,9 +3,16 @@ export default function useTags(props) {
   const projectId = props.projectId;
   const type = props.type;
   const onlyIncludeIds = props.onlyIncludeIds;
+  // Callers can opt out of fetching (e.g. when a feature that needs tags is
+  // turned off) without breaking the rules of hooks. Defaults to enabled for
+  // backward compatibility.
+  const enabled = props.enabled !== false;
+  const resolvedProjectId = projectId || self.projectId;
 
   const { data, error, isLoading } = self.useSWR(
-    { projectId: projectId || self.projectId, type, onlyIncludeIds },
+    enabled && resolvedProjectId
+      ? { projectId: resolvedProjectId, type, onlyIncludeIds }
+      : null,
     'tags.fetch'
   );
 

--- a/packages/data-store/src/hooks/use-widgets.js
+++ b/packages/data-store/src/hooks/use-widgets.js
@@ -1,0 +1,19 @@
+export default function useWidgets({ projectId } = {}) {
+  let self = this;
+
+  const { data, error, isLoading } = self.useSWR(
+    projectId ? { projectId } : null,
+    'widgets.fetch'
+  );
+
+  let widgets = data || [];
+
+  if (error) {
+    const event = new window.CustomEvent('osc-error', {
+      detail: new Error(error),
+    });
+    document.dispatchEvent(event);
+  }
+
+  return { data: widgets, error, isLoading };
+}

--- a/packages/data-store/src/index.js
+++ b/packages/data-store/src/index.js
@@ -21,6 +21,7 @@ import useTags from './hooks/use-tags.js';
 import useUserActivity from './hooks/use-user-activity';
 import useUserVote from './hooks/use-user-vote.js';
 import useWidget from './hooks/use-widget';
+import useWidgets from './hooks/use-widgets';
 import mergeData from './merge-data';
 
 const windowGlobal = typeof window !== 'undefined' ? window : {};
@@ -52,6 +53,7 @@ function DataStore(props = {}) {
   self.useProjectVotedUsersCount = useProjectVotedUsersCount.bind(self);
   self.useUserActivity = useUserActivity.bind(self);
   self.useWidget = useWidget.bind(self);
+  self.useWidgets = useWidgets.bind(self);
 
   // current user
   const {

--- a/packages/resource-detail/src/resource-detail.css
+++ b/packages/resource-detail/src/resource-detail.css
@@ -40,6 +40,86 @@
   flex-wrap: wrap;
 }
 
+/* Collapsible tag group: one label pill that expands to its member tags. */
+.osc-collapsible-tags {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  align-items: flex-start;
+}
+
+.osc-tag-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font: inherit;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition:
+    border-color 160ms cubic-bezier(0.22, 1, 0.36, 1),
+    background-color 160ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.osc-tag-toggle:hover {
+  border-color: var(--osc-muted-foreground);
+}
+
+.osc-tag-toggle:focus-visible {
+  outline: 2px solid var(--osc-muted-foreground);
+  outline-offset: 2px;
+}
+
+.osc-tag-toggle-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.375rem;
+  height: 1.375rem;
+  padding: 0 0.4rem;
+  border-radius: 999px;
+  background-color: rgba(23, 23, 27, 0.18);
+  color: inherit;
+  font-size: 0.75rem;
+  font-weight: 600;
+  line-height: 1;
+}
+
+.osc-tag-toggle-chevron {
+  transition: transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.osc-tag-toggle.is-open .osc-tag-toggle-chevron {
+  transform: rotate(180deg);
+}
+
+.osc-collapsible-tags-panel {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding-left: 0.875rem;
+  animation: osc-tags-reveal 260ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes osc-tags-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(-0.25rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .osc-tag-toggle-chevron,
+  .osc-collapsible-tags-panel {
+    transition: none;
+    animation: none;
+  }
+}
+
 .resource-detail-comments-container {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));

--- a/packages/resource-detail/src/resource-detail.tsx
+++ b/packages/resource-detail/src/resource-detail.tsx
@@ -86,6 +86,8 @@ export type ResourceDetailWidgetProps = {
     backUrlText?: string;
     urlWithResourceFormForEditing?: string;
     displayDeleteButton?: boolean;
+    collapseTagType?: string;
+    collapseTagLabel?: string;
   } & MapPropsType &
   booleanProps & {
     likeWidget?: Omit<
@@ -114,6 +116,50 @@ type DocumentType = {
   name?: string;
   url?: string;
 };
+
+// A collapsed tag group: shows a single interactive label pill (with a count
+// and a chevron) that expands to reveal the individual tags it stands for.
+function CollapsibleTagGroup({
+  label,
+  tags,
+}: {
+  label: string;
+  tags: Array<{ name: string }>;
+}) {
+  const [open, setOpen] = useState(false);
+  const panelId = useId();
+
+  return (
+    <div className="osc-collapsible-tags">
+      <button
+        type="button"
+        className={`osc-pill osc-tag-toggle ${open ? 'is-open' : ''}`}
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={() => setOpen((prev) => !prev)}>
+        <span className="osc-tag-toggle-label">{label}</span>
+        <span className="osc-tag-toggle-count">{tags.length}</span>
+        <Icon
+          icon="ri-arrow-down-s-line"
+          iconOnly
+          className="osc-tag-toggle-chevron"
+        />
+      </button>
+
+      {open ? (
+        <div
+          id={panelId}
+          role="group"
+          aria-label={label}
+          className="osc-collapsible-tags-panel">
+          {tags.map((t, index) => (
+            <Pill key={`${t.name}-${index}`} text={t.name} />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
 
 function ResourceDetail({
   displayImage = true,
@@ -148,6 +194,8 @@ function ResourceDetail({
   displayDeleteButton = true,
   displayDeleteEditButtonOnTop = false,
   displayTimeline = false,
+  collapseTagType = '',
+  collapseTagLabel = '',
   selectedSocialShareOptions = [
     'facebook',
     'x',
@@ -185,6 +233,46 @@ function ResourceDetail({
     projectId: props.projectId,
     resourceId: resourceId,
   });
+
+  // Tags of the type configured for "collapse": when a resource holds the full
+  // set, the Tags section renders a single label pill instead of every tag.
+  // This uses the same shared useTags as the resource-form tag field (see
+  // resource-form/src/parts/init-fields.tsx), so the set compared here matches
+  // exactly what the form's "Selecteer alles" selects — keep them in sync.
+  // Only fetched when the collapse feature is configured.
+  const { data: collapseTags } = datastore.useTags({
+    projectId: props.projectId,
+    type: collapseTagType,
+    enabled: !!collapseTagType,
+  });
+
+  // The collapse label follows the project form's "Selecteer alles" label for
+  // this tag type, so it is edited in one place (the form). Falls back to the
+  // widget's own label when no matching form field is found. Only fetched when
+  // the collapse feature is configured.
+  const { data: projectWidgets } = datastore.useWidgets({
+    projectId: collapseTagType ? props.projectId : undefined,
+  });
+
+  const formSelectAllLabel = React.useMemo(() => {
+    if (!collapseTagType || !Array.isArray(projectWidgets)) return '';
+    for (const widget of projectWidgets) {
+      if (widget?.type !== 'resourceform') continue;
+      const items = widget?.config?.items;
+      if (!Array.isArray(items)) continue;
+      const match = items.find(
+        (item: any) =>
+          item?.type === 'tags' &&
+          item?.tags === collapseTagType &&
+          item?.selectAll &&
+          item?.selectAllLabel
+      );
+      if (match) return match.selectAllLabel as string;
+    }
+    return '';
+  }, [projectWidgets, collapseTagType]);
+
+  const resolvedCollapseLabel = formSelectAllLabel || collapseTagLabel;
 
   const showDate = (date: string) => {
     return date.split(' ').slice(0, -1).join(' ');
@@ -693,23 +781,62 @@ function ResourceDetail({
 
                   <Spacer size={0.5} />
                   <div className="resource-detail-pil-list-content">
-                    {(
-                      resource.tags as Array<{
+                    {(() => {
+                      type TagItem = {
                         type: string;
                         name: string;
                         seqnr?: number;
-                      }>
-                    )
-                      ?.filter((t) => t.type !== 'status')
-                      ?.sort((a: { seqnr?: number }, b: { seqnr?: number }) => {
+                      };
+                      const sortBySeqnr = (
+                        a: { seqnr?: number },
+                        b: { seqnr?: number }
+                      ) => {
                         if (a.seqnr === undefined || a.seqnr === null) return 1;
                         if (b.seqnr === undefined || b.seqnr === null)
                           return -1;
                         return a.seqnr - b.seqnr;
-                      })
-                      ?.map((t) => (
-                        <Pill text={t.name} />
-                      ))}
+                      };
+
+                      const visibleTags = (
+                        (resource.tags as Array<TagItem>) || []
+                      ).filter((t) => t.type !== 'status');
+
+                      // Collapse: when the resource holds every tag of the
+                      // configured type, show a single label pill instead.
+                      const tagsOfCollapseType = visibleTags.filter(
+                        (t) => t.type === collapseTagType
+                      );
+                      const shouldCollapse =
+                        !!collapseTagType &&
+                        !!resolvedCollapseLabel &&
+                        Array.isArray(collapseTags) &&
+                        collapseTags.length > 0 &&
+                        tagsOfCollapseType.length === collapseTags.length;
+
+                      if (shouldCollapse) {
+                        const collapsed = tagsOfCollapseType.sort(sortBySeqnr);
+                        const remaining = visibleTags
+                          .filter((t) => t.type !== collapseTagType)
+                          .sort(sortBySeqnr);
+                        return (
+                          <>
+                            <CollapsibleTagGroup
+                              label={resolvedCollapseLabel}
+                              tags={collapsed}
+                            />
+                            {remaining.map((t, index) => (
+                              <Pill key={`${t.name}-${index}`} text={t.name} />
+                            ))}
+                          </>
+                        );
+                      }
+
+                      return visibleTags
+                        .sort(sortBySeqnr)
+                        .map((t, index) => (
+                          <Pill key={`${t.name}-${index}`} text={t.name} />
+                        ));
+                    })()}
                   </div>
                   <Spacer size={2} />
                 </div>


### PR DESCRIPTION
## What & why

Adds an option to the **resource-detail** widget to collapse a fully-selected tag type into a single, expandable label pill. When a resource holds *every* tag of a configured type (e.g. all districts / `staddelen`), the Tags box shows one pill with a count + chevron instead of listing every tag; clicking it reveals the individual tags.

The pill label follows the project form's "Selecteer alles" (`selectAllLabel`) so it stays a single source of truth, with a widget-level fallback label when no matching form field exists.

## Changes

- **Widget** (`resource-detail.tsx` / `.css`): `CollapsibleTagGroup` component, collapse logic, form-label resolution, reveal animation, accessible toggle (`aria-expanded`/`aria-controls`).
- **Admin** (`resourcedetail/[id]/display.tsx`): `collapseTagType` dropdown + `collapseTagLabel` fallback field (shown under Weergave when tags are displayed).
- **data-store**: new `useWidgets` hook + `widgets` list API action to read the project's widgets (for the form label).
- **Review fixes**: gate the widgets/tags fetches behind the feature so no requests fire when it's off; add React `key`s to the tag lists; add a backward-compatible `enabled` opt-out to the shared `useTags` hook.

## Verification

- `tsc && vite build` passes for `resource-detail`.
- Prettier clean; husky pre-commit passed.
- Verified live (anonymous) that `GET /api/project/:id/widgets` returns widget configs without auth, and the resourceform `selectAllLabel` resolves end-to-end with real data.

## Notes

- The `useTags` change is additive/backward-compatible; other widgets bundling data-store are unaffected until individually rebuilt.
- Label-resolution invariant: `collapseTags` uses the same shared `useTags` as the resource-form tag field, so the compared set matches exactly what the form's "Selecteer alles" selects — keep them in sync.
