### PR TITLE
feat(resource-detail): add file size and mime type to document links

### DIFF
--- a/apps/admin-server/src/components/document-uploader.tsx
+++ b/apps/admin-server/src/components/document-uploader.tsx
@@ -14,7 +14,12 @@ import { Input } from './ui/input';
 export const DocumentUploader: React.FC<{
   form: UseFormReturn<any>;
   fieldName: Path<FieldValues>;
-  onDocumentUploaded?: (documentObject: { url: string; name?: string; size?: number; mimeType?: string }) => void;
+  onDocumentUploaded?: (documentObject: {
+    url: string;
+    name?: string;
+    size?: number;
+    mimeType?: string;
+  }) => void;
   documentLabel?: string;
   allowedTypes?: string[];
   project?: string;

--- a/apps/admin-server/src/components/document-uploader.tsx
+++ b/apps/admin-server/src/components/document-uploader.tsx
@@ -14,7 +14,7 @@ import { Input } from './ui/input';
 export const DocumentUploader: React.FC<{
   form: UseFormReturn<any>;
   fieldName: Path<FieldValues>;
-  onDocumentUploaded?: (documentObject: { url: string; name?: string }) => void;
+  onDocumentUploaded?: (documentObject: { url: string; name?: string; size?: number; mimeType?: string }) => void;
   documentLabel?: string;
   allowedTypes?: string[];
   project?: string;
@@ -53,6 +53,8 @@ export const DocumentUploader: React.FC<{
     onDocumentUploaded?.({
       url: uploadedDocumentUrl,
       name: uploadedDocument?.name,
+      size: uploadedDocument?.size,
+      mimeType: uploadedDocument?.mimeType,
     });
   }
 

--- a/apps/admin-server/src/components/resource-form.tsx
+++ b/apps/admin-server/src/components/resource-form.tsx
@@ -108,7 +108,12 @@ const baseSchema = z.object({
   document: z.string().optional(),
   documents: z
     .array(
-      z.object({ url: z.string().optional(), name: z.string().optional() })
+      z.object({
+        url: z.string().optional(),
+        name: z.string().optional(),
+        size: z.number().optional(),
+        mimeType: z.string().optional(),
+      })
     )
     .optional()
     .default([]),

--- a/apps/image-server/server.js
+++ b/apps/image-server/server.js
@@ -636,6 +636,8 @@ app.post('/document', documentUpload.single('document'), (req, res, next) => {
     JSON.stringify({
       name: sanitizeFileName(req.file.originalname),
       url: protocol + url,
+      size: req.file.size,
+      mimeType: req.file.mimetype,
     })
   );
 });
@@ -658,6 +660,8 @@ app.post(
           return {
             name: sanitizeFileName(file.originalname),
             url: protocol + url,
+            size: file.size,
+            mimeType: file.mimetype,
           };
         })
       )

--- a/packages/resource-detail/cypress/component/utils.cy.tsx
+++ b/packages/resource-detail/cypress/component/utils.cy.tsx
@@ -37,4 +37,28 @@ describe('formatDocumentLabel', () => {
   it('omits the type suffix when no extension can be derived', () => {
     expect(formatDocumentLabel('Toelichting bewonersavond', '')).to.equal('Toelichting bewonersavond');
   });
+
+  it('appends a human-readable size in MB with Dutch notation', () => {
+    expect(
+      formatDocumentLabel('rapport_pdf', 'https://example.com/r.pdf', 1300000)
+    ).to.equal('Rapport (PDF, 1,2 MB)');
+  });
+
+  it('formats sizes under 1 MB in kB', () => {
+    expect(
+      formatDocumentLabel('nota_pdf', 'https://example.com/n.pdf', 5000)
+    ).to.equal('Nota (PDF, 5 kB)');
+  });
+
+  it('omits the size when it is not provided', () => {
+    expect(
+      formatDocumentLabel('nota_pdf', 'https://example.com/n.pdf')
+    ).to.equal('Nota (PDF)');
+  });
+
+  it('omits the size when it is zero or invalid', () => {
+    expect(
+      formatDocumentLabel('nota_pdf', 'https://example.com/n.pdf', 0)
+    ).to.equal('Nota (PDF)');
+  });
 });

--- a/packages/resource-detail/cypress/component/utils.cy.tsx
+++ b/packages/resource-detail/cypress/component/utils.cy.tsx
@@ -3,39 +3,56 @@ import { formatDocumentLabel } from '../../src/utils';
 describe('formatDocumentLabel', () => {
   it('humanizes underscores and derives the type from the URL', () => {
     expect(
-      formatDocumentLabel('Groenontwerp_Burggraafstraat_pdf', 'https://example.com/files/groenontwerp.pdf')
+      formatDocumentLabel(
+        'Groenontwerp_Burggraafstraat_pdf',
+        'https://example.com/files/groenontwerp.pdf'
+      )
     ).to.equal('Groenontwerp Burggraafstraat (PDF)');
   });
 
   it('only strips a trailing suffix when it is a known extension', () => {
     expect(
-      formatDocumentLabel('20250630_Paneel_1_Ontwerp_pdf', 'https://example.com/p1.pdf')
+      formatDocumentLabel(
+        '20250630_Paneel_1_Ontwerp_pdf',
+        'https://example.com/p1.pdf'
+      )
     ).to.equal('20250630 Paneel 1 Ontwerp (PDF)');
   });
 
   it('handles hyphen-underscore combinations', () => {
     expect(
-      formatDocumentLabel('Reactienota_Rechters-_en_Kanunnikenbuurt_pdf', 'https://example.com/r.pdf')
+      formatDocumentLabel(
+        'Reactienota_Rechters-_en_Kanunnikenbuurt_pdf',
+        'https://example.com/r.pdf'
+      )
     ).to.equal('Reactienota Rechters en Kanunnikenbuurt (PDF)');
   });
 
   it('supports regular dotted file names', () => {
-    expect(formatDocumentLabel('rapport_2026.pdf', '')).to.equal('Rapport 2026 (PDF)');
+    expect(formatDocumentLabel('rapport_2026.pdf', '')).to.equal(
+      'Rapport 2026 (PDF)'
+    );
   });
 
   it('ignores query strings in the URL', () => {
     expect(
-      formatDocumentLabel('verslag_docx', 'https://example.com/verslag.docx?v=2')
+      formatDocumentLabel(
+        'verslag_docx',
+        'https://example.com/verslag.docx?v=2'
+      )
     ).to.equal('Verslag (DOCX)');
   });
 
   it('falls back to the URL file name when the name is empty', () => {
-    expect(formatDocumentLabel('', 'https://example.com/files/begroting_2026.pdf'))
-      .to.equal('Begroting 2026 (PDF)');
+    expect(
+      formatDocumentLabel('', 'https://example.com/files/begroting_2026.pdf')
+    ).to.equal('Begroting 2026 (PDF)');
   });
 
   it('omits the type suffix when no extension can be derived', () => {
-    expect(formatDocumentLabel('Toelichting bewonersavond', '')).to.equal('Toelichting bewonersavond');
+    expect(formatDocumentLabel('Toelichting bewonersavond', '')).to.equal(
+      'Toelichting bewonersavond'
+    );
   });
 
   it('appends a human-readable size in MB with Dutch notation', () => {

--- a/packages/resource-detail/src/resource-detail.tsx
+++ b/packages/resource-detail/src/resource-detail.tsx
@@ -114,6 +114,8 @@ export type ResourceDetailWidgetProps = {
 type DocumentType = {
   name?: string;
   url?: string;
+  size?: number;
+  mimeType?: string;
 };
 
 function ResourceDetail({
@@ -748,7 +750,7 @@ function ResourceDetail({
                             href={document.url}
                             key={index}>
                             <Icon icon="ri-download-2-fill" iconOnly />
-                            {formatDocumentLabel(document.name, document.url)}
+                            {formatDocumentLabel(document.name, document.url, document.size)}
                           </ButtonLink>
                         )
                       )}

--- a/packages/resource-detail/src/resource-detail.tsx
+++ b/packages/resource-detail/src/resource-detail.tsx
@@ -750,7 +750,11 @@ function ResourceDetail({
                             href={document.url}
                             key={index}>
                             <Icon icon="ri-download-2-fill" iconOnly />
-                            {formatDocumentLabel(document.name, document.url, document.size)}
+                            {formatDocumentLabel(
+                              document.name,
+                              document.url,
+                              document.size
+                            )}
                           </ButtonLink>
                         )
                       )}

--- a/packages/resource-detail/src/utils.ts
+++ b/packages/resource-detail/src/utils.ts
@@ -3,24 +3,33 @@ const KNOWN_EXTENSIONS = [
   'csv', 'txt', 'zip', 'png', 'jpg', 'jpeg', 'gif', 'svg',
 ];
 
+// Removes the query string and hash fragment from a URL.
+function stripUrlParams(url: string): string {
+  return url.split('?')[0].split('#')[0];
+}
+
+// Removes a trailing dotted extension, e.g. "report.pdf" -> "report".
+function stripDottedExtension(value: string): string {
+  return value.replace(/\.[^.]+$/, '');
+}
+
 // Returns the lowercase extension of a path, or '' if there is none.
 function getExtension(path: string): string {
   if (!path.includes('.')) return '';
   return path.split('.').pop()?.toLowerCase() ?? '';
 }
 
-// Strips query string and hash from a URL, then returns its extension.
+// Returns the extension of a URL, ignoring query string and hash.
 function getExtensionFromUrl(url: string): string {
-  const path = url.split('?')[0].split('#')[0];
-  return getExtension(path);
+  return getExtension(stripUrlParams(url));
 }
 
-// Returns the file name (without extension) from a URL path, used as a
+// Returns the file name (without extension) from a URL, used as a
 // fallback when the document has no stored name.
 function getFileNameFromUrl(url: string): string {
-  const path = url.split('?')[0].split('#')[0];
+  const path = stripUrlParams(url);
   if (!path) return '';
-  return path.split('/').pop()?.replace(/\.[^.]+$/, '') ?? '';
+  return stripDottedExtension(path.split('/').pop() ?? '');
 }
 
 // Removes a trailing "_pdf" / "-docx" style suffix, but only when it
@@ -54,15 +63,32 @@ function humanizeBase(base: string): string {
   return words.charAt(0).toUpperCase() + words.slice(1);
 }
 
+// Formats a byte count into a human-readable size using Dutch notation
+// (comma as decimal separator), e.g. 1300000 -> "1,2 MB", 5000 -> "5 kB".
+function formatFileSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '';
+  const kb = bytes / 1024;
+  if (kb < 1024) {
+    return `${Math.max(1, Math.round(kb))} kB`;
+  }
+  const mb = kb / 1024;
+  return `${mb.toFixed(1).replace('.', ',')} MB`;
+}
+
 // Builds an accessible, human-readable label for a document link,
-// e.g. "Groenontwerp Burggraafstraat (PDF)".
-export function formatDocumentLabel(name?: string, url?: string): string {
+// e.g. "Groenontwerp Burggraafstraat (PDF, 1,2 MB)". The size is omitted
+// when it is not available (e.g. for documents uploaded before size was
+// stored), falling back to "Title (PDF)".
+export function formatDocumentLabel(
+  name?: string,
+  url?: string,
+  size?: number
+): string {
   const rawName = name || '';
   const documentUrl = url || '';
 
-  const withoutDottedExtension = rawName.replace(/\.[^.]+$/, '');
   const { base: strippedBase, extension: suffixExtension } =
-    stripKnownSuffix(withoutDottedExtension);
+    stripKnownSuffix(stripDottedExtension(rawName));
 
   const base = strippedBase || getFileNameFromUrl(documentUrl);
 
@@ -73,5 +99,8 @@ export function formatDocumentLabel(name?: string, url?: string): string {
   );
 
   const title = humanizeBase(base);
-  return extension ? `${title} (${extension.toUpperCase()})` : title;
+  const fileSize = size === undefined ? '' : formatFileSize(size);
+
+  const meta = [extension.toUpperCase(), fileSize].filter(Boolean).join(', ');
+  return meta ? `${title} (${meta})` : title;
 }

--- a/packages/resource-detail/src/utils.ts
+++ b/packages/resource-detail/src/utils.ts
@@ -1,6 +1,19 @@
 const KNOWN_EXTENSIONS = [
-  'pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx',
-  'csv', 'txt', 'zip', 'png', 'jpg', 'jpeg', 'gif', 'svg',
+  'pdf',
+  'doc',
+  'docx',
+  'xls',
+  'xlsx',
+  'ppt',
+  'pptx',
+  'csv',
+  'txt',
+  'zip',
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'svg',
 ];
 
 // Removes the query string and hash fragment from a URL.
@@ -87,8 +100,9 @@ export function formatDocumentLabel(
   const rawName = name || '';
   const documentUrl = url || '';
 
-  const { base: strippedBase, extension: suffixExtension } =
-    stripKnownSuffix(stripDottedExtension(rawName));
+  const { base: strippedBase, extension: suffixExtension } = stripKnownSuffix(
+    stripDottedExtension(rawName)
+  );
 
   const base = strippedBase || getFileNameFromUrl(documentUrl);
 


### PR DESCRIPTION
## What

Document download links now show the file size next to the type, e.g.
`Title (PDF, 4,3 MB)`, with Dutch number notation. Builds on #1674 (Part 1).

### After
<img width="1263" height="975" alt="Bijlage-met-metadata" src="https://github.com/user-attachments/assets/11347096-cb35-423b-b514-cc43aace6700" />

The bottom document was uploaded after this change and shows the size;
the documents above it predate the change and gracefully fall back to
`(PDF)` — existing documents keep working unchanged.

## Why

Relates to #1669 (Part 2). Part 1 added accessible humanized labels and the
file type. This part adds the file size, which WCAG 2.1 SC 2.4.4 calls for so
users know what they're downloading before they open it.

## How — the size flows end-to-end

Tracing the upload chain, the size was being dropped at several points; this
PR fixes each:

1. **image-server** (`/document`, `/documents`): the upload response now
   includes `size` (bytes) and `mimeType`, which multer already provides.
2. **admin document-uploader**: forwards `size`/`mimeType` from the upload
   response to the form (previously only `url`/`name`).
3. **admin resource-form**: the zod schema for `documents` now accepts
   `size`/`mimeType` — zod strips unknown keys on submit, so without this the
   size never reached the API.
4. **resource-detail widget**: `formatDocumentLabel` takes the size and
   renders `(PDF, 4,3 MB)`, with kB/MB formatting and a no-size fallback.

The `documents` field on the resource is a schemaless JSON column, so no
migration is needed.

## Testing

- Component tests cover the label formatting (MB/kB, Dutch comma, no-size
  fallback) — 11 cases.
- Verified end-to-end locally: uploaded a PDF via the admin panel and
  confirmed `size`/`mimeType` are stored and rendered (see screenshot).

## Notes

- Existing documents have no stored size and show `(PDF)` — this is the
  intended graceful fallback per #1669, not a regression. A backfill of
  existing documents could be a future improvement.
- No styling changes in the widget; label text only.