### PR TITLE
feat(admin): add resourceIdRelativePath field to comments widget

### DIFF
--- a/apps/admin-server/src/pages/projects/[project]/widgets/comments/[id]/general.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/comments/[id]/general.tsx
@@ -33,6 +33,13 @@ import { ArgumentWidgetTabProps } from '.';
 
 const formSchema = z.object({
   resourceId: z.string().optional(),
+  resourceIdRelativePath: z
+    .string()
+    .optional()
+    .refine(
+      (value) => !value || value.includes('[id]'),
+      'Specificeer een [id] veld'
+    ),
   sentiment: z.string(),
   useSentiments: z.string().optional(),
   itemsPerPage: z.coerce.number(),
@@ -71,7 +78,10 @@ export default function ArgumentsGeneral({
   const form = useForm<finalSchemaInfer>({
     resolver: zodResolver<any>(finalSchema),
     defaultValues: {
-      resourceId: props.resourceId,
+      resourceId: props?.resourceId || undefined,
+      resourceIdRelativePath: props?.resourceId
+        ? ''
+        : props?.resourceIdRelativePath || '',
       sentiment: props.sentiment || 'for',
       useSentiments: JSON.stringify(props.useSentiments || ['for', 'against']),
       itemsPerPage: props?.itemsPerPage || 9999,
@@ -89,7 +99,14 @@ export default function ArgumentsGeneral({
     try {
       useSentiments = JSON.parse(values.useSentiments || '');
     } catch (err) {}
-    props.updateConfig({ ...props, ...values, useSentiments });
+    props.updateConfig({
+      ...props,
+      ...values,
+      resourceIdRelativePath: values.resourceId
+        ? ''
+        : values.resourceIdRelativePath,
+      useSentiments,
+    });
   }
 
   const { data } = useResources(props.projectId);
@@ -113,9 +130,44 @@ export default function ArgumentsGeneral({
               items={resources}
               keyForValue="id"
               label={(resource) => `${resource.id} ${resource.title}`}
-              onFieldChanged={props.onFieldChanged}
-              noSelection="Niet koppelen (gebruik queryparam openstadResourceId)"
+              onFieldChanged={(key, value) => {
+                if (value) {
+                  form.setValue('resourceIdRelativePath', '');
+                }
+                props.onFieldChanged(key, value);
+              }}
+              noSelection="Niet koppelen - beschrijf het path of gebruik queryparam openstadResourceId"
             />
+          )}
+
+          {conditionallyRenderField(
+            'resourceIdRelativePath',
+            !form.watch('resourceId') ? (
+              <FormField
+                control={form.control}
+                name="resourceIdRelativePath"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Geen specifieke inzending gekoppeld?</FormLabel>
+                    <FormDescription className="italic">
+                      Beschrijf hoe de inzending gehaald wordt uit de url:
+                      (/pad/naar/[id]) of laat leeg om terug te vallen op
+                      ?openstadResourceId
+                    </FormDescription>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        onChange={(e) => {
+                          onFieldChange(field.name, e.target.value);
+                          field.onChange(e);
+                        }}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            ) : null
           )}
 
           {conditionallyRenderField(


### PR DESCRIPTION
## What

Adds a configurable URL-pattern field (`resourceIdRelativePath`, e.g.
`?Id=[id]`) to the **comments widget** General/Algemeen tab. Admins can
now control how the resource ID is extracted from the page URL, matching
the existing field on the resource-detail widget.

- Field is shown only when **no specific resource is coupled**
- Validates that the pattern contains `[id]` ("Specificeer een [id] veld")
- When a specific resource **is** coupled, the field is cleared to an
  empty string so a stale pattern doesn't linger in the stored config

## Bug fix (bundled)

Fixes a pre-existing save bug: the resource select stored an empty string
which the Zod schema rejected as `null`, silently blocking saves on
uncoupled comments widgets. Empty `resourceId` now coerces to `undefined`.