### PR TITLE
feat(document-map): pass email notification settings

### DIFF
--- a/packages/document-map/src/document-map.tsx
+++ b/packages/document-map/src/document-map.tsx
@@ -533,6 +533,15 @@ function DocumentMap({
           createdAt: new Date(),
           sentiment: 'no sentiment',
           tags: allTags,
+          confirmation: props.commentsWidget?.confirmation || false,
+          confirmationReplies:
+            props.commentsWidget?.confirmationReplies || false,
+          overwriteEmailAddress:
+            props.commentsWidget?.confirmation &&
+            props.commentsWidget?.overwriteEmailAddress
+              ? props.commentsWidget.overwriteEmailAddress
+              : '',
+          embeddedUrl: window.location.href,
         });
 
         if (goToLastPage && displayPagination) {
@@ -1495,6 +1504,13 @@ function DocumentMap({
             <Comments
               {...props}
               key={`refresh-${refreshComments}`}
+              confirmation={props.commentsWidget?.confirmation || false}
+              confirmationReplies={
+                props.commentsWidget?.confirmationReplies || false
+              }
+              overwriteEmailAddress={
+                props.commentsWidget?.overwriteEmailAddress || ''
+              }
               onlyIncludeTags={
                 selectedTagsString || filteredTagsIdsString || ''
               }


### PR DESCRIPTION
The interactive image (document-map) widget stores the notification settings under the commentsWidget sub-config but never forwarded them. As a result confirmation/confirmationReplies/overwriteEmailAddress were not sent when creating a comment, so no notification was created.

- addComment (top-level comment via marker) now sends confirmation, confirmationReplies, overwriteEmailAddress and embeddedUrl.
- <Comments> (reply flow) receives the three fields explicitly from props.commentsWidget so the comments widget picks them up.