### PR TITLE
Nijmegen: city-wide postcode filter + 25 MB upload limit

### DIFF
--- a/apps/admin-server/src/components/resource-form.tsx
+++ b/apps/admin-server/src/components/resource-form.tsx
@@ -3,6 +3,7 @@ import MapInput from '@/components/maps/leaflet-input';
 import { MapErrorBoundary } from '@/components/maps/map-error-boundary';
 import { SimpleCalendar } from '@/components/simple-calender-popup';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { CodeEditor } from '@/components/ui/code-editor';
 import {
   Form,
@@ -118,6 +119,7 @@ const baseSchema = z.object({
       originalId: z.coerce
         .number({ invalid_type_error: onlyNumbersMessage })
         .optional(),
+      cityWide: z.boolean().optional(),
     })
     .default({}),
   tags: z.number().array().default([]),
@@ -273,6 +275,7 @@ export default function ResourceForm({ onFormSubmit }: Props) {
       documents: existingData?.documents || [],
       extraData: {
         originalId: existingData?.extraData?.originalId || undefined,
+        cityWide: existingData?.extraData?.cityWide || false,
       },
     }),
     [existingData]
@@ -324,12 +327,21 @@ export default function ResourceForm({ onFormSubmit }: Props) {
   });
 
   function onSubmit(values: FormType) {
+    // Capture the city-wide flag from the checkbox before the CodeEditor state
+    // potentially overwrites the whole extraData object below.
+    const cityWide = !!values.extraData?.cityWide;
+
     // Add extraData if its valid JSON
     try {
       if (extraData !== values.extraData) {
         values.extraData = JSON.parse(extraData);
       }
     } catch (e) {}
+
+    // Re-apply the city-wide flag so it survives the JSON overwrite.
+    if (values.extraData && typeof values.extraData === 'object') {
+      values.extraData.cityWide = cityWide;
+    }
 
     onFormSubmit(values)
       .then(() => {
@@ -827,18 +839,51 @@ export default function ResourceForm({ onFormSubmit }: Props) {
             )}
           /> */}
 
-          <FormField
-            control={form.control}
-            name="location"
-            render={({ field }) => (
-              <MapErrorBoundary>
-                <MapInput
-                  onSelectLocation={handleLocationSelect}
-                  field={field}
-                />
-              </MapErrorBoundary>
-            )}
-          />
+          <div className="col-span-full lg:col-span-1 flex flex-col gap-4">
+            <FormField
+              control={form.control}
+              name="location"
+              render={({ field }) => (
+                <MapErrorBoundary>
+                  <MapInput
+                    onSelectLocation={handleLocationSelect}
+                    field={field}
+                  />
+                </MapErrorBoundary>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="extraData.cityWide"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Stadsbreed project</FormLabel>
+                  <FormDescription>
+                    Vink dit aan voor projecten die de hele stad bestrijken.
+                    Deze worden dan altijd getoond bij het filteren op postcode,
+                    ongeacht de afstand. Je hoeft hiervoor geen wijken aan te
+                    vinken.
+                  </FormDescription>
+                  <FormControl>
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        id={field.name}
+                        checked={!!field.value}
+                        onCheckedChange={(checked) =>
+                          field.onChange(Boolean(checked))
+                        }
+                      />
+                      <label htmlFor={field.name} className="cursor-pointer">
+                        Stadsbreed project (altijd tonen bij postcodefilter)
+                      </label>
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
 
           <Separator className="lg:col-span-2 my-6" />
 

--- a/apps/admin-server/src/components/resource-form.tsx
+++ b/apps/admin-server/src/components/resource-form.tsx
@@ -119,7 +119,7 @@ const baseSchema = z.object({
       originalId: z.coerce
         .number({ invalid_type_error: onlyNumbersMessage })
         .optional(),
-      cityWide: z.boolean().optional(),
+      locationIndependent: z.boolean().optional(),
     })
     .default({}),
   tags: z.number().array().default([]),
@@ -275,7 +275,8 @@ export default function ResourceForm({ onFormSubmit }: Props) {
       documents: existingData?.documents || [],
       extraData: {
         originalId: existingData?.extraData?.originalId || undefined,
-        cityWide: existingData?.extraData?.cityWide || false,
+        locationIndependent:
+          existingData?.extraData?.locationIndependent || false,
       },
     }),
     [existingData]
@@ -327,9 +328,9 @@ export default function ResourceForm({ onFormSubmit }: Props) {
   });
 
   function onSubmit(values: FormType) {
-    // Capture the city-wide flag from the checkbox before the CodeEditor state
-    // potentially overwrites the whole extraData object below.
-    const cityWide = !!values.extraData?.cityWide;
+    // Capture the location-independent flag from the checkbox before the
+    // CodeEditor state potentially overwrites the whole extraData object below.
+    const locationIndependent = !!values.extraData?.locationIndependent;
 
     // Add extraData if its valid JSON
     try {
@@ -338,9 +339,9 @@ export default function ResourceForm({ onFormSubmit }: Props) {
       }
     } catch (e) {}
 
-    // Re-apply the city-wide flag so it survives the JSON overwrite.
+    // Re-apply the location-independent flag so it survives the JSON overwrite.
     if (values.extraData && typeof values.extraData === 'object') {
-      values.extraData.cityWide = cityWide;
+      values.extraData.locationIndependent = locationIndependent;
     }
 
     onFormSubmit(values)
@@ -855,15 +856,14 @@ export default function ResourceForm({ onFormSubmit }: Props) {
 
             <FormField
               control={form.control}
-              name="extraData.cityWide"
+              name="extraData.locationIndependent"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Stadsbreed project</FormLabel>
+                  <FormLabel>Locatieonafhankelijk</FormLabel>
                   <FormDescription>
-                    Vink dit aan voor projecten die de hele stad bestrijken.
-                    Deze worden dan altijd getoond bij het filteren op postcode,
-                    ongeacht de afstand. Je hoeft hiervoor geen wijken aan te
-                    vinken.
+                    Vink dit aan voor inzendingen die niet aan één specifieke
+                    locatie gebonden zijn. Ze worden dan altijd getoond bij het
+                    filteren op postcode, ongeacht de afstand.
                   </FormDescription>
                   <FormControl>
                     <div className="flex items-center gap-2">
@@ -875,7 +875,7 @@ export default function ResourceForm({ onFormSubmit }: Props) {
                         }
                       />
                       <label htmlFor={field.name} className="cursor-pointer">
-                        Stadsbreed project (altijd tonen bij postcodefilter)
+                        Altijd tonen bij postcodefilter
                       </label>
                     </div>
                   </FormControl>

--- a/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/choiceguide/[id]/items.tsx
@@ -82,6 +82,10 @@ const formSchema = z.object({
   maxChoicesMessage: z.string().optional(),
   variant: z.string().optional(),
   multiple: z.boolean().optional(),
+  maxUploadSizeMB: z.preprocess(
+    (val) => (val === '' || val === null ? undefined : val),
+    z.coerce.number().positive().optional()
+  ),
   prevPageText: z.string().optional(),
   nextPageText: z.string().optional(),
   options: z
@@ -319,6 +323,7 @@ export default function WidgetChoiceGuideItems(
             maxCharacters: values.maxCharacters,
             variant: values.variant || 'text input',
             multiple: values.multiple || false,
+            maxUploadSizeMB: values.maxUploadSizeMB || 25,
             options: values.options || [],
             showMoreInfo: values.showMoreInfo || false,
             moreInfoButton: values.moreInfoButton || '',
@@ -480,6 +485,7 @@ export default function WidgetChoiceGuideItems(
     maxCharacters: '',
     variant: 'text input',
     multiple: false,
+    maxUploadSizeMB: 25,
     prevPageText: '',
     nextPageText: '',
     options: [],
@@ -564,6 +570,7 @@ export default function WidgetChoiceGuideItems(
         maxCharacters: selectedItem.maxCharacters || '',
         variant: selectedItem.variant || '',
         multiple: selectedItem.multiple || false,
+        maxUploadSizeMB: selectedItem.maxUploadSizeMB || 25,
         showMoreInfo: selectedItem.showMoreInfo || false,
         moreInfoButton: selectedItem.moreInfoButton || '',
         moreInfoContent: selectedItem.moreInfoContent || '',
@@ -2180,6 +2187,33 @@ export default function WidgetChoiceGuideItems(
                                       <SelectItem value="false">Nee</SelectItem>
                                     </SelectContent>
                                   </Select>
+                                  <FormMessage />
+                                </FormItem>
+                              )}
+                            />
+                          )}
+
+                          {(form.watch('type') === 'imageUpload' ||
+                            form.watch('type') === 'documentUpload') && (
+                            <FormField
+                              control={form.control}
+                              name="maxUploadSizeMB"
+                              render={({ field }) => (
+                                <FormItem>
+                                  <FormLabel>
+                                    Maximale uploadgrootte (MB)
+                                  </FormLabel>
+                                  <FormDescription>
+                                    <em className="text-xs">
+                                      De maximale bestandsgrootte die een
+                                      gebruiker mag uploaden. Standaard 25 MB.
+                                      Let op: de server hanteert een absolute
+                                      bovengrens (standaard 25 MB); hogere
+                                      waarden kunnen alsnog door de server
+                                      geweigerd worden.
+                                    </em>
+                                  </FormDescription>
+                                  <Input type="number" min="1" {...field} />
                                   <FormMessage />
                                 </FormItem>
                               )}

--- a/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/enquete/[id]/items.tsx
@@ -113,6 +113,10 @@ const formSchema = z.object({
     })
     .optional(),
   multiple: z.boolean().optional(),
+  maxUploadSizeMB: z.preprocess(
+    (val) => (val === '' || val === null ? undefined : val),
+    z.coerce.number().positive().optional()
+  ),
   randomizeItems: z.boolean().optional(),
   image: z.string().optional(),
   imageUpload: z.string().optional(),
@@ -284,6 +288,7 @@ export default function WidgetEnqueteItems(
             variant: values.variant || 'text input',
             options: values.options || [],
             multiple: values.multiple || false,
+            maxUploadSizeMB: values.maxUploadSizeMB || 25,
             randomizeItems: values.randomizeItems || false,
             image_b: values.image_b || '',
             description_b: values.description_b || '',
@@ -456,6 +461,7 @@ export default function WidgetEnqueteItems(
     variant: 'text input',
     options: [],
     multiple: false,
+    maxUploadSizeMB: 25,
     randomizeItems: false,
     infoBlockStyle: 'default',
     infoBlockShareButton: false,
@@ -538,6 +544,7 @@ export default function WidgetEnqueteItems(
       variant: item.variant || '',
       options: item.options || [],
       multiple: item.multiple || false,
+      maxUploadSizeMB: item.maxUploadSizeMB || 25,
       randomizeItems: item.randomizeItems || false,
       infoBlockStyle: item.infoBlockStyle || 'default',
       infoBlockShareButton: item.infoBlockShareButton || false,
@@ -2208,9 +2215,37 @@ export default function WidgetEnqueteItems(
                       />
                     )}
 
-                    {!['pagination', 'scale', 'a-b-slider', 'video'].includes(
-                      form.watch('questionType') || ''
-                    ) && (
+                    {(form.watch('questionType') === 'imageUpload' ||
+                      form.watch('questionType') === 'documentUpload') && (
+                      <FormField
+                        control={form.control}
+                        name="maxUploadSizeMB"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Maximale uploadgrootte (MB)</FormLabel>
+                            <FormDescription>
+                              <em className="text-xs">
+                                De maximale bestandsgrootte die een gebruiker
+                                mag uploaden. Standaard 25 MB. Let op: de server
+                                hanteert een absolute bovengrens (standaard 25
+                                MB); hogere waarden kunnen alsnog door de server
+                                geweigerd worden.
+                              </em>
+                            </FormDescription>
+                            <Input type="number" min="1" {...field} />
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    )}
+
+                    {![
+                      'pagination',
+                      'sort',
+                      'scale',
+                      'a-b-slider',
+                      'video',
+                    ].includes(form.watch('questionType') || '') && (
                       <FormField
                         control={form.control}
                         name="fieldRequired"

--- a/apps/admin-server/src/pages/projects/[project]/widgets/resourceform/[id]/items.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/widgets/resourceform/[id]/items.tsx
@@ -76,6 +76,10 @@ const formSchema = z.object({
   maxChoicesMessage: z.string().optional(),
   variant: z.string().optional(),
   multiple: z.boolean().optional(),
+  maxUploadSizeMB: z.preprocess(
+    (val) => (val === '' || val === null ? undefined : val),
+    z.coerce.number().positive().optional()
+  ),
   prevPageText: z.string().optional(),
   nextPageText: z.string().optional(),
   placeholder: z.string().optional(),
@@ -240,6 +244,7 @@ export default function WidgetResourceFormItems(
             maxChoicesMessage: values.maxChoicesMessage || '',
             variant: values.variant || 'text input',
             multiple: values.multiple || false,
+            maxUploadSizeMB: values.maxUploadSizeMB || 25,
             prevPageText: values.prevPageText || '',
             nextPageText: values.nextPageText || '',
             options: values.options || [],
@@ -387,6 +392,7 @@ export default function WidgetResourceFormItems(
     maxChoicesMessage: '',
     variant: 'text input',
     multiple: false,
+    maxUploadSizeMB: 25,
     prevPageText: '',
     nextPageText: '',
     options: [],
@@ -441,6 +447,7 @@ export default function WidgetResourceFormItems(
         maxChoicesMessage: selectedItem.maxChoicesMessage || '',
         variant: selectedItem.variant || '',
         multiple: selectedItem.multiple || false,
+        maxUploadSizeMB: selectedItem.maxUploadSizeMB || 25,
         prevPageText: selectedItem.prevPageText || '',
         nextPageText: selectedItem.nextPageText || '',
         matrix: selectedItem.matrix || matrixDefault,
@@ -1794,6 +1801,30 @@ export default function WidgetResourceFormItems(
                                 <SelectItem value="false">Nee</SelectItem>
                               </SelectContent>
                             </Select>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    )}
+
+                    {(form.watch('type') === 'imageUpload' ||
+                      form.watch('type') === 'documentUpload') && (
+                      <FormField
+                        control={form.control}
+                        name="maxUploadSizeMB"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Maximale uploadgrootte (MB)</FormLabel>
+                            <FormDescription>
+                              <em className="text-xs">
+                                De maximale bestandsgrootte die een gebruiker
+                                mag uploaden. Standaard 25 MB. Let op: de server
+                                hanteert een absolute bovengrens (standaard 25
+                                MB); hogere waarden kunnen alsnog door de server
+                                geweigerd worden.
+                              </em>
+                            </FormDescription>
+                            <Input type="number" min="1" {...field} />
                             <FormMessage />
                           </FormItem>
                         )}

--- a/apps/api-server/src/models/Resource.js
+++ b/apps/api-server/src/models/Resource.js
@@ -875,35 +875,49 @@ module.exports = function (db, sequelize, DataTypes) {
           return {};
         return {
           where: {
-            [db.Sequelize.Op.and]: [
-              db.Sequelize.literal(
-                `location IS NOT NULL AND JSON_EXTRACT(location, '$.lat') IS NOT NULL AND JSON_EXTRACT(location, '$.lng') IS NOT NULL`
-              ),
-              db.Sequelize.where(
-                db.Sequelize.fn(
-                  'ST_Distance_Sphere',
-                  db.Sequelize.fn(
-                    'POINT',
-                    db.Sequelize.cast(
-                      db.Sequelize.fn(
-                        'JSON_EXTRACT',
-                        db.Sequelize.col('location'),
-                        db.Sequelize.literal("'$.lng'")
-                      ),
-                      'DECIMAL(10,7)'
-                    ),
-                    db.Sequelize.cast(
-                      db.Sequelize.fn(
-                        'JSON_EXTRACT',
-                        db.Sequelize.col('location'),
-                        db.Sequelize.literal("'$.lat'")
-                      ),
-                      'DECIMAL(10,7)'
-                    )
+            // A resource matches the postcode filter when it is within the
+            // requested distance OR when it is flagged as a city-wide project.
+            // City-wide projects have no pin near the postcode, so they would
+            // otherwise drop out of the results; the flag keeps them visible.
+            [db.Sequelize.Op.or]: [
+              {
+                [db.Sequelize.Op.and]: [
+                  db.Sequelize.literal(
+                    `location IS NOT NULL AND JSON_EXTRACT(location, '$.lat') IS NOT NULL AND JSON_EXTRACT(location, '$.lng') IS NOT NULL`
                   ),
-                  db.Sequelize.fn('POINT', safeLng, safeLat)
-                ),
-                { [db.Sequelize.Op.lte]: safeDistance }
+                  db.Sequelize.where(
+                    db.Sequelize.fn(
+                      'ST_Distance_Sphere',
+                      db.Sequelize.fn(
+                        'POINT',
+                        db.Sequelize.cast(
+                          db.Sequelize.fn(
+                            'JSON_EXTRACT',
+                            db.Sequelize.col('location'),
+                            db.Sequelize.literal("'$.lng'")
+                          ),
+                          'DECIMAL(10,7)'
+                        ),
+                        db.Sequelize.cast(
+                          db.Sequelize.fn(
+                            'JSON_EXTRACT',
+                            db.Sequelize.col('location'),
+                            db.Sequelize.literal("'$.lat'")
+                          ),
+                          'DECIMAL(10,7)'
+                        )
+                      ),
+                      db.Sequelize.fn('POINT', safeLng, safeLat)
+                    ),
+                    { [db.Sequelize.Op.lte]: safeDistance }
+                  ),
+                ],
+              },
+              db.Sequelize.literal(
+                // Qualify with the model alias: several joined models (user,
+                // comment, tag, status) also have an `extraData` column, so an
+                // unqualified reference is ambiguous in the count/list query.
+                "JSON_EXTRACT(`resource`.`extraData`, '$.cityWide') = true"
               ),
             ],
           },

--- a/apps/api-server/src/models/Resource.js
+++ b/apps/api-server/src/models/Resource.js
@@ -876,9 +876,10 @@ module.exports = function (db, sequelize, DataTypes) {
         return {
           where: {
             // A resource matches the postcode filter when it is within the
-            // requested distance OR when it is flagged as a city-wide project.
-            // City-wide projects have no pin near the postcode, so they would
-            // otherwise drop out of the results; the flag keeps them visible.
+            // requested distance OR when it is flagged as location-independent.
+            // Location-independent resources have no pin near the postcode, so
+            // they would otherwise drop out of the results; the flag keeps them
+            // visible.
             [db.Sequelize.Op.or]: [
               {
                 [db.Sequelize.Op.and]: [
@@ -917,7 +918,7 @@ module.exports = function (db, sequelize, DataTypes) {
                 // Qualify with the model alias: several joined models (user,
                 // comment, tag, status) also have an `extraData` column, so an
                 // unqualified reference is ambiguous in the count/list query.
-                "JSON_EXTRACT(`resource`.`extraData`, '$.cityWide') = true"
+                "JSON_EXTRACT(`resource`.`extraData`, '$.locationIndependent') = true"
               ),
             ],
           },

--- a/apps/image-server/server.js
+++ b/apps/image-server/server.js
@@ -65,6 +65,13 @@ const path = require('path');
 
 console.log('S3 enabled:', s3.isEnabled());
 
+// Absolute server-side upload cap (safety net). Defaults to 25 MB and can be
+// overridden via the MAX_FILE_UPLOAD_SIZE_MB env var. This is independent of any
+// per-widget client-side limit and protects the server from oversized uploads
+// that would otherwise stream until a socket timeout and hang without feedback.
+const maxFileUploadBytes =
+  (Number(process.env.MAX_FILE_UPLOAD_SIZE_MB) || 25) * 1024 * 1024;
+
 const swapLastDotUnderscore = (name) => {
   if (!name) return null;
   const match = name.match(/^(.*)([._])([a-z0-9]+)$/i);
@@ -74,6 +81,7 @@ const swapLastDotUnderscore = (name) => {
 };
 
 const imageMulterConfig = {
+  limits: { fileSize: maxFileUploadBytes },
   onError: function (err, next) {
     console.error(err);
     next(err);
@@ -350,6 +358,7 @@ app.get('/image/*', rateLimiter(), async function (req, res, next) {
 });
 
 const documentMulterConfig = {
+  limits: { fileSize: maxFileUploadBytes },
   onError: function (err, next) {
     console.error(err);
     next(err);
@@ -666,6 +675,18 @@ app.post(
 );
 
 app.use(function (err, req, res, next) {
+  // Multer rejects oversized uploads with a LIMIT_FILE_SIZE error. Map it to a
+  // clear HTTP 413 instead of a generic 500 so the upload fails fast with a
+  // readable message rather than hanging.
+  if (err && err.code === 'LIMIT_FILE_SIZE') {
+    const maxMB = Math.round(maxFileUploadBytes / (1024 * 1024));
+    return res.status(413).send(
+      JSON.stringify({
+        error: `File too large. The maximum upload size is ${maxMB} MB.`,
+      })
+    );
+  }
+
   const status = err.status ? err.status : 500;
   console.error(err);
   // if (!res.headerSent) {

--- a/packages/choiceguide/src/parts/default-values.tsx
+++ b/packages/choiceguide/src/parts/default-values.tsx
@@ -61,6 +61,7 @@ export const defaultFormValues = [
     multiple: true,
     options: [],
     allowedTypes: ['image/*'],
+    maxUploadSizeMB: 25,
     fieldType: 'upload',
   },
   {

--- a/packages/choiceguide/src/parts/init-fields.tsx
+++ b/packages/choiceguide/src/parts/init-fields.tsx
@@ -156,6 +156,10 @@ export const InitializeFormFields = (
           break;
         case 'imageUpload':
           fieldData['allowedTypes'] = item.allowedTypes || ['image/*'];
+          fieldData['maxUploadSizeMB'] = item.maxUploadSizeMB ?? 25;
+          break;
+        case 'documentUpload':
+          fieldData['maxUploadSizeMB'] = item.maxUploadSizeMB ?? 25;
           break;
         case 'text':
           if (item.defaultValue) {

--- a/packages/choiceguide/src/props.ts
+++ b/packages/choiceguide/src/props.ts
@@ -103,6 +103,7 @@ export type Item = {
   maxCharacters?: string;
   variant?: string;
   multiple?: boolean;
+  maxUploadSizeMB?: number;
   options?: Array<Option>;
   sliderTitleUnderA?: string;
   sliderTitleUnderB?: string;

--- a/packages/enquete/src/enquete.tsx
+++ b/packages/enquete/src/enquete.tsx
@@ -394,10 +394,12 @@ function Enquete(props: EnqueteWidgetProps) {
           fieldData['allowedTypes'] = ['image/*'];
           fieldData['imageUrl'] = props?.imageUrl;
           fieldData['multiple'] = item.multiple;
+          fieldData['maxUploadSizeMB'] = item.maxUploadSizeMB ?? 25;
           break;
         case 'documentUpload':
           fieldData['type'] = 'documentUpload';
           fieldData['multiple'] = item.multiple;
+          fieldData['maxUploadSizeMB'] = item.maxUploadSizeMB ?? 25;
           break;
         case 'scale': {
           fieldData['type'] = 'tickmark-slider';

--- a/packages/enquete/src/types/enquete-props.ts
+++ b/packages/enquete/src/types/enquete-props.ts
@@ -43,6 +43,7 @@ export type Item = {
   options?: Array<Option>;
   imageUpload?: string;
   multiple?: boolean;
+  maxUploadSizeMB?: number;
   randomizeItems?: boolean;
   image?: string;
   imageAlt?: string;

--- a/packages/resource-form/src/parts/default-values.tsx
+++ b/packages/resource-form/src/parts/default-values.tsx
@@ -61,6 +61,7 @@ export const defaultFormValues = [
     multiple: true,
     options: [],
     allowedTypes: ['image/*'],
+    maxUploadSizeMB: 25,
     fieldType: 'imageUpload',
   },
   {

--- a/packages/resource-form/src/parts/init-fields.tsx
+++ b/packages/resource-form/src/parts/init-fields.tsx
@@ -138,6 +138,10 @@ export const InitializeFormFields = (items, data) => {
           break;
         case 'imageUpload':
           fieldData['allowedTypes'] = item.allowedTypes || ['image/*'];
+          fieldData['maxUploadSizeMB'] = item.maxUploadSizeMB ?? 25;
+          break;
+        case 'documentUpload':
+          fieldData['maxUploadSizeMB'] = item.maxUploadSizeMB ?? 25;
           break;
         case 'tags':
           if (item.options && item.options.length > 0) {

--- a/packages/resource-form/src/props.ts
+++ b/packages/resource-form/src/props.ts
@@ -72,6 +72,7 @@ export type Item = {
   maxCharacters?: string;
   variant?: string;
   multiple?: boolean;
+  maxUploadSizeMB?: number;
   images?: Array<{
     image?: never;
     src: string;

--- a/packages/ui/src/form-elements/document-upload/index.tsx
+++ b/packages/ui/src/form-elements/document-upload/index.tsx
@@ -62,8 +62,6 @@ const filePondSettings = {
   labelButtonRetryItemProcessing: 'Retry',
   labelButtonProcessItem: 'Upload',
   labelFileTypeNotAllowed: 'Bestandstype is niet toegestaan',
-  allowFileSizeValidation: true,
-  maxFileSize: '8mb',
   name: 'document',
   maxParallelUploads: 1,
 };
@@ -78,6 +76,7 @@ export type DocumentUploadProps = {
   allowedTypes?: string[];
   disabled?: boolean;
   multiple?: boolean;
+  maxUploadSizeMB?: number;
   type?: string;
   onChange?: (
     e: { name: string; value: { name: string; url: string }[] },
@@ -146,6 +145,11 @@ const DocumentUploadField: FC<DocumentUploadProps> = ({
   ...props
 }) => {
   const datastore = new DataStore(props);
+
+  // Client-side upload limit (in MB). Falls back to 25 MB so existing widgets
+  // without a stored value immediately get the new limit.
+  const maxMB = props.maxUploadSizeMB ?? 25;
+  const maxBytes = maxMB * 1024 * 1024;
 
   const initialValue: MockDocFile[] =
     overrideDefaultValue && Array.isArray(overrideDefaultValue)
@@ -288,6 +292,11 @@ const DocumentUploadField: FC<DocumentUploadProps> = ({
           <RteContent content={description} unwrapSingleRootDiv={true} />
         </FormFieldDescription>
       )}
+
+      <FormFieldDescription className="openstad-max-upload-size">
+        Maximale bestandsgrootte: {maxMB} MB
+      </FormFieldDescription>
+
       {showMoreInfo && (
         <AccordionProvider
           sections={[
@@ -360,7 +369,11 @@ const DocumentUploadField: FC<DocumentUploadProps> = ({
               const fileName = fileItem.file.name;
               const forbiddenChar = fileName.match(forbiddenCharsRegex);
 
-              if (forbiddenChar) {
+              if (fileItem.file.size > maxBytes) {
+                reject(
+                  `Het bestand is te groot. De maximale bestandsgrootte is ${maxMB} MB.`
+                );
+              } else if (forbiddenChar) {
                 const forbiddenCharName = forbiddenChar[0];
                 const forbiddenCharIndex =
                   fileName.indexOf(forbiddenCharName) + 1;

--- a/packages/ui/src/form-elements/image-upload/index.tsx
+++ b/packages/ui/src/form-elements/image-upload/index.tsx
@@ -1,5 +1,7 @@
 import DataStore from '@openstad-headless/data-store/src';
 import { FormValue } from '@openstad-headless/form/src/form';
+import NotificationProvider from '@openstad-headless/lib/NotificationProvider/notification-provider';
+import NotificationService from '@openstad-headless/lib/NotificationProvider/notification-service';
 import {
   AccordionProvider,
   FormField,
@@ -59,8 +61,6 @@ const filePondSettings = {
   labelButtonRetryItemProcessing: 'Retry',
   labelButtonProcessItem: 'Upload',
   labelFileTypeNotAllowed: 'Bestandstype is niet toegestaan',
-  allowFileSizeValidation: true,
-  maxFileSize: '8mb',
   name: 'image',
   maxParallelUploads: 1,
 };
@@ -87,6 +87,7 @@ export type ImageUploadProps = {
   allowedTypes?: string[];
   disabled?: boolean;
   multiple?: boolean;
+  maxUploadSizeMB?: number;
   type?: string;
   onChange?: (
     e: { name: string; value: { name: string; url: string }[] },
@@ -135,6 +136,13 @@ const ImageUploadField: FC<ImageUploadProps> = ({
   ...props
 }) => {
   const datastore = new DataStore(props);
+
+  // Client-side upload limit (in MB). Falls back to 25 MB so existing widgets
+  // without a stored value immediately get the new limit.
+  const maxMB = props.maxUploadSizeMB ?? 25;
+  const maxBytes = maxMB * 1024 * 1024;
+  const notifyFailed = (message: string) =>
+    NotificationService.addNotification(message, 'error');
 
   const initialValue: MockImageFile[] =
     overrideDefaultValue && Array.isArray(overrideDefaultValue)
@@ -235,6 +243,10 @@ const ImageUploadField: FC<ImageUploadProps> = ({
           <RteContent content={description} unwrapSingleRootDiv={true} />
         </FormFieldDescription>
       )}
+
+      <FormFieldDescription className="openstad-max-upload-size">
+        Maximale bestandsgrootte: {maxMB} MB
+      </FormFieldDescription>
 
       {showMoreInfo && (
         <>
@@ -343,10 +355,25 @@ const ImageUploadField: FC<ImageUploadProps> = ({
               ? [acceptAttribute]
               : acceptAttribute
           }
+          beforeAddFile={(fileItem) => {
+            return new Promise<boolean>((resolve, reject) => {
+              if (fileItem.file.size > maxBytes) {
+                reject(
+                  `Het bestand is te groot. De maximale bestandsgrootte is ${maxMB} MB.`
+                );
+              } else {
+                resolve(true);
+              }
+            }).catch((error) => {
+              notifyFailed(error);
+              return false;
+            });
+          }}
           aria-invalid={fieldInvalid}
           aria-describedby={`${randomId}_error`}
           {...filePondSettings}
         />
+        <NotificationProvider />
       </div>
     </FormField>
   );


### PR DESCRIPTION

  ## 1. Always include city-wide projects in the postcode filter

  City-wide projects should always show up when users filter by postcode,
  regardless of distance — whether or not the resource has a pin. This adds an
  opt-in flag that always includes such projects in the postcode/distance filter,
  in both the list and on the map. Unflagged resources are unaffected.

  - **Admin** (`resource-form.tsx`): new checkbox "Stadsbreed project", bound to
    `extraData.cityWide`, placed under the location map. Flag is preserved across
    the CodeEditor JSON overwrite on submit.
  - **API** (`Resource.js`): `withinDistance` scope wrapped in `Op.or` —
    `(within distance) OR (resource.extraData.cityWide = true)`. Column qualified
    as `` `resource`.`extraData` `` to avoid ambiguity with joined models. Covers
    list and `/markers` via the shared `req.scope`.

  ## 2. Enforce a 25 MB upload limit and show it in the form (ticket 367)

  Large uploads (images >10 MB or big PDFs) previously hung the system without
  feedback because no explicit file-size limit existed. Adds a configurable
  maximum upload size, enforced both server- and client-side, and surfaces it in
  the upload form.

  - **image-server**: absolute server-side cap (default 25 MB, override via
    `MAX_FILE_UPLOAD_SIZE_MB`) on both image and document multer configs.
    Oversized uploads now fail fast with HTTP 413 instead of hanging.
  - **ui**: client-side size check in image/document upload via a
    `maxUploadSizeMB` prop (default 25). Shows "Maximale bestandsgrootte: N MB"
    and rejects oversized files before upload.
  - **enquete, resource-form, choiceguide**: pass `maxUploadSizeMB` to upload
    fields and add a "Maximale uploadgrootte (MB)" admin setting.