### PR TITLE
style(resource-detail): prettier formatting

### DIFF
--- a/packages/resource-detail/cypress/component/utils.cy.tsx
+++ b/packages/resource-detail/cypress/component/utils.cy.tsx
@@ -3,38 +3,55 @@ import { formatDocumentLabel } from '../../src/utils';
 describe('formatDocumentLabel', () => {
   it('humanizes underscores and derives the type from the URL', () => {
     expect(
-      formatDocumentLabel('Groenontwerp_Burggraafstraat_pdf', 'https://example.com/files/groenontwerp.pdf')
+      formatDocumentLabel(
+        'Groenontwerp_Burggraafstraat_pdf',
+        'https://example.com/files/groenontwerp.pdf'
+      )
     ).to.equal('Groenontwerp Burggraafstraat (PDF)');
   });
 
   it('only strips a trailing suffix when it is a known extension', () => {
     expect(
-      formatDocumentLabel('20250630_Paneel_1_Ontwerp_pdf', 'https://example.com/p1.pdf')
+      formatDocumentLabel(
+        '20250630_Paneel_1_Ontwerp_pdf',
+        'https://example.com/p1.pdf'
+      )
     ).to.equal('20250630 Paneel 1 Ontwerp (PDF)');
   });
 
   it('handles hyphen-underscore combinations', () => {
     expect(
-      formatDocumentLabel('Reactienota_Rechters-_en_Kanunnikenbuurt_pdf', 'https://example.com/r.pdf')
+      formatDocumentLabel(
+        'Reactienota_Rechters-_en_Kanunnikenbuurt_pdf',
+        'https://example.com/r.pdf'
+      )
     ).to.equal('Reactienota Rechters en Kanunnikenbuurt (PDF)');
   });
 
   it('supports regular dotted file names', () => {
-    expect(formatDocumentLabel('rapport_2026.pdf', '')).to.equal('Rapport 2026 (PDF)');
+    expect(formatDocumentLabel('rapport_2026.pdf', '')).to.equal(
+      'Rapport 2026 (PDF)'
+    );
   });
 
   it('ignores query strings in the URL', () => {
     expect(
-      formatDocumentLabel('verslag_docx', 'https://example.com/verslag.docx?v=2')
+      formatDocumentLabel(
+        'verslag_docx',
+        'https://example.com/verslag.docx?v=2'
+      )
     ).to.equal('Verslag (DOCX)');
   });
 
   it('falls back to the URL file name when the name is empty', () => {
-    expect(formatDocumentLabel('', 'https://example.com/files/begroting_2026.pdf'))
-      .to.equal('Begroting 2026 (PDF)');
+    expect(
+      formatDocumentLabel('', 'https://example.com/files/begroting_2026.pdf')
+    ).to.equal('Begroting 2026 (PDF)');
   });
 
   it('omits the type suffix when no extension can be derived', () => {
-    expect(formatDocumentLabel('Toelichting bewonersavond', '')).to.equal('Toelichting bewonersavond');
+    expect(formatDocumentLabel('Toelichting bewonersavond', '')).to.equal(
+      'Toelichting bewonersavond'
+    );
   });
 });

--- a/packages/resource-detail/src/utils.ts
+++ b/packages/resource-detail/src/utils.ts
@@ -1,6 +1,19 @@
 const KNOWN_EXTENSIONS = [
-  'pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx',
-  'csv', 'txt', 'zip', 'png', 'jpg', 'jpeg', 'gif', 'svg',
+  'pdf',
+  'doc',
+  'docx',
+  'xls',
+  'xlsx',
+  'ppt',
+  'pptx',
+  'csv',
+  'txt',
+  'zip',
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'svg',
 ];
 
 // Returns the lowercase extension of a path, or '' if there is none.
@@ -20,7 +33,12 @@ function getExtensionFromUrl(url: string): string {
 function getFileNameFromUrl(url: string): string {
   const path = url.split('?')[0].split('#')[0];
   if (!path) return '';
-  return path.split('/').pop()?.replace(/\.[^.]+$/, '') ?? '';
+  return (
+    path
+      .split('/')
+      .pop()
+      ?.replace(/\.[^.]+$/, '') ?? ''
+  );
 }
 
 // Removes a trailing "_pdf" / "-docx" style suffix, but only when it
@@ -61,8 +79,9 @@ export function formatDocumentLabel(name?: string, url?: string): string {
   const documentUrl = url || '';
 
   const withoutDottedExtension = rawName.replace(/\.[^.]+$/, '');
-  const { base: strippedBase, extension: suffixExtension } =
-    stripKnownSuffix(withoutDottedExtension);
+  const { base: strippedBase, extension: suffixExtension } = stripKnownSuffix(
+    withoutDottedExtension
+  );
 
   const base = strippedBase || getFileNameFromUrl(documentUrl);
 


### PR DESCRIPTION
Format two `resource-detail` files that were changed in #1674, but the prettier format check did not run on that PR.

This ensures that the prettier formatting action will run correctly for the `main` branch again.