### PR TITLE
fix(cms): prevent subdirectory site hijacking page with same name

### DIFF
--- a/apps/cms-server/app.js
+++ b/apps/cms-server/app.js
@@ -16,6 +16,7 @@ const app = express();
 const _ = require('lodash');
 const projectService = require('./services/projects');
 const aposConfig = require('./lib/apos-config');
+const { resolveSitePrefix } = require('./lib/resolve-site-prefix');
 const { refresh } = require('less');
 const REFRESH_PROJECTS_INTERVAL = 60000 * 5;
 const Url = require('node:url');
@@ -421,9 +422,12 @@ app.use(function (req, res, next) {
  * if openstad.org exists of course.
  */
 app.use('/:sitePrefix', function (req, res, next) {
-  const domainAndPath = req.openstadDomain + '/' + req.params.sitePrefix;
-
-  const site = projects[domainAndPath] ? projects[domainAndPath] : false;
+  const site = resolveSitePrefix({
+    projects,
+    openstadDomain: req.openstadDomain,
+    sitePrefix: req.params.sitePrefix,
+    alreadyResolved: Boolean(req.sitePrefix),
+  });
 
   if (site) {
     site.sitePrefix = req.params.sitePrefix;

--- a/apps/cms-server/lib/resolve-site-prefix.js
+++ b/apps/cms-server/lib/resolve-site-prefix.js
@@ -1,0 +1,23 @@
+/**
+ * Resolve which subdirectory site, if any, a request prefix maps to.
+ */
+function resolveSitePrefix({
+  projects,
+  openstadDomain,
+  sitePrefix,
+  alreadyResolved,
+}) {
+  if (alreadyResolved) {
+    return null;
+  }
+
+  if (!projects || !openstadDomain || !sitePrefix) {
+    return null;
+  }
+
+  const domainAndPath = openstadDomain + '/' + sitePrefix;
+
+  return projects[domainAndPath] || null;
+}
+
+module.exports = { resolveSitePrefix };

--- a/apps/cms-server/lib/resolve-site-prefix.test.js
+++ b/apps/cms-server/lib/resolve-site-prefix.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+const { resolveSitePrefix } = require('./resolve-site-prefix');
+
+describe('resolveSitePrefix', () => {
+  const projects = {
+    'example.com/site-a': { id: 1, name: 'site-a' },
+    'example.com/site-b': { id: 2, name: 'site-b' },
+  };
+
+  it('returns the matching subdirectory site for a known prefix', () => {
+    const site = resolveSitePrefix({
+      projects,
+      openstadDomain: 'example.com',
+      sitePrefix: 'site-b',
+      alreadyResolved: false,
+    });
+
+    expect(site).toBe(projects['example.com/site-b']);
+  });
+
+  it('returns null when a prefix was already resolved on a previous routing pass', () => {
+    const site = resolveSitePrefix({
+      projects,
+      openstadDomain: 'example.com',
+      sitePrefix: 'site-a',
+      alreadyResolved: true,
+    });
+
+    expect(site).toBeNull();
+  });
+
+  it('returns null when no project matches the prefix', () => {
+    const site = resolveSitePrefix({
+      projects,
+      openstadDomain: 'example.com',
+      sitePrefix: 'nonexistent',
+      alreadyResolved: false,
+    });
+
+    expect(site).toBeNull();
+  });
+
+  it('returns null when required inputs are missing', () => {
+    expect(
+      resolveSitePrefix({
+        projects,
+        openstadDomain: 'example.com',
+        sitePrefix: '',
+        alreadyResolved: false,
+      })
+    ).toBeNull();
+
+    expect(
+      resolveSitePrefix({
+        projects: undefined,
+        openstadDomain: 'example.com',
+        sitePrefix: 'site-a',
+        alreadyResolved: false,
+      })
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
The /:sitePrefix middleware re-ran after rewriting the URL and calling req.app._router.handle(), matching the next path segment as a site prefix. A page named like another subdirectory site (e.g. /site-b/site-a when a /site-a site exists) loaded the wrong site.

Extract the matching decision into resolveSitePrefix, guarded against re-resolution once a prefix is set, and add vitest coverage.