### PR TITLE
fix: timeline dates and active marker

### DIFF
--- a/apps/admin-server/src/components/agenda-items-editor.tsx
+++ b/apps/admin-server/src/components/agenda-items-editor.tsx
@@ -12,6 +12,7 @@ import { Separator } from '@/components/ui/separator';
 import { Heading } from '@/components/ui/typography';
 import { generateId, withId } from '@/lib/widget-item-helpers';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { formatDutchDate } from '@openstad-headless/lib/timeline-dates';
 import * as Switch from '@radix-ui/react-switch';
 import { ArrowDown, ArrowUp, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
@@ -42,6 +43,7 @@ interface AgendaItemsEditorProps {
   items: AgendaItem[];
   onItemsChange: (items: AgendaItem[]) => void;
   showActiveDates?: boolean;
+  timelineMode?: boolean;
 }
 
 const formSchema = z.object({
@@ -126,12 +128,19 @@ export function AgendaItemsEditor({
   items,
   onItemsChange,
   showActiveDates = false,
+  timelineMode = false,
 }: AgendaItemsEditorProps) {
   const [links, setLinks] = useState<AgendaLink[]>([]);
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
   const selectedItem = selectedItemId
     ? items.find((i) => i.id === selectedItemId) || null
     : null;
+  // The last item (by start date) keeps a manually-editable end date;
+  // all earlier items have their end date auto-computed in timeline mode.
+  const lastItemId = [...items].sort((a, b) =>
+    (a.activeFrom ?? '').localeCompare(b.activeFrom ?? '')
+  )[items.length - 1]?.id;
+  const isLastItemSelected = !!selectedItem && selectedItem.id === lastItemId;
   const [selectedLink, setLink] = useState<AgendaLink | null>(null);
   const [settingLinks, setSettingLinks] = useState<boolean>(false);
 
@@ -315,6 +324,13 @@ export function AgendaItemsEditor({
                             className="gap-2 py-3 px-2 w-full"
                             onClick={() => setSelectedItemId(item.id ?? null)}>
                             {item.title || item.description || '(geen titel)'}
+                            {item.activeFrom && (
+                              <span className="block text-sm text-muted-foreground">
+                                {formatDutchDate(
+                                  toDateInputValue(item.activeFrom)
+                                )}
+                              </span>
+                            )}
                           </span>
                           <span className="gap-2 py-3 px-2">
                             <X
@@ -559,12 +575,21 @@ export function AgendaItemsEditor({
                         render={({ field }) => (
                           <FormItem className="items-start md:col-span-full">
                             <FormLabel>
-                              Actief t/m (hele dag) - laat leeg voor geen
-                              einddatum
+                              {timelineMode && !isLastItemSelected
+                                ? 'Actief t/m (hele dag)'
+                                : 'Actief t/m (hele dag) - laat leeg voor geen einddatum'}
                             </FormLabel>
+                            {timelineMode && !isLastItemSelected && (
+                              <FormDescription>
+                                Wordt automatisch berekend uit de startdatum van
+                                het volgende item.
+                              </FormDescription>
+                            )}
                             <Input
                               type="date"
                               {...field}
+                              readOnly={timelineMode && !isLastItemSelected}
+                              disabled={timelineMode && !isLastItemSelected}
                               className="inline-block !w-auto"
                             />
                             <FormMessage />

--- a/apps/admin-server/src/pages/projects/[project]/resources/[id]/timeline.tsx
+++ b/apps/admin-server/src/pages/projects/[project]/resources/[id]/timeline.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import useResource from '@/hooks/use-resource';
 import useResources from '@/hooks/use-resources';
 import { withId } from '@/lib/widget-item-helpers';
+import { fillTimelineEndDates } from '@openstad-headless/lib/timeline-dates';
 import { useRouter } from 'next/router';
 import React, { useEffect, useState } from 'react';
 import toast from 'react-hot-toast';
@@ -28,15 +29,23 @@ export default function ProjectResourceTimeline() {
   useEffect(() => {
     if (!resource || itemsInitialized.current) return;
     itemsInitialized.current = true;
-    setItems((resource?.timeline ?? []).map(withId) as AgendaItem[]);
+    setItems(
+      fillTimelineEndDates(
+        (resource?.timeline ?? []).map(withId)
+      ) as AgendaItem[]
+    );
   }, [resource?.id]);
+
+  function handleItemsChange(next: AgendaItem[]) {
+    setItems(fillTimelineEndDates(next));
+  }
 
   async function handleSave() {
     if (!id) return;
 
     try {
       await update(Number.parseInt(id as string), {
-        timeline: items,
+        timeline: fillTimelineEndDates(items),
       });
       itemsInitialized.current = false;
       mutate();
@@ -52,8 +61,9 @@ export default function ProjectResourceTimeline() {
     <div>
       <AgendaItemsEditor
         items={items}
-        onItemsChange={setItems}
+        onItemsChange={handleItemsChange}
         showActiveDates={true}
+        timelineMode={true}
       />
       <div className="flex gap-2 mt-4">
         <Button type="button" onClick={handleSave}>

--- a/packages/lib/timeline-dates.ts
+++ b/packages/lib/timeline-dates.ts
@@ -1,0 +1,77 @@
+const DUTCH_MONTHS = [
+  'januari',
+  'februari',
+  'maart',
+  'april',
+  'mei',
+  'juni',
+  'juli',
+  'augustus',
+  'september',
+  'oktober',
+  'november',
+  'december',
+];
+
+/** Format a YYYY-MM-DD string as a Dutch long date ("17 juni 2026"). */
+export function formatDutchDate(isoDate: string): string {
+  if (!isoDate) return '';
+  const [year, month, day] = isoDate.split('-').map(Number);
+  if (!year || !month || !day) return isoDate;
+  return `${day} ${DUTCH_MONTHS[month - 1]} ${year}`;
+}
+
+/** Subtract one day from a YYYY-MM-DD string; returns '' for invalid input. */
+export function subtractOneDay(iso: string): string {
+  if (!iso || !/^\d{4}-\d{2}-\d{2}$/.test(iso)) return '';
+  const [year, month, day] = iso.split('-').map(Number);
+  if (!year || !month || !day) return '';
+  const utcMs = Date.UTC(year, month - 1, day - 1);
+  const d = new Date(utcMs);
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${dd}`;
+}
+
+type DateRangeItem = {
+  activeFrom?: string;
+  activeTo?: string;
+};
+
+/**
+ * Set each item's activeTo to the day before the next item's activeFrom.
+ * The last item keeps its own (manually entered) end date, which may be empty
+ * for an open-ended final phase.
+ */
+export function fillTimelineEndDates<T extends DateRangeItem>(items: T[]): T[] {
+  if (!items || items.length === 0) return items;
+
+  const sorted = [...items].sort((a, b) => {
+    const af = a.activeFrom ?? '';
+    const bf = b.activeFrom ?? '';
+    if (af < bf) return -1;
+    if (af > bf) return 1;
+    return 0;
+  });
+
+  return sorted.map((item, index) => {
+    const next = sorted[index + 1];
+
+    // Last item: keep its manually entered end date (may be open-ended).
+    if (!next) {
+      return item;
+    }
+
+    const nextStart = next.activeFrom ?? '';
+    const currentStart = item.activeFrom ?? '';
+
+    // Two items share a start date: no valid range to derive, leave end open.
+    if (!nextStart || nextStart === currentStart) {
+      const { activeTo, ...rest } = item;
+      return rest as T;
+    }
+
+    return { ...item, activeTo: subtractOneDay(nextStart) };
+  });
+}


### PR DESCRIPTION
## What

  Fixes two timeline (Tijdlijn) issues in the admin panel.

  ## Fixes

  - Show the start date in the admin items list (it was missing).
  - Auto-calculate each item's end date from the next item's start, so only the
    current phase is active and the marker moves automatically. The last item
    keeps a manually editable end date.